### PR TITLE
[Domain] Add cross-service message envelope and payload validation

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -38,7 +38,7 @@ Milestone: `v2-provisioning-event-channel`
 | `[Docs] Align SPEC with provisioning/event-channel v2 scope` | P0 | `docs`, `v2` | None | planned | `docs/SPEC.md` describes v2 APIs, data model, streams, statuses, metadata keys, and acceptance criteria. |
 | `[Docs] Add v2 implementation checklist and issue map` | P0 | `docs`, `v2` | None | planned | This document contains the issue map, dependency order, and status tracking. |
 | `[DB] Add device operations, outbox, and inbox persistence` | P1 | `database`, `backend`, `v2` | Docs issues | planned | Migrations and store methods for operation tracking, outbox publication state, and inbox dedupe. |
-| `[Domain] Add cross-service message envelope and payload validation` | P1 | `backend`, `v2` | Docs issues | planned | Envelope and payload types validate contract-required fields, stream/message types, schema version, and partition key. |
+| `[Domain] Add cross-service message envelope and payload validation` | P1 | `backend`, `v2` | Docs issues | in_progress | Envelope and payload types validate contract-required fields, stream/message types, schema version, and partition key. |
 | `[Device] Add metadata merge and projection primitives` | P1 | `backend`, `v2` | DB, Domain | planned | Store-level partial metadata merge and projection helpers for video metadata and online status. |
 | `[API] Add provisioning and deactivation endpoints` | P1 | `api`, `backend`, `v2` | DB, Domain, Device | planned | HTTP endpoints create/reuse operations and enqueue lifecycle command messages. |
 | `[Worker] Implement outbox publisher with local broker adapter` | P1 | `worker`, `backend`, `v2` | DB, Domain | planned | Independent worker publishes pending command messages and records retry/dead-letter state. |

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -1,9 +1,11 @@
 package channel
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 )
@@ -50,6 +52,18 @@ type Envelope struct {
 	PartitionKey  string          `json:"partition_key"`
 	OccurredAt    time.Time       `json:"occurred_at"`
 	Payload       json.RawMessage `json:"payload"`
+}
+
+func (e *Envelope) UnmarshalJSON(data []byte) error {
+	type envelopeAlias Envelope
+
+	var decoded envelopeAlias
+	if err := decodeStrictJSON(data, &decoded); err != nil {
+		return err
+	}
+
+	*e = Envelope(decoded)
+	return nil
 }
 
 type Payload interface {
@@ -229,6 +243,9 @@ func (e Envelope) ValidateAndDecode(expectedStream string) (Payload, error) {
 	if e.OccurredAt.IsZero() {
 		return nil, fieldError("occurred_at", "must be set")
 	}
+	if err := validateUTC("occurred_at", e.OccurredAt); err != nil {
+		return nil, err
+	}
 	if len(e.Payload) == 0 {
 		return nil, fieldError("payload", "must be set")
 	}
@@ -251,7 +268,7 @@ func (e Envelope) ValidateAndDecode(expectedStream string) (Payload, error) {
 	}
 
 	payload := spec.newPayload()
-	if err := json.Unmarshal(e.Payload, payload); err != nil {
+	if err := decodeStrictJSON(e.Payload, payload); err != nil {
 		return nil, fmt.Errorf("payload: %w", err)
 	}
 	if err := payload.Validate(); err != nil {
@@ -427,6 +444,29 @@ func requireNonBlank(field, value string) error {
 	if strings.TrimSpace(value) == "" {
 		return fieldError(field, "must be non-empty")
 	}
+	return nil
+}
+
+func validateUTC(field string, value time.Time) error {
+	_, offset := value.Zone()
+	if offset != 0 {
+		return fieldError(field, "must use UTC")
+	}
+	return nil
+}
+
+func decodeStrictJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return errors.New("must contain a single JSON value")
+	}
+
 	return nil
 }
 

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -290,9 +291,11 @@ func (e Envelope) ValidateAndDecode(expectedStream string) (Payload, error) {
 }
 
 func (p *DeviceProvisionRequestedPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
+
 	return validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 		fieldValue{"payload.activity_id", p.ActivityID},
 		fieldValue{"payload.clip_public_key", p.ClipPublicKey},
@@ -305,9 +308,10 @@ func (p *DeviceProvisionRequestedPayload) PartitionKey() string {
 }
 
 func (p *DeviceProvisionSucceededPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
 	if err := validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 		fieldValue{"payload.activity_id", p.ActivityID},
 	); err != nil {
@@ -327,9 +331,10 @@ func (p *DeviceProvisionSucceededPayload) PartitionKey() string {
 }
 
 func (p *DeviceProvisionFailedPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
 	if err := validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 		fieldValue{"payload.activity_id", p.ActivityID},
 		fieldValue{"payload.error_code", p.ErrorCode},
@@ -351,9 +356,11 @@ func (p *DeviceProvisionFailedPayload) PartitionKey() string {
 }
 
 func (p *DeviceDeactivateRequestedPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
+
 	return validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 		fieldValue{"payload.requested_by", p.RequestedBy},
 		fieldValue{"payload.reason", p.Reason},
@@ -365,9 +372,10 @@ func (p *DeviceDeactivateRequestedPayload) PartitionKey() string {
 }
 
 func (p *DeviceDeactivateSucceededPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
 	if err := validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 	); err != nil {
 		return err
@@ -386,9 +394,10 @@ func (p *DeviceDeactivateSucceededPayload) PartitionKey() string {
 }
 
 func (p *DeviceDeactivateFailedPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
 	if err := validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 		fieldValue{"payload.error_code", p.ErrorCode},
 		fieldValue{"payload.error_message", p.ErrorMessage},
@@ -409,9 +418,10 @@ func (p *DeviceDeactivateFailedPayload) PartitionKey() string {
 }
 
 func (p *DeviceOnlineChangedPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
 	if err := validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 	); err != nil {
 		return err
@@ -433,9 +443,10 @@ func (p *DeviceOnlineChangedPayload) PartitionKey() string {
 }
 
 func (p *DeviceMetadataChangedPayload) Validate() error {
+	if err := validateLifecyclePayloadIDs(p.OrgID, p.AccountDeviceID); err != nil {
+		return err
+	}
 	if err := validateRequiredStrings(
-		fieldValue{"payload.org_id", p.OrgID},
-		fieldValue{"payload.account_device_id", p.AccountDeviceID},
 		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
 	); err != nil {
 		return err
@@ -464,9 +475,29 @@ func validateRequiredStrings(fields ...fieldValue) error {
 	return nil
 }
 
+func validateLifecyclePayloadIDs(orgID, accountDeviceID string) error {
+	if err := requireUUID("payload.org_id", orgID); err != nil {
+		return err
+	}
+	if err := requireUUID("payload.account_device_id", accountDeviceID); err != nil {
+		return err
+	}
+	return nil
+}
+
 func requireNonBlank(field, value string) error {
 	if strings.TrimSpace(value) == "" {
 		return fieldError(field, "must be non-empty")
+	}
+	return nil
+}
+
+func requireUUID(field, value string) error {
+	if err := requireNonBlank(field, value); err != nil {
+		return err
+	}
+	if !isUUID(value) {
+		return fieldError(field, "must be a UUID")
 	}
 	return nil
 }
@@ -511,6 +542,29 @@ func requireJSONFields(data []byte, prefix string, fields ...string) error {
 	}
 
 	return nil
+}
+
+func isUUID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+
+	segments := [5]string{
+		value[0:8],
+		value[9:13],
+		value[14:18],
+		value[19:23],
+		value[24:36],
+	}
+	if value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-' {
+		return false
+	}
+	for _, segment := range segments {
+		if _, err := hex.DecodeString(segment); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func fieldError(field, message string) error {

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -1,0 +1,435 @@
+package channel
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaVersionV1 = "1.0"
+
+	StreamAccountVideoCommands = "account.video.commands"
+	StreamVideoAccountEvents   = "video.account.events"
+
+	ServiceAccountManager    = "rtk_account_manager"
+	ServiceRealtekVideoCloud = "realtek_video_server"
+)
+
+type MessageType string
+
+const (
+	MessageTypeDeviceProvisionRequested  MessageType = "DeviceProvisionRequested"
+	MessageTypeDeviceProvisionSucceeded  MessageType = "DeviceProvisionSucceeded"
+	MessageTypeDeviceProvisionFailed     MessageType = "DeviceProvisionFailed"
+	MessageTypeDeviceDeactivateRequested MessageType = "DeviceDeactivateRequested"
+	MessageTypeDeviceDeactivateSucceeded MessageType = "DeviceDeactivateSucceeded"
+	MessageTypeDeviceDeactivateFailed    MessageType = "DeviceDeactivateFailed"
+	MessageTypeDeviceOnlineChanged       MessageType = "DeviceOnlineChanged"
+	MessageTypeDeviceMetadataChanged     MessageType = "DeviceMetadataChanged"
+)
+
+type OnlineStatus string
+
+const (
+	OnlineStatusOnline  OnlineStatus = "online"
+	OnlineStatusOffline OnlineStatus = "offline"
+)
+
+type Envelope struct {
+	MessageID     string          `json:"message_id"`
+	CorrelationID string          `json:"correlation_id"`
+	CausationID   string          `json:"causation_id,omitempty"`
+	OperationID   string          `json:"operation_id"`
+	SourceService string          `json:"source_service"`
+	TargetService string          `json:"target_service"`
+	MessageType   MessageType     `json:"message_type"`
+	SchemaVersion string          `json:"schema_version"`
+	PartitionKey  string          `json:"partition_key"`
+	OccurredAt    time.Time       `json:"occurred_at"`
+	Payload       json.RawMessage `json:"payload"`
+}
+
+type Payload interface {
+	Validate() error
+	PartitionKey() string
+}
+
+type DeviceProvisionRequestedPayload struct {
+	OrgID           string `json:"org_id"`
+	AccountDeviceID string `json:"account_device_id"`
+	VideoCloudDevid string `json:"video_cloud_devid"`
+	ActivityID      string `json:"activity_id"`
+	ClipPublicKey   string `json:"clip_public_key"`
+	RequestedBy     string `json:"requested_by"`
+}
+
+type DeviceProvisionSucceededPayload struct {
+	OrgID           string    `json:"org_id"`
+	AccountDeviceID string    `json:"account_device_id"`
+	VideoCloudDevid string    `json:"video_cloud_devid"`
+	ActivityID      string    `json:"activity_id"`
+	ActivatedAt     time.Time `json:"activated_at"`
+}
+
+type DeviceProvisionFailedPayload struct {
+	OrgID           string    `json:"org_id"`
+	AccountDeviceID string    `json:"account_device_id"`
+	VideoCloudDevid string    `json:"video_cloud_devid"`
+	ActivityID      string    `json:"activity_id"`
+	ErrorCode       string    `json:"error_code"`
+	ErrorMessage    string    `json:"error_message"`
+	Retryable       bool      `json:"retryable"`
+	FailedAt        time.Time `json:"failed_at"`
+}
+
+type DeviceDeactivateRequestedPayload struct {
+	OrgID           string `json:"org_id"`
+	AccountDeviceID string `json:"account_device_id"`
+	VideoCloudDevid string `json:"video_cloud_devid"`
+	RequestedBy     string `json:"requested_by"`
+	Reason          string `json:"reason"`
+}
+
+type DeviceDeactivateSucceededPayload struct {
+	OrgID           string    `json:"org_id"`
+	AccountDeviceID string    `json:"account_device_id"`
+	VideoCloudDevid string    `json:"video_cloud_devid"`
+	DeactivatedAt   time.Time `json:"deactivated_at"`
+}
+
+type DeviceDeactivateFailedPayload struct {
+	OrgID           string    `json:"org_id"`
+	AccountDeviceID string    `json:"account_device_id"`
+	VideoCloudDevid string    `json:"video_cloud_devid"`
+	ErrorCode       string    `json:"error_code"`
+	ErrorMessage    string    `json:"error_message"`
+	Retryable       bool      `json:"retryable"`
+	FailedAt        time.Time `json:"failed_at"`
+}
+
+type DeviceOnlineChangedPayload struct {
+	OrgID           string       `json:"org_id"`
+	AccountDeviceID string       `json:"account_device_id"`
+	VideoCloudDevid string       `json:"video_cloud_devid"`
+	Status          OnlineStatus `json:"status"`
+	LastSeenAt      time.Time    `json:"last_seen_at"`
+}
+
+type DeviceMetadataChangedPayload struct {
+	OrgID           string         `json:"org_id"`
+	AccountDeviceID string         `json:"account_device_id"`
+	VideoCloudDevid string         `json:"video_cloud_devid"`
+	Metadata        map[string]any `json:"metadata"`
+}
+
+type messageSpec struct {
+	stream        string
+	sourceService string
+	targetService string
+	newPayload    func() Payload
+}
+
+var messageSpecs = map[MessageType]messageSpec{
+	MessageTypeDeviceProvisionRequested: {
+		stream:        StreamAccountVideoCommands,
+		sourceService: ServiceAccountManager,
+		targetService: ServiceRealtekVideoCloud,
+		newPayload: func() Payload {
+			return &DeviceProvisionRequestedPayload{}
+		},
+	},
+	MessageTypeDeviceProvisionSucceeded: {
+		stream:        StreamVideoAccountEvents,
+		sourceService: ServiceRealtekVideoCloud,
+		targetService: ServiceAccountManager,
+		newPayload: func() Payload {
+			return &DeviceProvisionSucceededPayload{}
+		},
+	},
+	MessageTypeDeviceProvisionFailed: {
+		stream:        StreamVideoAccountEvents,
+		sourceService: ServiceRealtekVideoCloud,
+		targetService: ServiceAccountManager,
+		newPayload: func() Payload {
+			return &DeviceProvisionFailedPayload{}
+		},
+	},
+	MessageTypeDeviceDeactivateRequested: {
+		stream:        StreamAccountVideoCommands,
+		sourceService: ServiceAccountManager,
+		targetService: ServiceRealtekVideoCloud,
+		newPayload: func() Payload {
+			return &DeviceDeactivateRequestedPayload{}
+		},
+	},
+	MessageTypeDeviceDeactivateSucceeded: {
+		stream:        StreamVideoAccountEvents,
+		sourceService: ServiceRealtekVideoCloud,
+		targetService: ServiceAccountManager,
+		newPayload: func() Payload {
+			return &DeviceDeactivateSucceededPayload{}
+		},
+	},
+	MessageTypeDeviceDeactivateFailed: {
+		stream:        StreamVideoAccountEvents,
+		sourceService: ServiceRealtekVideoCloud,
+		targetService: ServiceAccountManager,
+		newPayload: func() Payload {
+			return &DeviceDeactivateFailedPayload{}
+		},
+	},
+	MessageTypeDeviceOnlineChanged: {
+		stream:        StreamVideoAccountEvents,
+		sourceService: ServiceRealtekVideoCloud,
+		targetService: ServiceAccountManager,
+		newPayload: func() Payload {
+			return &DeviceOnlineChangedPayload{}
+		},
+	},
+	MessageTypeDeviceMetadataChanged: {
+		stream:        StreamVideoAccountEvents,
+		sourceService: ServiceRealtekVideoCloud,
+		targetService: ServiceAccountManager,
+		newPayload: func() Payload {
+			return &DeviceMetadataChangedPayload{}
+		},
+	},
+}
+
+func (e Envelope) Validate(expectedStream string) error {
+	_, err := e.ValidateAndDecode(expectedStream)
+	return err
+}
+
+func (e Envelope) ValidateAndDecode(expectedStream string) (Payload, error) {
+	if err := requireNonBlank("message_id", e.MessageID); err != nil {
+		return nil, err
+	}
+	if err := requireNonBlank("correlation_id", e.CorrelationID); err != nil {
+		return nil, err
+	}
+	if err := requireNonBlank("operation_id", e.OperationID); err != nil {
+		return nil, err
+	}
+	if err := requireNonBlank("source_service", e.SourceService); err != nil {
+		return nil, err
+	}
+	if err := requireNonBlank("target_service", e.TargetService); err != nil {
+		return nil, err
+	}
+	if err := requireNonBlank("schema_version", e.SchemaVersion); err != nil {
+		return nil, err
+	}
+	if err := requireNonBlank("partition_key", e.PartitionKey); err != nil {
+		return nil, err
+	}
+	if e.OccurredAt.IsZero() {
+		return nil, fieldError("occurred_at", "must be set")
+	}
+	if len(e.Payload) == 0 {
+		return nil, fieldError("payload", "must be set")
+	}
+
+	spec, ok := messageSpecs[e.MessageType]
+	if !ok {
+		return nil, fieldError("message_type", fmt.Sprintf("unsupported value %q", e.MessageType))
+	}
+	if e.SchemaVersion != SchemaVersionV1 {
+		return nil, fieldError("schema_version", fmt.Sprintf("unsupported value %q", e.SchemaVersion))
+	}
+	if expectedStream != "" && expectedStream != spec.stream {
+		return nil, fieldError("stream", fmt.Sprintf("message type %q must use %q", e.MessageType, spec.stream))
+	}
+	if e.SourceService != spec.sourceService {
+		return nil, fieldError("source_service", fmt.Sprintf("message type %q must use %q", e.MessageType, spec.sourceService))
+	}
+	if e.TargetService != spec.targetService {
+		return nil, fieldError("target_service", fmt.Sprintf("message type %q must use %q", e.MessageType, spec.targetService))
+	}
+
+	payload := spec.newPayload()
+	if err := json.Unmarshal(e.Payload, payload); err != nil {
+		return nil, fmt.Errorf("payload: %w", err)
+	}
+	if err := payload.Validate(); err != nil {
+		return nil, err
+	}
+	if e.PartitionKey != payload.PartitionKey() {
+		return nil, fieldError("partition_key", "must equal payload.account_device_id")
+	}
+	return payload, nil
+}
+
+func (p *DeviceProvisionRequestedPayload) Validate() error {
+	return validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+		fieldValue{"payload.activity_id", p.ActivityID},
+		fieldValue{"payload.clip_public_key", p.ClipPublicKey},
+		fieldValue{"payload.requested_by", p.RequestedBy},
+	)
+}
+
+func (p *DeviceProvisionRequestedPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceProvisionSucceededPayload) Validate() error {
+	if err := validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+		fieldValue{"payload.activity_id", p.ActivityID},
+	); err != nil {
+		return err
+	}
+	if p.ActivatedAt.IsZero() {
+		return fieldError("payload.activated_at", "must be set")
+	}
+	return nil
+}
+
+func (p *DeviceProvisionSucceededPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceProvisionFailedPayload) Validate() error {
+	if err := validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+		fieldValue{"payload.activity_id", p.ActivityID},
+		fieldValue{"payload.error_code", p.ErrorCode},
+		fieldValue{"payload.error_message", p.ErrorMessage},
+	); err != nil {
+		return err
+	}
+	if p.FailedAt.IsZero() {
+		return fieldError("payload.failed_at", "must be set")
+	}
+	return nil
+}
+
+func (p *DeviceProvisionFailedPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceDeactivateRequestedPayload) Validate() error {
+	return validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+		fieldValue{"payload.requested_by", p.RequestedBy},
+		fieldValue{"payload.reason", p.Reason},
+	)
+}
+
+func (p *DeviceDeactivateRequestedPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceDeactivateSucceededPayload) Validate() error {
+	if err := validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+	); err != nil {
+		return err
+	}
+	if p.DeactivatedAt.IsZero() {
+		return fieldError("payload.deactivated_at", "must be set")
+	}
+	return nil
+}
+
+func (p *DeviceDeactivateSucceededPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceDeactivateFailedPayload) Validate() error {
+	if err := validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+		fieldValue{"payload.error_code", p.ErrorCode},
+		fieldValue{"payload.error_message", p.ErrorMessage},
+	); err != nil {
+		return err
+	}
+	if p.FailedAt.IsZero() {
+		return fieldError("payload.failed_at", "must be set")
+	}
+	return nil
+}
+
+func (p *DeviceDeactivateFailedPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceOnlineChangedPayload) Validate() error {
+	if err := validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+	); err != nil {
+		return err
+	}
+	if p.Status != OnlineStatusOnline && p.Status != OnlineStatusOffline {
+		return fieldError("payload.status", fmt.Sprintf("unsupported value %q", p.Status))
+	}
+	if p.LastSeenAt.IsZero() {
+		return fieldError("payload.last_seen_at", "must be set")
+	}
+	return nil
+}
+
+func (p *DeviceOnlineChangedPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+func (p *DeviceMetadataChangedPayload) Validate() error {
+	if err := validateRequiredStrings(
+		fieldValue{"payload.org_id", p.OrgID},
+		fieldValue{"payload.account_device_id", p.AccountDeviceID},
+		fieldValue{"payload.video_cloud_devid", p.VideoCloudDevid},
+	); err != nil {
+		return err
+	}
+	if p.Metadata == nil {
+		return fieldError("payload.metadata", "must be set")
+	}
+	return nil
+}
+
+func (p *DeviceMetadataChangedPayload) PartitionKey() string {
+	return p.AccountDeviceID
+}
+
+type fieldValue struct {
+	name  string
+	value string
+}
+
+func validateRequiredStrings(fields ...fieldValue) error {
+	for _, field := range fields {
+		if err := requireNonBlank(field.name, field.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireNonBlank(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fieldError(field, "must be non-empty")
+	}
+	return nil
+}
+
+func fieldError(field, message string) error {
+	return errors.New(field + " " + message)
+}

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -307,6 +307,9 @@ func (p *DeviceProvisionSucceededPayload) Validate() error {
 	if p.ActivatedAt.IsZero() {
 		return fieldError("payload.activated_at", "must be set")
 	}
+	if err := validateUTC("payload.activated_at", p.ActivatedAt); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -327,6 +330,9 @@ func (p *DeviceProvisionFailedPayload) Validate() error {
 	}
 	if p.FailedAt.IsZero() {
 		return fieldError("payload.failed_at", "must be set")
+	}
+	if err := validateUTC("payload.failed_at", p.FailedAt); err != nil {
+		return err
 	}
 	return nil
 }
@@ -360,6 +366,9 @@ func (p *DeviceDeactivateSucceededPayload) Validate() error {
 	if p.DeactivatedAt.IsZero() {
 		return fieldError("payload.deactivated_at", "must be set")
 	}
+	if err := validateUTC("payload.deactivated_at", p.DeactivatedAt); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -379,6 +388,9 @@ func (p *DeviceDeactivateFailedPayload) Validate() error {
 	}
 	if p.FailedAt.IsZero() {
 		return fieldError("payload.failed_at", "must be set")
+	}
+	if err := validateUTC("payload.failed_at", p.FailedAt); err != nil {
+		return err
 	}
 	return nil
 }
@@ -400,6 +412,9 @@ func (p *DeviceOnlineChangedPayload) Validate() error {
 	}
 	if p.LastSeenAt.IsZero() {
 		return fieldError("payload.last_seen_at", "must be set")
+	}
+	if err := validateUTC("payload.last_seen_at", p.LastSeenAt); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -140,10 +140,11 @@ type DeviceMetadataChangedPayload struct {
 }
 
 type messageSpec struct {
-	stream        string
-	sourceService string
-	targetService string
-	newPayload    func() Payload
+	stream             string
+	sourceService      string
+	targetService      string
+	requiredJSONFields []string
+	newPayload         func() Payload
 }
 
 var messageSpecs = map[MessageType]messageSpec{
@@ -164,9 +165,10 @@ var messageSpecs = map[MessageType]messageSpec{
 		},
 	},
 	MessageTypeDeviceProvisionFailed: {
-		stream:        StreamVideoAccountEvents,
-		sourceService: ServiceRealtekVideoCloud,
-		targetService: ServiceAccountManager,
+		stream:             StreamVideoAccountEvents,
+		sourceService:      ServiceRealtekVideoCloud,
+		targetService:      ServiceAccountManager,
+		requiredJSONFields: []string{"retryable"},
 		newPayload: func() Payload {
 			return &DeviceProvisionFailedPayload{}
 		},
@@ -188,9 +190,10 @@ var messageSpecs = map[MessageType]messageSpec{
 		},
 	},
 	MessageTypeDeviceDeactivateFailed: {
-		stream:        StreamVideoAccountEvents,
-		sourceService: ServiceRealtekVideoCloud,
-		targetService: ServiceAccountManager,
+		stream:             StreamVideoAccountEvents,
+		sourceService:      ServiceRealtekVideoCloud,
+		targetService:      ServiceAccountManager,
+		requiredJSONFields: []string{"retryable"},
 		newPayload: func() Payload {
 			return &DeviceDeactivateFailedPayload{}
 		},
@@ -265,6 +268,9 @@ func (e Envelope) ValidateAndDecode(expectedStream string) (Payload, error) {
 	}
 	if e.TargetService != spec.targetService {
 		return nil, fieldError("target_service", fmt.Sprintf("message type %q must use %q", e.MessageType, spec.targetService))
+	}
+	if err := requireJSONFields(e.Payload, "payload", spec.requiredJSONFields...); err != nil {
+		return nil, err
 	}
 
 	payload := spec.newPayload()
@@ -480,6 +486,25 @@ func decodeStrictJSON(data []byte, target any) error {
 
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return errors.New("must contain a single JSON value")
+	}
+
+	return nil
+}
+
+func requireJSONFields(data []byte, prefix string, fields ...string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := decodeStrictJSON(data, &decoded); err != nil {
+		return err
+	}
+
+	for _, field := range fields {
+		if _, ok := decoded[field]; !ok {
+			return fieldError(prefix+"."+field, "must be set")
+		}
 	}
 
 	return nil

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -237,6 +237,9 @@ func (e Envelope) ValidateAndDecode(expectedStream string) (Payload, error) {
 	if err := requireNonBlank("target_service", e.TargetService); err != nil {
 		return nil, err
 	}
+	if err := requireNonBlank("message_type", string(e.MessageType)); err != nil {
+		return nil, err
+	}
 	if err := requireNonBlank("schema_version", e.SchemaVersion); err != nil {
 		return nil, err
 	}

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -1,0 +1,385 @@
+package channel
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testTime = time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		envelope    Envelope
+		stream      string
+		wantPayload any
+	}{
+		{
+			name: "DeviceProvisionRequested",
+			envelope: validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+				ClipPublicKey:   "clip-key",
+				RequestedBy:     "user-1",
+			}),
+			stream:      StreamAccountVideoCommands,
+			wantPayload: &DeviceProvisionRequestedPayload{},
+		},
+		{
+			name: "DeviceProvisionSucceeded",
+			envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+				ActivatedAt:     testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantPayload: &DeviceProvisionSucceededPayload{},
+		},
+		{
+			name: "DeviceProvisionFailed",
+			envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+				ErrorCode:       "activation_failed",
+				ErrorMessage:    "activation failed",
+				Retryable:       true,
+				FailedAt:        testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantPayload: &DeviceProvisionFailedPayload{},
+		},
+		{
+			name: "DeviceDeactivateRequested",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateRequested, DeviceDeactivateRequestedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				RequestedBy:     "user-1",
+				Reason:          "account_device_disabled",
+			}),
+			stream:      StreamAccountVideoCommands,
+			wantPayload: &DeviceDeactivateRequestedPayload{},
+		},
+		{
+			name: "DeviceDeactivateSucceeded",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				DeactivatedAt:   testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantPayload: &DeviceDeactivateSucceededPayload{},
+		},
+		{
+			name: "DeviceDeactivateFailed",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ErrorCode:       "deactivation_failed",
+				ErrorMessage:    "deactivation failed",
+				Retryable:       true,
+				FailedAt:        testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantPayload: &DeviceDeactivateFailedPayload{},
+		},
+		{
+			name: "DeviceOnlineChanged",
+			envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				Status:          OnlineStatusOnline,
+				LastSeenAt:      testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantPayload: &DeviceOnlineChangedPayload{},
+		},
+		{
+			name: "DeviceMetadataChanged",
+			envelope: validEnvelope(MessageTypeDeviceMetadataChanged, DeviceMetadataChangedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				Metadata: map[string]any{
+					"video_cloud_activation_status": "activated",
+				},
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantPayload: &DeviceMetadataChangedPayload{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload, err := tt.envelope.ValidateAndDecode(tt.stream)
+			if err != nil {
+				t.Fatalf("ValidateAndDecode() error = %v", err)
+			}
+			if payload.PartitionKey() != "device-1" {
+				t.Fatalf("expected account device id device-1, got %q", payload.PartitionKey())
+			}
+			if reflect.TypeOf(payload) != reflect.TypeOf(tt.wantPayload) {
+				t.Fatalf("expected payload type %T, got %T", tt.wantPayload, payload)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		envelope    Envelope
+		stream      string
+		wantMessage string
+	}{
+		{
+			name: "DeviceProvisionRequested",
+			envelope: validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "",
+				ClipPublicKey:   "clip-key",
+				RequestedBy:     "user-1",
+			}),
+			stream:      StreamAccountVideoCommands,
+			wantMessage: "payload.activity_id must be non-empty",
+		},
+		{
+			name: "DeviceProvisionSucceeded",
+			envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantMessage: "payload.activated_at must be set",
+		},
+		{
+			name: "DeviceProvisionFailed",
+			envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+				ErrorCode:       "",
+				ErrorMessage:    "activation failed",
+				Retryable:       true,
+				FailedAt:        testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantMessage: "payload.error_code must be non-empty",
+		},
+		{
+			name: "DeviceDeactivateRequested",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateRequested, DeviceDeactivateRequestedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				RequestedBy:     "user-1",
+				Reason:          "",
+			}),
+			stream:      StreamAccountVideoCommands,
+			wantMessage: "payload.reason must be non-empty",
+		},
+		{
+			name: "DeviceDeactivateSucceeded",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantMessage: "payload.deactivated_at must be set",
+		},
+		{
+			name: "DeviceDeactivateFailed",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ErrorCode:       "deactivation_failed",
+				ErrorMessage:    "",
+				Retryable:       true,
+				FailedAt:        testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantMessage: "payload.error_message must be non-empty",
+		},
+		{
+			name: "DeviceOnlineChanged",
+			envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				Status:          "busy",
+				LastSeenAt:      testTime,
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantMessage: "payload.status unsupported value",
+		},
+		{
+			name: "DeviceMetadataChanged",
+			envelope: validEnvelope(MessageTypeDeviceMetadataChanged, DeviceMetadataChangedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+			}),
+			stream:      StreamVideoAccountEvents,
+			wantMessage: "payload.metadata must be set",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.envelope.Validate(tt.stream)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantMessage) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantMessage, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown message type", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			ActivityID:      "activity-1",
+			ClipPublicKey:   "clip-key",
+			RequestedBy:     "user-1",
+		})
+		envelope.MessageType = MessageType("DeviceMysteryChanged")
+
+		err := envelope.Validate(StreamAccountVideoCommands)
+		if err == nil || !strings.Contains(err.Error(), `message_type unsupported value "DeviceMysteryChanged"`) {
+			t.Fatalf("expected unknown message type error, got %v", err)
+		}
+	})
+
+	t.Run("unsupported schema version", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			ActivityID:      "activity-1",
+			ClipPublicKey:   "clip-key",
+			RequestedBy:     "user-1",
+		})
+		envelope.SchemaVersion = "2.0"
+
+		err := envelope.Validate(StreamAccountVideoCommands)
+		if err == nil || !strings.Contains(err.Error(), `schema_version unsupported value "2.0"`) {
+			t.Fatalf("expected unsupported schema version error, got %v", err)
+		}
+	})
+
+	t.Run("stream mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			ActivityID:      "activity-1",
+			ClipPublicKey:   "clip-key",
+			RequestedBy:     "user-1",
+		})
+
+		err := envelope.Validate(StreamVideoAccountEvents)
+		if err == nil || !strings.Contains(err.Error(), `stream message type "DeviceProvisionRequested" must use "account.video.commands"`) {
+			t.Fatalf("expected stream mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("source service mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			Status:          OnlineStatusOnline,
+			LastSeenAt:      testTime,
+		})
+		envelope.SourceService = ServiceAccountManager
+
+		err := envelope.Validate(StreamVideoAccountEvents)
+		if err == nil || !strings.Contains(err.Error(), `source_service message type "DeviceOnlineChanged" must use "realtek_video_server"`) {
+			t.Fatalf("expected source service mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("partition key mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			Status:          OnlineStatusOnline,
+			LastSeenAt:      testTime,
+		})
+		envelope.PartitionKey = "device-2"
+
+		err := envelope.Validate(StreamVideoAccountEvents)
+		if err == nil || !strings.Contains(err.Error(), "partition_key must equal payload.account_device_id") {
+			t.Fatalf("expected partition key mismatch error, got %v", err)
+		}
+	})
+}
+
+func validEnvelope(messageType MessageType, payload any) Envelope {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	spec := messageSpecs[messageType]
+	return Envelope{
+		MessageID:     "msg-1",
+		CorrelationID: "corr-1",
+		CausationID:   "msg-0",
+		OperationID:   "op-1",
+		SourceService: spec.sourceService,
+		TargetService: spec.targetService,
+		MessageType:   messageType,
+		SchemaVersion: SchemaVersionV1,
+		PartitionKey:  "device-1",
+		OccurredAt:    testTime,
+		Payload:       raw,
+	}
+}

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -266,6 +266,55 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsExplicitFalseRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		envelope Envelope
+		stream   string
+	}{
+		{
+			name: "provision failed",
+			envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+				ErrorCode:       "activation_failed",
+				ErrorMessage:    "activation failed",
+				Retryable:       false,
+				FailedAt:        testTime,
+			}),
+			stream: StreamVideoAccountEvents,
+		},
+		{
+			name: "deactivate failed",
+			envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ErrorCode:       "deactivation_failed",
+				ErrorMessage:    "deactivation failed",
+				Retryable:       false,
+				FailedAt:        testTime,
+			}),
+			stream: StreamVideoAccountEvents,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := tt.envelope.Validate(tt.stream); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 	t.Parallel()
 
@@ -421,6 +470,63 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		err := envelope.Validate(StreamAccountVideoCommands)
 		if err == nil || !strings.Contains(err.Error(), `payload: json: unknown field "unexpected"`) {
 			t.Fatalf("expected unknown payload field error, got %v", err)
+		}
+	})
+
+	t.Run("missing retryable field", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			messageType MessageType
+			stream      string
+			payload     string
+			wantMessage string
+		}{
+			{
+				name:        "provision failed",
+				messageType: MessageTypeDeviceProvisionFailed,
+				stream:      StreamVideoAccountEvents,
+				payload: `{
+					"org_id":"org-1",
+					"account_device_id":"device-1",
+					"video_cloud_devid":"video-1",
+					"activity_id":"activity-1",
+					"error_code":"activation_failed",
+					"error_message":"activation failed",
+					"failed_at":"2026-04-28T12:00:00Z"
+				}`,
+				wantMessage: "payload.retryable must be set",
+			},
+			{
+				name:        "deactivate failed",
+				messageType: MessageTypeDeviceDeactivateFailed,
+				stream:      StreamVideoAccountEvents,
+				payload: `{
+					"org_id":"org-1",
+					"account_device_id":"device-1",
+					"video_cloud_devid":"video-1",
+					"error_code":"deactivation_failed",
+					"error_message":"deactivation failed",
+					"failed_at":"2026-04-28T12:00:00Z"
+				}`,
+				wantMessage: "payload.retryable must be set",
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				envelope := validEnvelope(tt.messageType, DeviceProvisionRequestedPayload{})
+				envelope.Payload = json.RawMessage(tt.payload)
+
+				err := envelope.Validate(tt.stream)
+				if err == nil || !strings.Contains(err.Error(), tt.wantMessage) {
+					t.Fatalf("expected missing retryable error %q, got %v", tt.wantMessage, err)
+				}
+			})
 		}
 	})
 

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -10,6 +10,11 @@ import (
 
 var testTime = time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 
+const (
+	testOrgID    = "11111111-1111-1111-1111-111111111111"
+	testDeviceID = "22222222-2222-2222-2222-222222222222"
+)
+
 func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 	t.Parallel()
 
@@ -22,8 +27,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceProvisionRequested",
 			envelope: validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 				ClipPublicKey:   "clip-key",
@@ -35,8 +40,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceProvisionSucceeded",
 			envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 				ActivatedAt:     testTime,
@@ -47,8 +52,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceProvisionFailed",
 			envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 				ErrorCode:       "activation_failed",
@@ -62,8 +67,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceDeactivateRequested",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateRequested, DeviceDeactivateRequestedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				RequestedBy:     "user-1",
 				Reason:          "account_device_disabled",
@@ -74,8 +79,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceDeactivateSucceeded",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				DeactivatedAt:   testTime,
 			}),
@@ -85,8 +90,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceDeactivateFailed",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ErrorCode:       "deactivation_failed",
 				ErrorMessage:    "deactivation failed",
@@ -99,8 +104,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceOnlineChanged",
 			envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				Status:          OnlineStatusOnline,
 				LastSeenAt:      testTime,
@@ -111,8 +116,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 		{
 			name: "DeviceMetadataChanged",
 			envelope: validEnvelope(MessageTypeDeviceMetadataChanged, DeviceMetadataChangedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				Metadata: map[string]any{
 					"video_cloud_activation_status": "activated",
@@ -132,8 +137,8 @@ func TestValidateAndDecodeAcceptsEachMessageType(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ValidateAndDecode() error = %v", err)
 			}
-			if payload.PartitionKey() != "device-1" {
-				t.Fatalf("expected account device id device-1, got %q", payload.PartitionKey())
+			if payload.PartitionKey() != testDeviceID {
+				t.Fatalf("expected account device id %s, got %q", testDeviceID, payload.PartitionKey())
 			}
 			if reflect.TypeOf(payload) != reflect.TypeOf(tt.wantPayload) {
 				t.Fatalf("expected payload type %T, got %T", tt.wantPayload, payload)
@@ -154,8 +159,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceProvisionRequested",
 			envelope: validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "",
 				ClipPublicKey:   "clip-key",
@@ -167,8 +172,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceProvisionSucceeded",
 			envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 			}),
@@ -178,8 +183,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceProvisionFailed",
 			envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 				ErrorCode:       "",
@@ -193,8 +198,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceDeactivateRequested",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateRequested, DeviceDeactivateRequestedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				RequestedBy:     "user-1",
 				Reason:          "",
@@ -205,8 +210,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceDeactivateSucceeded",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 			}),
 			stream:      StreamVideoAccountEvents,
@@ -215,8 +220,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceDeactivateFailed",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ErrorCode:       "deactivation_failed",
 				ErrorMessage:    "",
@@ -229,8 +234,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceOnlineChanged",
 			envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				Status:          "busy",
 				LastSeenAt:      testTime,
@@ -241,8 +246,8 @@ func TestValidateRejectsInvalidMessagesForEachType(t *testing.T) {
 		{
 			name: "DeviceMetadataChanged",
 			envelope: validEnvelope(MessageTypeDeviceMetadataChanged, DeviceMetadataChangedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 			}),
 			stream:      StreamVideoAccountEvents,
@@ -277,8 +282,8 @@ func TestValidateAcceptsExplicitFalseRetryable(t *testing.T) {
 		{
 			name: "provision failed",
 			envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 				ErrorCode:       "activation_failed",
@@ -291,8 +296,8 @@ func TestValidateAcceptsExplicitFalseRetryable(t *testing.T) {
 		{
 			name: "deactivate failed",
 			envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ErrorCode:       "deactivation_failed",
 				ErrorMessage:    "deactivation failed",
@@ -315,6 +320,145 @@ func TestValidateAcceptsExplicitFalseRetryable(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsLifecycleIDsThatAreNotUUIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("org id", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: testDeviceID,
+			VideoCloudDevid: "video-1",
+			ActivityID:      "activity-1",
+			ClipPublicKey:   "clip-key",
+			RequestedBy:     "user-1",
+		})
+
+		err := envelope.Validate(StreamAccountVideoCommands)
+		if err == nil || !strings.Contains(err.Error(), "payload.org_id must be a UUID") {
+			t.Fatalf("expected invalid org id error, got %v", err)
+		}
+	})
+
+	t.Run("account device id", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			envelope Envelope
+			stream   string
+		}{
+			{
+				name: "DeviceProvisionRequested",
+				envelope: validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ActivityID:      "activity-1",
+					ClipPublicKey:   "clip-key",
+					RequestedBy:     "user-1",
+				}),
+				stream: StreamAccountVideoCommands,
+			},
+			{
+				name: "DeviceProvisionSucceeded",
+				envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ActivityID:      "activity-1",
+					ActivatedAt:     testTime,
+				}),
+				stream: StreamVideoAccountEvents,
+			},
+			{
+				name: "DeviceProvisionFailed",
+				envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ActivityID:      "activity-1",
+					ErrorCode:       "activation_failed",
+					ErrorMessage:    "activation failed",
+					Retryable:       true,
+					FailedAt:        testTime,
+				}),
+				stream: StreamVideoAccountEvents,
+			},
+			{
+				name: "DeviceDeactivateRequested",
+				envelope: validEnvelope(MessageTypeDeviceDeactivateRequested, DeviceDeactivateRequestedPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					RequestedBy:     "user-1",
+					Reason:          "account_device_disabled",
+				}),
+				stream: StreamAccountVideoCommands,
+			},
+			{
+				name: "DeviceDeactivateSucceeded",
+				envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					DeactivatedAt:   testTime,
+				}),
+				stream: StreamVideoAccountEvents,
+			},
+			{
+				name: "DeviceDeactivateFailed",
+				envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ErrorCode:       "deactivation_failed",
+					ErrorMessage:    "deactivation failed",
+					Retryable:       true,
+					FailedAt:        testTime,
+				}),
+				stream: StreamVideoAccountEvents,
+			},
+			{
+				name: "DeviceOnlineChanged",
+				envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					Status:          OnlineStatusOnline,
+					LastSeenAt:      testTime,
+				}),
+				stream: StreamVideoAccountEvents,
+			},
+			{
+				name: "DeviceMetadataChanged",
+				envelope: validEnvelope(MessageTypeDeviceMetadataChanged, DeviceMetadataChangedPayload{
+					OrgID:           testOrgID,
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					Metadata: map[string]any{
+						"video_cloud_activation_status": "activated",
+					},
+				}),
+				stream: StreamVideoAccountEvents,
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				err := tt.envelope.Validate(tt.stream)
+				if err == nil || !strings.Contains(err.Error(), "payload.account_device_id must be a UUID") {
+					t.Fatalf("expected invalid account device id error, got %v", err)
+				}
+			})
+		}
+	})
+}
+
 func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 	t.Parallel()
 
@@ -322,8 +466,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			ActivityID:      "activity-1",
 			ClipPublicKey:   "clip-key",
@@ -341,8 +485,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			ActivityID:      "activity-1",
 			ClipPublicKey:   "clip-key",
@@ -360,8 +504,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			ActivityID:      "activity-1",
 			ClipPublicKey:   "clip-key",
@@ -378,8 +522,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			Status:          OnlineStatusOnline,
 			LastSeenAt:      testTime,
@@ -396,8 +540,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			Status:          OnlineStatusOnline,
 			LastSeenAt:      testTime,
@@ -414,8 +558,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			Status:          OnlineStatusOnline,
 			LastSeenAt:      testTime,
@@ -432,8 +576,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			Status:          OnlineStatusOnline,
 			LastSeenAt:      testTime,
@@ -450,16 +594,16 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		t.Parallel()
 
 		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-			OrgID:           "org-1",
-			AccountDeviceID: "device-1",
+			OrgID:           testOrgID,
+			AccountDeviceID: testDeviceID,
 			VideoCloudDevid: "video-1",
 			ActivityID:      "activity-1",
 			ClipPublicKey:   "clip-key",
 			RequestedBy:     "user-1",
 		})
 		envelope.Payload = json.RawMessage(`{
-			"org_id":"org-1",
-			"account_device_id":"device-1",
+			"org_id":"11111111-1111-1111-1111-111111111111",
+			"account_device_id":"22222222-2222-2222-2222-222222222222",
 			"video_cloud_devid":"video-1",
 			"activity_id":"activity-1",
 			"clip_public_key":"clip-key",
@@ -488,8 +632,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 				messageType: MessageTypeDeviceProvisionFailed,
 				stream:      StreamVideoAccountEvents,
 				payload: `{
-					"org_id":"org-1",
-					"account_device_id":"device-1",
+					"org_id":"11111111-1111-1111-1111-111111111111",
+					"account_device_id":"22222222-2222-2222-2222-222222222222",
 					"video_cloud_devid":"video-1",
 					"activity_id":"activity-1",
 					"error_code":"activation_failed",
@@ -503,8 +647,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 				messageType: MessageTypeDeviceDeactivateFailed,
 				stream:      StreamVideoAccountEvents,
 				payload: `{
-					"org_id":"org-1",
-					"account_device_id":"device-1",
+					"org_id":"11111111-1111-1111-1111-111111111111",
+					"account_device_id":"22222222-2222-2222-2222-222222222222",
 					"video_cloud_devid":"video-1",
 					"error_code":"deactivation_failed",
 					"error_message":"deactivation failed",
@@ -543,8 +687,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			{
 				name: "provision succeeded",
 				envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
-					OrgID:           "org-1",
-					AccountDeviceID: "device-1",
+					OrgID:           testOrgID,
+					AccountDeviceID: testDeviceID,
 					VideoCloudDevid: "video-1",
 					ActivityID:      "activity-1",
 					ActivatedAt:     nonUTC,
@@ -555,8 +699,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			{
 				name: "provision failed",
 				envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
-					OrgID:           "org-1",
-					AccountDeviceID: "device-1",
+					OrgID:           testOrgID,
+					AccountDeviceID: testDeviceID,
 					VideoCloudDevid: "video-1",
 					ActivityID:      "activity-1",
 					ErrorCode:       "activation_failed",
@@ -570,8 +714,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			{
 				name: "deactivate succeeded",
 				envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
-					OrgID:           "org-1",
-					AccountDeviceID: "device-1",
+					OrgID:           testOrgID,
+					AccountDeviceID: testDeviceID,
 					VideoCloudDevid: "video-1",
 					DeactivatedAt:   nonUTC,
 				}),
@@ -581,8 +725,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			{
 				name: "deactivate failed",
 				envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
-					OrgID:           "org-1",
-					AccountDeviceID: "device-1",
+					OrgID:           testOrgID,
+					AccountDeviceID: testDeviceID,
 					VideoCloudDevid: "video-1",
 					ErrorCode:       "deactivation_failed",
 					ErrorMessage:    "deactivation failed",
@@ -595,8 +739,8 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			{
 				name: "online changed",
 				envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
-					OrgID:           "org-1",
-					AccountDeviceID: "device-1",
+					OrgID:           testOrgID,
+					AccountDeviceID: testDeviceID,
 					VideoCloudDevid: "video-1",
 					Status:          OnlineStatusOnline,
 					LastSeenAt:      nonUTC,
@@ -706,8 +850,8 @@ func TestValidateRejectsMissingEnvelopeFields(t *testing.T) {
 			t.Parallel()
 
 			envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
-				OrgID:           "org-1",
-				AccountDeviceID: "device-1",
+				OrgID:           testOrgID,
+				AccountDeviceID: testDeviceID,
 				VideoCloudDevid: "video-1",
 				ActivityID:      "activity-1",
 				ClipPublicKey:   "clip-key",
@@ -735,7 +879,7 @@ func TestEnvelopeUnmarshalRejectsUnknownFields(t *testing.T) {
 		"target_service":"realtek_video_server",
 		"message_type":"DeviceProvisionRequested",
 		"schema_version":"1.0",
-		"partition_key":"device-1",
+		"partition_key":"22222222-2222-2222-2222-222222222222",
 		"occurred_at":"2026-04-28T12:00:00Z",
 		"payload":{},
 		"unexpected":"value"
@@ -757,7 +901,7 @@ func TestDecodeStrictJSONRejectsMultipleJSONValues(t *testing.T) {
 		"target_service":"realtek_video_server",
 		"message_type":"DeviceProvisionRequested",
 		"schema_version":"1.0",
-		"partition_key":"device-1",
+		"partition_key":"22222222-2222-2222-2222-222222222222",
 		"occurred_at":"2026-04-28T12:00:00Z",
 		"payload":{}
 	} {}`), &envelope)
@@ -782,7 +926,7 @@ func validEnvelope(messageType MessageType, payload any) Envelope {
 		TargetService: spec.targetService,
 		MessageType:   messageType,
 		SchemaVersion: SchemaVersionV1,
-		PartitionKey:  "device-1",
+		PartitionKey:  testDeviceID,
 		OccurredAt:    testTime,
 		Payload:       raw,
 	}

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -671,6 +671,13 @@ func TestValidateRejectsMissingEnvelopeFields(t *testing.T) {
 			wantMessage: "schema_version must be non-empty",
 		},
 		{
+			name: "message type",
+			mutate: func(envelope *Envelope) {
+				envelope.MessageType = ""
+			},
+			wantMessage: "message_type must be non-empty",
+		},
+		{
 			name: "partition key",
 			mutate: func(envelope *Envelope) {
 				envelope.PartitionKey = ""

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -343,6 +343,24 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 		}
 	})
 
+	t.Run("target service mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			Status:          OnlineStatusOnline,
+			LastSeenAt:      testTime,
+		})
+		envelope.TargetService = ServiceRealtekVideoCloud
+
+		err := envelope.Validate(StreamVideoAccountEvents)
+		if err == nil || !strings.Contains(err.Error(), `target_service message type "DeviceOnlineChanged" must use "rtk_account_manager"`) {
+			t.Fatalf("expected target service mismatch error, got %v", err)
+		}
+	})
+
 	t.Run("partition key mismatch", func(t *testing.T) {
 		t.Parallel()
 
@@ -496,6 +514,102 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 	})
 }
 
+func TestValidateRejectsMissingEnvelopeFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mutate      func(*Envelope)
+		wantMessage string
+	}{
+		{
+			name: "message id",
+			mutate: func(envelope *Envelope) {
+				envelope.MessageID = " "
+			},
+			wantMessage: "message_id must be non-empty",
+		},
+		{
+			name: "correlation id",
+			mutate: func(envelope *Envelope) {
+				envelope.CorrelationID = ""
+			},
+			wantMessage: "correlation_id must be non-empty",
+		},
+		{
+			name: "operation id",
+			mutate: func(envelope *Envelope) {
+				envelope.OperationID = ""
+			},
+			wantMessage: "operation_id must be non-empty",
+		},
+		{
+			name: "source service",
+			mutate: func(envelope *Envelope) {
+				envelope.SourceService = ""
+			},
+			wantMessage: "source_service must be non-empty",
+		},
+		{
+			name: "target service",
+			mutate: func(envelope *Envelope) {
+				envelope.TargetService = ""
+			},
+			wantMessage: "target_service must be non-empty",
+		},
+		{
+			name: "schema version",
+			mutate: func(envelope *Envelope) {
+				envelope.SchemaVersion = ""
+			},
+			wantMessage: "schema_version must be non-empty",
+		},
+		{
+			name: "partition key",
+			mutate: func(envelope *Envelope) {
+				envelope.PartitionKey = ""
+			},
+			wantMessage: "partition_key must be non-empty",
+		},
+		{
+			name: "occurred at",
+			mutate: func(envelope *Envelope) {
+				envelope.OccurredAt = time.Time{}
+			},
+			wantMessage: "occurred_at must be set",
+		},
+		{
+			name: "payload",
+			mutate: func(envelope *Envelope) {
+				envelope.Payload = nil
+			},
+			wantMessage: "payload must be set",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+				OrgID:           "org-1",
+				AccountDeviceID: "device-1",
+				VideoCloudDevid: "video-1",
+				ActivityID:      "activity-1",
+				ClipPublicKey:   "clip-key",
+				RequestedBy:     "user-1",
+			})
+			tt.mutate(&envelope)
+
+			err := envelope.Validate(StreamAccountVideoCommands)
+			if err == nil || !strings.Contains(err.Error(), tt.wantMessage) {
+				t.Fatalf("expected missing field error %q, got %v", tt.wantMessage, err)
+			}
+		})
+	}
+}
+
 func TestEnvelopeUnmarshalRejectsUnknownFields(t *testing.T) {
 	t.Parallel()
 
@@ -515,6 +629,27 @@ func TestEnvelopeUnmarshalRejectsUnknownFields(t *testing.T) {
 	}`), &envelope)
 	if err == nil || !strings.Contains(err.Error(), `json: unknown field "unexpected"`) {
 		t.Fatalf("expected unknown field error, got %v", err)
+	}
+}
+
+func TestDecodeStrictJSONRejectsMultipleJSONValues(t *testing.T) {
+	t.Parallel()
+
+	var envelope Envelope
+	err := decodeStrictJSON([]byte(`{
+		"message_id":"msg-1",
+		"correlation_id":"corr-1",
+		"operation_id":"op-1",
+		"source_service":"rtk_account_manager",
+		"target_service":"realtek_video_server",
+		"message_type":"DeviceProvisionRequested",
+		"schema_version":"1.0",
+		"partition_key":"device-1",
+		"occurred_at":"2026-04-28T12:00:00Z",
+		"payload":{}
+	} {}`), &envelope)
+	if err == nil || !strings.Contains(err.Error(), "must contain a single JSON value") {
+		t.Fatalf("expected multiple JSON values error, got %v", err)
 	}
 }
 

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -405,6 +405,95 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			t.Fatalf("expected unknown payload field error, got %v", err)
 		}
 	})
+
+	t.Run("payload timestamps must use UTC", func(t *testing.T) {
+		t.Parallel()
+
+		nonUTC := time.Date(2026, 4, 28, 20, 0, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+		tests := []struct {
+			name        string
+			envelope    Envelope
+			stream      string
+			wantMessage string
+		}{
+			{
+				name: "provision succeeded",
+				envelope: validEnvelope(MessageTypeDeviceProvisionSucceeded, DeviceProvisionSucceededPayload{
+					OrgID:           "org-1",
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ActivityID:      "activity-1",
+					ActivatedAt:     nonUTC,
+				}),
+				stream:      StreamVideoAccountEvents,
+				wantMessage: "payload.activated_at must use UTC",
+			},
+			{
+				name: "provision failed",
+				envelope: validEnvelope(MessageTypeDeviceProvisionFailed, DeviceProvisionFailedPayload{
+					OrgID:           "org-1",
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ActivityID:      "activity-1",
+					ErrorCode:       "activation_failed",
+					ErrorMessage:    "activation failed",
+					Retryable:       true,
+					FailedAt:        nonUTC,
+				}),
+				stream:      StreamVideoAccountEvents,
+				wantMessage: "payload.failed_at must use UTC",
+			},
+			{
+				name: "deactivate succeeded",
+				envelope: validEnvelope(MessageTypeDeviceDeactivateSucceeded, DeviceDeactivateSucceededPayload{
+					OrgID:           "org-1",
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					DeactivatedAt:   nonUTC,
+				}),
+				stream:      StreamVideoAccountEvents,
+				wantMessage: "payload.deactivated_at must use UTC",
+			},
+			{
+				name: "deactivate failed",
+				envelope: validEnvelope(MessageTypeDeviceDeactivateFailed, DeviceDeactivateFailedPayload{
+					OrgID:           "org-1",
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					ErrorCode:       "deactivation_failed",
+					ErrorMessage:    "deactivation failed",
+					Retryable:       true,
+					FailedAt:        nonUTC,
+				}),
+				stream:      StreamVideoAccountEvents,
+				wantMessage: "payload.failed_at must use UTC",
+			},
+			{
+				name: "online changed",
+				envelope: validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+					OrgID:           "org-1",
+					AccountDeviceID: "device-1",
+					VideoCloudDevid: "video-1",
+					Status:          OnlineStatusOnline,
+					LastSeenAt:      nonUTC,
+				}),
+				stream:      StreamVideoAccountEvents,
+				wantMessage: "payload.last_seen_at must use UTC",
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				err := tt.envelope.Validate(tt.stream)
+				if err == nil || !strings.Contains(err.Error(), tt.wantMessage) {
+					t.Fatalf("expected UTC payload timestamp error %q, got %v", tt.wantMessage, err)
+				}
+			})
+		}
+	})
 }
 
 func TestEnvelopeUnmarshalRejectsUnknownFields(t *testing.T) {

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -360,6 +360,73 @@ func TestValidateRejectsEnvelopeContractMismatches(t *testing.T) {
 			t.Fatalf("expected partition key mismatch error, got %v", err)
 		}
 	})
+
+	t.Run("non-UTC occurred at", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceOnlineChanged, DeviceOnlineChangedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			Status:          OnlineStatusOnline,
+			LastSeenAt:      testTime,
+		})
+		envelope.OccurredAt = time.Date(2026, 4, 28, 20, 0, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+
+		err := envelope.Validate(StreamVideoAccountEvents)
+		if err == nil || !strings.Contains(err.Error(), "occurred_at must use UTC") {
+			t.Fatalf("expected UTC timestamp error, got %v", err)
+		}
+	})
+
+	t.Run("payload unknown field", func(t *testing.T) {
+		t.Parallel()
+
+		envelope := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+			OrgID:           "org-1",
+			AccountDeviceID: "device-1",
+			VideoCloudDevid: "video-1",
+			ActivityID:      "activity-1",
+			ClipPublicKey:   "clip-key",
+			RequestedBy:     "user-1",
+		})
+		envelope.Payload = json.RawMessage(`{
+			"org_id":"org-1",
+			"account_device_id":"device-1",
+			"video_cloud_devid":"video-1",
+			"activity_id":"activity-1",
+			"clip_public_key":"clip-key",
+			"requested_by":"user-1",
+			"unexpected":"value"
+		}`)
+
+		err := envelope.Validate(StreamAccountVideoCommands)
+		if err == nil || !strings.Contains(err.Error(), `payload: json: unknown field "unexpected"`) {
+			t.Fatalf("expected unknown payload field error, got %v", err)
+		}
+	})
+}
+
+func TestEnvelopeUnmarshalRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	var envelope Envelope
+	err := json.Unmarshal([]byte(`{
+		"message_id":"msg-1",
+		"correlation_id":"corr-1",
+		"operation_id":"op-1",
+		"source_service":"rtk_account_manager",
+		"target_service":"realtek_video_server",
+		"message_type":"DeviceProvisionRequested",
+		"schema_version":"1.0",
+		"partition_key":"device-1",
+		"occurred_at":"2026-04-28T12:00:00Z",
+		"payload":{},
+		"unexpected":"value"
+	}`), &envelope)
+	if err == nil || !strings.Contains(err.Error(), `json: unknown field "unexpected"`) {
+		t.Fatalf("expected unknown field error, got %v", err)
+	}
 }
 
 func validEnvelope(messageType MessageType, payload any) Envelope {

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -112,6 +112,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Member management | Owner add/update/remove/disable/enable member flows, admin/member forbidden paths, last-owner downgrade/remove/disable protection. |
 | Device lifecycle | Device create/list/get/update/status update/soft-delete, disabled-device read-only behavior, duplicate serial rejection, same serial in another org allowed. |
 | Authorization boundaries | owner/admin/member role permissions and cross-organization device/member access rejection. |
+| Message validation | Envelope fields, supported \`schema_version\`, message-type/stream/service pairing, lifecycle UUIDs, UTC timestamps, and \`partition_key\` validation for cross-service messages. |
 | Database invariants | Idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, automatic updated_at triggers. |
 | OpenAPI contract | OpenAPI schema validation and representative response validation against \`openapi.yaml\`. |
 | Configuration and maintenance | \`.env\` loading, TTL parsing/fallbacks, required JWT secrets, refresh-token cleanup behavior. |
@@ -146,7 +147,7 @@ go build ./...
 
 - Command entry points under \`cmd/*\` are intentionally validated by \`go build ./...\`, not unit coverage.
 - Store and database behavior are primarily covered through API integration tests.
-- Add or update integration tests whenever authorization, membership, token, migration, or device lifecycle behavior changes.
+- Add or update tests whenever authorization, membership, token, migration, device lifecycle, or cross-service channel validation behavior changes.
 EOF
 
 cat "$REPORT_FILE"


### PR DESCRIPTION
## Summary
- add an `internal/channel` package for the cross-service envelope, message types, payload structs, and validation rules
- validate supported schema version, stream/message pairing, service direction, and partition-key/device-id alignment
- add unit coverage for valid and invalid messages across all v2 lifecycle families

## Validation
- `go test ./internal/channel/...`
- `go test ./...`
- `go build ./...`

Refs #4
