### PR TITLE
[DB] Add device operations, outbox, and inbox persistence

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -37,7 +37,7 @@ Milestone: `v2-provisioning-event-channel`
 | --- | --- | --- | --- | --- | --- |
 | `[Docs] Align SPEC with provisioning/event-channel v2 scope` | P0 | `docs`, `v2` | None | planned | `docs/SPEC.md` describes v2 APIs, data model, streams, statuses, metadata keys, and acceptance criteria. |
 | `[Docs] Add v2 implementation checklist and issue map` | P0 | `docs`, `v2` | None | planned | This document contains the issue map, dependency order, and status tracking. |
-| `[DB] Add device operations, outbox, and inbox persistence` | P1 | `database`, `backend`, `v2` | Docs issues | planned | Migrations and store methods for operation tracking, outbox publication state, and inbox dedupe. |
+| `[DB] Add device operations, outbox, and inbox persistence` | P1 | `database`, `backend`, `v2` | Docs issues | in_progress | Migrations and store methods for operation tracking, outbox publication state, and inbox dedupe. |
 | `[Domain] Add cross-service message envelope and payload validation` | P1 | `backend`, `v2` | Docs issues | planned | Envelope and payload types validate contract-required fields, stream/message types, schema version, and partition key. |
 | `[Device] Add metadata merge and projection primitives` | P1 | `backend`, `v2` | DB, Domain | planned | Store-level partial metadata merge and projection helpers for video metadata and online status. |
 | `[API] Add provisioning and deactivation endpoints` | P1 | `api`, `backend`, `v2` | DB, Domain, Device | planned | HTTP endpoints create/reuse operations and enqueue lifecycle command messages. |

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"rtk_account_manager/internal/auth"
 	"rtk_account_manager/internal/database"
 	"rtk_account_manager/internal/store"
+	"rtk_account_manager/internal/testutil"
 )
 
 type integrationEnv struct {
@@ -37,6 +38,8 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(db.Close)
+
+	testutil.LockIntegrationDatabase(t, db)
 
 	if err := database.Migrate(ctx, db); err != nil {
 		t.Fatal(err)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -27,6 +27,42 @@ const (
 	DeviceStatusDisabled DeviceStatus = "disabled"
 )
 
+type DeviceOperationType string
+
+const (
+	DeviceOperationTypeProvision  DeviceOperationType = "provision"
+	DeviceOperationTypeDeactivate DeviceOperationType = "deactivate"
+)
+
+type DeviceOperationStatus string
+
+const (
+	DeviceOperationStatusPending      DeviceOperationStatus = "pending"
+	DeviceOperationStatusPublished    DeviceOperationStatus = "published"
+	DeviceOperationStatusSucceeded    DeviceOperationStatus = "succeeded"
+	DeviceOperationStatusFailed       DeviceOperationStatus = "failed"
+	DeviceOperationStatusRetrying     DeviceOperationStatus = "retrying"
+	DeviceOperationStatusDeadLettered DeviceOperationStatus = "dead_lettered"
+)
+
+type DeviceMessageOutboxStatus string
+
+const (
+	DeviceMessageOutboxStatusPending      DeviceMessageOutboxStatus = "pending"
+	DeviceMessageOutboxStatusPublished    DeviceMessageOutboxStatus = "published"
+	DeviceMessageOutboxStatusRetrying     DeviceMessageOutboxStatus = "retrying"
+	DeviceMessageOutboxStatusDeadLettered DeviceMessageOutboxStatus = "dead_lettered"
+)
+
+type DeviceMessageInboxStatus string
+
+const (
+	DeviceMessageInboxStatusProcessed    DeviceMessageInboxStatus = "processed"
+	DeviceMessageInboxStatusFailed       DeviceMessageInboxStatus = "failed"
+	DeviceMessageInboxStatusRetrying     DeviceMessageInboxStatus = "retrying"
+	DeviceMessageInboxStatusDeadLettered DeviceMessageInboxStatus = "dead_lettered"
+)
+
 type User struct {
 	ID          string     `json:"id"`
 	Email       string     `json:"email"`
@@ -70,4 +106,63 @@ type Device struct {
 	CreatedAt      time.Time      `json:"created_at"`
 	UpdatedAt      time.Time      `json:"updated_at"`
 	DisabledAt     *time.Time     `json:"disabled_at,omitempty"`
+}
+
+type DeviceOperation struct {
+	ID             string                `json:"id"`
+	OperationID    string                `json:"operation_id"`
+	CorrelationID  string                `json:"correlation_id"`
+	OrganizationID string                `json:"organization_id"`
+	DeviceID       string                `json:"device_id"`
+	OperationType  DeviceOperationType   `json:"operation_type"`
+	Status         DeviceOperationStatus `json:"status"`
+	RequestedBy    *string               `json:"requested_by,omitempty"`
+	RequestPayload map[string]any        `json:"request_payload"`
+	ResultPayload  map[string]any        `json:"result_payload"`
+	ErrorCode      *string               `json:"error_code,omitempty"`
+	ErrorMessage   *string               `json:"error_message,omitempty"`
+	Retryable      *bool                 `json:"retryable,omitempty"`
+	CreatedAt      time.Time             `json:"created_at"`
+	UpdatedAt      time.Time             `json:"updated_at"`
+	CompletedAt    *time.Time            `json:"completed_at,omitempty"`
+}
+
+type DeviceMessageOutbox struct {
+	ID            string                    `json:"id"`
+	MessageID     string                    `json:"message_id"`
+	OperationID   string                    `json:"operation_id"`
+	CorrelationID string                    `json:"correlation_id"`
+	CausationID   *string                   `json:"causation_id,omitempty"`
+	Stream        string                    `json:"stream"`
+	MessageType   string                    `json:"message_type"`
+	SchemaVersion string                    `json:"schema_version"`
+	PartitionKey  string                    `json:"partition_key"`
+	Payload       map[string]any            `json:"payload"`
+	Status        DeviceMessageOutboxStatus `json:"status"`
+	AttemptCount  int                       `json:"attempt_count"`
+	LastError     *string                   `json:"last_error,omitempty"`
+	AvailableAt   time.Time                 `json:"available_at"`
+	PublishedAt   *time.Time                `json:"published_at,omitempty"`
+	CreatedAt     time.Time                 `json:"created_at"`
+	UpdatedAt     time.Time                 `json:"updated_at"`
+}
+
+type DeviceMessageInbox struct {
+	ID            string                   `json:"id"`
+	MessageID     string                   `json:"message_id"`
+	OperationID   string                   `json:"operation_id"`
+	CorrelationID string                   `json:"correlation_id"`
+	CausationID   *string                  `json:"causation_id,omitempty"`
+	Stream        string                   `json:"stream"`
+	MessageType   string                   `json:"message_type"`
+	SchemaVersion string                   `json:"schema_version"`
+	PartitionKey  string                   `json:"partition_key"`
+	Payload       map[string]any           `json:"payload"`
+	Status        DeviceMessageInboxStatus `json:"status"`
+	AttemptCount  int                      `json:"attempt_count"`
+	LastError     *string                  `json:"last_error,omitempty"`
+	ReceivedAt    time.Time                `json:"received_at"`
+	ProcessedAt   *time.Time               `json:"processed_at,omitempty"`
+	CreatedAt     time.Time                `json:"created_at"`
+	UpdatedAt     time.Time                `json:"updated_at"`
 }

--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -1,0 +1,495 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type DeviceOperationCreateInput struct {
+	OperationID    string
+	CorrelationID  string
+	OrganizationID string
+	DeviceID       string
+	OperationType  model.DeviceOperationType
+	Status         model.DeviceOperationStatus
+	RequestedBy    *string
+	RequestPayload map[string]any
+	ResultPayload  map[string]any
+	ErrorCode      *string
+	ErrorMessage   *string
+	Retryable      *bool
+	CompletedAt    *time.Time
+}
+
+type DeviceOperationUpdateInput struct {
+	Status        model.DeviceOperationStatus
+	ResultPayload map[string]any
+	ErrorCode     *string
+	ErrorMessage  *string
+	Retryable     *bool
+	CompletedAt   *time.Time
+}
+
+type DeviceMessageOutboxCreateInput struct {
+	MessageID     string
+	OperationID   string
+	CorrelationID string
+	CausationID   *string
+	Stream        string
+	MessageType   string
+	SchemaVersion string
+	PartitionKey  string
+	Payload       map[string]any
+	Status        model.DeviceMessageOutboxStatus
+	AttemptCount  int
+	LastError     *string
+	AvailableAt   time.Time
+	PublishedAt   *time.Time
+}
+
+type DeviceMessageOutboxUpdateInput struct {
+	Status       model.DeviceMessageOutboxStatus
+	AttemptCount int
+	LastError    *string
+	AvailableAt  time.Time
+	PublishedAt  *time.Time
+}
+
+type DeviceMessageInboxCreateInput struct {
+	MessageID     string
+	OperationID   string
+	CorrelationID string
+	CausationID   *string
+	Stream        string
+	MessageType   string
+	SchemaVersion string
+	PartitionKey  string
+	Payload       map[string]any
+	Status        model.DeviceMessageInboxStatus
+	AttemptCount  int
+	LastError     *string
+	ReceivedAt    time.Time
+	ProcessedAt   *time.Time
+}
+
+type DeviceMessageInboxUpdateInput struct {
+	Status       model.DeviceMessageInboxStatus
+	AttemptCount int
+	LastError    *string
+	ProcessedAt  *time.Time
+}
+
+func (s *Store) CreateOrGetDeviceOperation(ctx context.Context, in DeviceOperationCreateInput) (model.DeviceOperation, bool, error) {
+	requestPayload, err := marshalJSONMap(in.RequestPayload)
+	if err != nil {
+		return model.DeviceOperation{}, false, err
+	}
+	resultPayload, err := marshalJSONMap(in.ResultPayload)
+	if err != nil {
+		return model.DeviceOperation{}, false, err
+	}
+
+	row := s.db.QueryRow(ctx, `
+		INSERT INTO device_operations (
+			operation_id,
+			correlation_id,
+			organization_id,
+			device_id,
+			operation_type,
+			status,
+			requested_by,
+			request_payload,
+			result_payload,
+			error_code,
+			error_message,
+			retryable,
+			completed_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11, $12, $13)
+		ON CONFLICT (operation_id) DO NOTHING
+		RETURNING id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+	`, in.OperationID, in.CorrelationID, in.OrganizationID, in.DeviceID, in.OperationType, in.Status, in.RequestedBy, requestPayload, resultPayload, in.ErrorCode, in.ErrorMessage, in.Retryable, in.CompletedAt)
+
+	operation, err := scanDeviceOperation(row)
+	if err == nil {
+		return operation, true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceOperation{}, false, err
+	}
+
+	existing, err := s.GetDeviceOperation(ctx, in.OperationID)
+	if err != nil {
+		return model.DeviceOperation{}, false, err
+	}
+	if err := compareOperationCreate(existing, in, requestPayload); err != nil {
+		return model.DeviceOperation{}, false, err
+	}
+	return existing, false, nil
+}
+
+func (s *Store) GetDeviceOperation(ctx context.Context, operationID string) (model.DeviceOperation, error) {
+	operation, err := scanDeviceOperation(s.db.QueryRow(ctx, `
+		SELECT id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+		FROM device_operations
+		WHERE operation_id = $1
+	`, operationID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceOperation{}, ErrNotFound
+	}
+	return operation, err
+}
+
+func (s *Store) UpdateDeviceOperation(ctx context.Context, operationID string, in DeviceOperationUpdateInput) (model.DeviceOperation, error) {
+	resultPayload, err := marshalJSONMap(in.ResultPayload)
+	if err != nil {
+		return model.DeviceOperation{}, err
+	}
+
+	operation, err := scanDeviceOperation(s.db.QueryRow(ctx, `
+		UPDATE device_operations
+		SET status = $2,
+			result_payload = $3::jsonb,
+			error_code = $4,
+			error_message = $5,
+			retryable = $6,
+			completed_at = $7
+		WHERE operation_id = $1
+		RETURNING id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+	`, operationID, in.Status, resultPayload, in.ErrorCode, in.ErrorMessage, in.Retryable, in.CompletedAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceOperation{}, ErrNotFound
+	}
+	return operation, err
+}
+
+func (s *Store) CreateOutboxMessage(ctx context.Context, in DeviceMessageOutboxCreateInput) (model.DeviceMessageOutbox, error) {
+	payload, err := marshalJSONMap(in.Payload)
+	if err != nil {
+		return model.DeviceMessageOutbox{}, err
+	}
+
+	message, err := scanDeviceMessageOutbox(s.db.QueryRow(ctx, `
+		INSERT INTO device_message_outbox (
+			message_id,
+			operation_id,
+			correlation_id,
+			causation_id,
+			stream,
+			message_type,
+			schema_version,
+			partition_key,
+			payload,
+			status,
+			attempt_count,
+			last_error,
+			available_at,
+			published_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13, $14)
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+	`, in.MessageID, in.OperationID, in.CorrelationID, in.CausationID, in.Stream, in.MessageType, in.SchemaVersion, in.PartitionKey, payload, in.Status, in.AttemptCount, in.LastError, in.AvailableAt, in.PublishedAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageOutbox{}, ErrNotFound
+	}
+	return message, err
+}
+
+func (s *Store) GetOutboxMessage(ctx context.Context, messageID string) (model.DeviceMessageOutbox, error) {
+	message, err := scanDeviceMessageOutbox(s.db.QueryRow(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+		FROM device_message_outbox
+		WHERE message_id = $1
+	`, messageID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageOutbox{}, ErrNotFound
+	}
+	return message, err
+}
+
+func (s *Store) ListOutboxMessagesReady(ctx context.Context, readyBefore time.Time, limit int) ([]model.DeviceMessageOutbox, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+		FROM device_message_outbox
+		WHERE status IN ('pending', 'retrying') AND available_at <= $1
+		ORDER BY available_at ASC, created_at ASC
+		LIMIT $2
+	`, readyBefore, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	messages := make([]model.DeviceMessageOutbox, 0)
+	for rows.Next() {
+		message, err := scanDeviceMessageOutbox(rows)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func (s *Store) UpdateOutboxMessage(ctx context.Context, messageID string, in DeviceMessageOutboxUpdateInput) (model.DeviceMessageOutbox, error) {
+	message, err := scanDeviceMessageOutbox(s.db.QueryRow(ctx, `
+		UPDATE device_message_outbox
+		SET status = $2,
+			attempt_count = $3,
+			last_error = $4,
+			available_at = $5,
+			published_at = $6
+		WHERE message_id = $1
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+	`, messageID, in.Status, in.AttemptCount, in.LastError, in.AvailableAt, in.PublishedAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageOutbox{}, ErrNotFound
+	}
+	return message, err
+}
+
+func (s *Store) CreateOrGetInboxMessage(ctx context.Context, in DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error) {
+	payload, err := marshalJSONMap(in.Payload)
+	if err != nil {
+		return model.DeviceMessageInbox{}, false, err
+	}
+
+	row := s.db.QueryRow(ctx, `
+		INSERT INTO device_message_inbox (
+			message_id,
+			operation_id,
+			correlation_id,
+			causation_id,
+			stream,
+			message_type,
+			schema_version,
+			partition_key,
+			payload,
+			status,
+			attempt_count,
+			last_error,
+			received_at,
+			processed_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13, $14)
+		ON CONFLICT (message_id) DO NOTHING
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+	`, in.MessageID, in.OperationID, in.CorrelationID, in.CausationID, in.Stream, in.MessageType, in.SchemaVersion, in.PartitionKey, payload, in.Status, in.AttemptCount, in.LastError, in.ReceivedAt, in.ProcessedAt)
+
+	message, err := scanDeviceMessageInbox(row)
+	if err == nil {
+		return message, true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageInbox{}, false, err
+	}
+
+	existing, err := s.GetInboxMessage(ctx, in.MessageID)
+	if err != nil {
+		return model.DeviceMessageInbox{}, false, err
+	}
+	if err := compareInboxCreate(existing, in, payload); err != nil {
+		return model.DeviceMessageInbox{}, false, err
+	}
+	return existing, false, nil
+}
+
+func (s *Store) GetInboxMessage(ctx context.Context, messageID string) (model.DeviceMessageInbox, error) {
+	message, err := scanDeviceMessageInbox(s.db.QueryRow(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+		FROM device_message_inbox
+		WHERE message_id = $1
+	`, messageID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageInbox{}, ErrNotFound
+	}
+	return message, err
+}
+
+func (s *Store) UpdateInboxMessage(ctx context.Context, messageID string, in DeviceMessageInboxUpdateInput) (model.DeviceMessageInbox, error) {
+	message, err := scanDeviceMessageInbox(s.db.QueryRow(ctx, `
+		UPDATE device_message_inbox
+		SET status = $2,
+			attempt_count = $3,
+			last_error = $4,
+			processed_at = $5
+		WHERE message_id = $1
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+	`, messageID, in.Status, in.AttemptCount, in.LastError, in.ProcessedAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageInbox{}, ErrNotFound
+	}
+	return message, err
+}
+
+func compareOperationCreate(existing model.DeviceOperation, in DeviceOperationCreateInput, requestPayload []byte) error {
+	if existing.OrganizationID != in.OrganizationID ||
+		existing.DeviceID != in.DeviceID ||
+		existing.OperationType != in.OperationType ||
+		!sameJSONMap(existing.RequestPayload, requestPayload) {
+		return ErrConflict
+	}
+	return nil
+}
+
+func compareInboxCreate(existing model.DeviceMessageInbox, in DeviceMessageInboxCreateInput, payload []byte) error {
+	if existing.OperationID != in.OperationID ||
+		existing.CorrelationID != in.CorrelationID ||
+		!sameStringPtr(existing.CausationID, in.CausationID) ||
+		existing.Stream != in.Stream ||
+		existing.MessageType != in.MessageType ||
+		existing.SchemaVersion != in.SchemaVersion ||
+		existing.PartitionKey != in.PartitionKey ||
+		!sameJSONMap(existing.Payload, payload) {
+		return ErrConflict
+	}
+	return nil
+}
+
+func sameStringPtr(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func sameJSONMap(existing map[string]any, want []byte) bool {
+	got, err := marshalJSONMap(existing)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(got, want)
+}
+
+func marshalJSONMap(value map[string]any) ([]byte, error) {
+	if value == nil {
+		value = map[string]any{}
+	}
+	return json.Marshal(value)
+}
+
+func scanDeviceOperation(row rowScanner) (model.DeviceOperation, error) {
+	var operation model.DeviceOperation
+	var requestPayload []byte
+	var resultPayload []byte
+	err := row.Scan(
+		&operation.ID,
+		&operation.OperationID,
+		&operation.CorrelationID,
+		&operation.OrganizationID,
+		&operation.DeviceID,
+		&operation.OperationType,
+		&operation.Status,
+		&operation.RequestedBy,
+		&requestPayload,
+		&resultPayload,
+		&operation.ErrorCode,
+		&operation.ErrorMessage,
+		&operation.Retryable,
+		&operation.CreatedAt,
+		&operation.UpdatedAt,
+		&operation.CompletedAt,
+	)
+	if err != nil {
+		return model.DeviceOperation{}, err
+	}
+	requestMap, err := unmarshalJSONMap(requestPayload)
+	if err != nil {
+		return model.DeviceOperation{}, err
+	}
+	resultMap, err := unmarshalJSONMap(resultPayload)
+	if err != nil {
+		return model.DeviceOperation{}, err
+	}
+	operation.RequestPayload = requestMap
+	operation.ResultPayload = resultMap
+	return operation, nil
+}
+
+func scanDeviceMessageOutbox(row rowScanner) (model.DeviceMessageOutbox, error) {
+	var message model.DeviceMessageOutbox
+	var payload []byte
+	err := row.Scan(
+		&message.ID,
+		&message.MessageID,
+		&message.OperationID,
+		&message.CorrelationID,
+		&message.CausationID,
+		&message.Stream,
+		&message.MessageType,
+		&message.SchemaVersion,
+		&message.PartitionKey,
+		&payload,
+		&message.Status,
+		&message.AttemptCount,
+		&message.LastError,
+		&message.AvailableAt,
+		&message.PublishedAt,
+		&message.CreatedAt,
+		&message.UpdatedAt,
+	)
+	if err != nil {
+		return model.DeviceMessageOutbox{}, err
+	}
+	message.Payload, err = unmarshalJSONMap(payload)
+	if err != nil {
+		return model.DeviceMessageOutbox{}, err
+	}
+	return message, nil
+}
+
+func scanDeviceMessageInbox(row rowScanner) (model.DeviceMessageInbox, error) {
+	var message model.DeviceMessageInbox
+	var payload []byte
+	err := row.Scan(
+		&message.ID,
+		&message.MessageID,
+		&message.OperationID,
+		&message.CorrelationID,
+		&message.CausationID,
+		&message.Stream,
+		&message.MessageType,
+		&message.SchemaVersion,
+		&message.PartitionKey,
+		&payload,
+		&message.Status,
+		&message.AttemptCount,
+		&message.LastError,
+		&message.ReceivedAt,
+		&message.ProcessedAt,
+		&message.CreatedAt,
+		&message.UpdatedAt,
+	)
+	if err != nil {
+		return model.DeviceMessageInbox{}, err
+	}
+	message.Payload, err = unmarshalJSONMap(payload)
+	if err != nil {
+		return model.DeviceMessageInbox{}, err
+	}
+	return message, nil
+}
+
+func unmarshalJSONMap(value []byte) (map[string]any, error) {
+	if len(value) == 0 {
+		return map[string]any{}, nil
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return nil, err
+	}
+	if decoded == nil {
+		return map[string]any{}, nil
+	}
+	return decoded, nil
+}

--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -333,7 +333,8 @@ func (s *Store) UpdateInboxMessage(ctx context.Context, messageID string, in Dev
 }
 
 func compareOperationCreate(existing model.DeviceOperation, in DeviceOperationCreateInput, requestPayload []byte) error {
-	if existing.OrganizationID != in.OrganizationID ||
+	if existing.CorrelationID != in.CorrelationID ||
+		existing.OrganizationID != in.OrganizationID ||
 		existing.DeviceID != in.DeviceID ||
 		existing.OperationType != in.OperationType ||
 		!sameJSONMap(existing.RequestPayload, requestPayload) {

--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -241,6 +241,45 @@ func (s *Store) ListOutboxMessagesReady(ctx context.Context, readyBefore time.Ti
 	return messages, nil
 }
 
+func (s *Store) ClaimOutboxMessagesReady(ctx context.Context, readyBefore, claimUntil time.Time, limit int) ([]model.DeviceMessageOutbox, error) {
+	rows, err := s.db.Query(ctx, `
+		WITH candidates AS (
+			SELECT id
+			FROM device_message_outbox
+			WHERE status IN ('pending', 'retrying') AND available_at <= $1
+			ORDER BY available_at ASC, created_at ASC
+			FOR UPDATE SKIP LOCKED
+			LIMIT $2
+		), claimed AS (
+			UPDATE device_message_outbox AS outbox
+			SET available_at = $3
+			FROM candidates
+			WHERE outbox.id = candidates.id
+			RETURNING outbox.id::text, outbox.message_id, outbox.operation_id, outbox.correlation_id, outbox.causation_id, outbox.stream, outbox.message_type, outbox.schema_version, outbox.partition_key, outbox.payload, outbox.status, outbox.attempt_count, outbox.last_error, outbox.available_at, outbox.published_at, outbox.created_at, outbox.updated_at
+		)
+		SELECT id, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+		FROM claimed
+		ORDER BY created_at ASC
+	`, readyBefore, limit, claimUntil)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	messages := make([]model.DeviceMessageOutbox, 0)
+	for rows.Next() {
+		message, err := scanDeviceMessageOutbox(rows)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
 func (s *Store) UpdateOutboxMessage(ctx context.Context, messageID string, in DeviceMessageOutboxUpdateInput) (model.DeviceMessageOutbox, error) {
 	message, err := scanDeviceMessageOutbox(s.db.QueryRow(ctx, `
 		UPDATE device_message_outbox

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -287,6 +287,105 @@ func TestOutboxMessagePersistenceAndReadyList(t *testing.T) {
 	}
 }
 
+func TestClaimOutboxMessagesReadyLeasesRows(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	op, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-claim",
+		CorrelationID:  "corr-claim",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	claimUntil := now.Add(5 * time.Minute)
+	for _, message := range []DeviceMessageOutboxCreateInput{
+		{
+			MessageID:     "claim-msg-1",
+			OperationID:   op.OperationID,
+			CorrelationID: op.CorrelationID,
+			Stream:        "account.video.commands",
+			MessageType:   "DeviceProvisionRequested",
+			SchemaVersion: "1.0",
+			PartitionKey:  deviceID,
+			Payload:       map[string]any{"operation_id": op.OperationID},
+			Status:        model.DeviceMessageOutboxStatusPending,
+			AvailableAt:   now.Add(-2 * time.Minute),
+		},
+		{
+			MessageID:     "claim-msg-2",
+			OperationID:   op.OperationID,
+			CorrelationID: op.CorrelationID,
+			Stream:        "account.video.commands",
+			MessageType:   "DeviceDeactivateRequested",
+			SchemaVersion: "1.0",
+			PartitionKey:  deviceID,
+			Payload:       map[string]any{"operation_id": op.OperationID},
+			Status:        model.DeviceMessageOutboxStatusRetrying,
+			AttemptCount:  1,
+			LastError:     stringPtr("temporary failure"),
+			AvailableAt:   now.Add(-time.Minute),
+		},
+		{
+			MessageID:     "claim-msg-3",
+			OperationID:   op.OperationID,
+			CorrelationID: op.CorrelationID,
+			Stream:        "account.video.commands",
+			MessageType:   "DeviceProvisionRequested",
+			SchemaVersion: "1.0",
+			PartitionKey:  deviceID,
+			Payload:       map[string]any{"operation_id": op.OperationID},
+			Status:        model.DeviceMessageOutboxStatusPending,
+			AvailableAt:   now.Add(time.Minute),
+		},
+	} {
+		if _, err := env.store.CreateOutboxMessage(ctx, message); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	claimed, err := env.store.ClaimOutboxMessagesReady(ctx, now, claimUntil, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 2 {
+		t.Fatalf("expected two claimed rows, got %+v", claimed)
+	}
+	if claimed[0].MessageID != "claim-msg-1" || claimed[1].MessageID != "claim-msg-2" {
+		t.Fatalf("expected oldest ready rows to be claimed, got %+v", claimed)
+	}
+	for _, message := range claimed {
+		if !message.AvailableAt.Equal(claimUntil) {
+			t.Fatalf("expected claimed row to be leased until %s, got %+v", claimUntil, message)
+		}
+	}
+
+	ready, err := env.store.ListOutboxMessagesReady(ctx, now, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ready) != 0 {
+		t.Fatalf("expected no rows to remain ready after claim, got %+v", ready)
+	}
+
+	claimed, err = env.store.ClaimOutboxMessagesReady(ctx, now, claimUntil.Add(time.Minute), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 0 {
+		t.Fatalf("expected leased rows to stay hidden until available_at, got %+v", claimed)
+	}
+}
+
 func TestCreateOrGetInboxMessageDeduplicates(t *testing.T) {
 	env := newStoreIntegrationEnv(t)
 	orgID, userID, deviceID := createDeviceFixture(t, env)

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"rtk_account_manager/internal/database"
 	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/testutil"
 )
 
 type storeIntegrationEnv struct {
@@ -32,6 +33,8 @@ func newStoreIntegrationEnv(t *testing.T) storeIntegrationEnv {
 		t.Fatal(err)
 	}
 	t.Cleanup(db.Close)
+
+	testutil.LockIntegrationDatabase(t, db)
 
 	if err := database.Migrate(ctx, db); err != nil {
 		t.Fatal(err)
@@ -151,6 +154,23 @@ func TestCreateOrGetDeviceOperationIsIdempotent(t *testing.T) {
 	if result.UpdatedAt.Before(op.UpdatedAt) {
 		t.Fatalf("expected updated_at to stay monotonic, before=%s after=%s", op.UpdatedAt, result.UpdatedAt)
 	}
+
+	stored, err := env.store.GetDeviceOperation(ctx, op.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ID != op.ID || stored.Status != model.DeviceOperationStatusSucceeded {
+		t.Fatalf("unexpected stored operation: %+v", stored)
+	}
+
+	if _, err := env.store.GetDeviceOperation(ctx, "missing-operation"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing operation to return ErrNotFound, got %v", err)
+	}
+	if _, err := env.store.UpdateDeviceOperation(ctx, "missing-operation", DeviceOperationUpdateInput{
+		Status: model.DeviceOperationStatusFailed,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing operation update to return ErrNotFound, got %v", err)
+	}
 }
 
 func TestOutboxMessagePersistenceAndReadyList(t *testing.T) {
@@ -232,6 +252,24 @@ func TestOutboxMessagePersistenceAndReadyList(t *testing.T) {
 	}
 	if published.Status != model.DeviceMessageOutboxStatusPublished {
 		t.Fatalf("expected published status, got %s", published.Status)
+	}
+
+	stored, err := env.store.GetOutboxMessage(ctx, first.MessageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ID != first.ID || stored.Status != model.DeviceMessageOutboxStatusPublished {
+		t.Fatalf("unexpected stored outbox message: %+v", stored)
+	}
+
+	if _, err := env.store.GetOutboxMessage(ctx, "missing-message"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing outbox message to return ErrNotFound, got %v", err)
+	}
+	if _, err := env.store.UpdateOutboxMessage(ctx, "missing-message", DeviceMessageOutboxUpdateInput{
+		Status:      model.DeviceMessageOutboxStatusRetrying,
+		AvailableAt: now,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing outbox update to return ErrNotFound, got %v", err)
 	}
 }
 
@@ -329,6 +367,23 @@ func TestCreateOrGetInboxMessageDeduplicates(t *testing.T) {
 	}
 	if processed.Status != model.DeviceMessageInboxStatusProcessed {
 		t.Fatalf("expected processed status, got %s", processed.Status)
+	}
+
+	stored, err := env.store.GetInboxMessage(ctx, message.MessageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ID != message.ID || stored.Status != model.DeviceMessageInboxStatusProcessed {
+		t.Fatalf("unexpected stored inbox message: %+v", stored)
+	}
+
+	if _, err := env.store.GetInboxMessage(ctx, "missing-event"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing inbox message to return ErrNotFound, got %v", err)
+	}
+	if _, err := env.store.UpdateInboxMessage(ctx, "missing-event", DeviceMessageInboxUpdateInput{
+		Status: model.DeviceMessageInboxStatusFailed,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing inbox update to return ErrNotFound, got %v", err)
 	}
 }
 

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"rtk_account_manager/internal/database"
@@ -185,6 +186,81 @@ func TestCreateOrGetDeviceOperationIsIdempotent(t *testing.T) {
 	}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected missing operation update to return ErrNotFound, got %v", err)
 	}
+}
+
+func TestDeviceMessagePersistenceRejectsInvalidSchemaValues(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	_, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-invalid-status",
+		CorrelationID:  "corr-invalid-status",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatus("unknown-status"),
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	requirePGErrorCode(t, err, "23514")
+
+	op, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-schema-checks",
+		CorrelationID:  "corr-schema-checks",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	_, err = env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "missing-op-message",
+		OperationID:   "missing-operation",
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceProvisionRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"operation_id": "missing-operation"},
+		Status:        model.DeviceMessageOutboxStatusPending,
+		AvailableAt:   now,
+	})
+	requirePGErrorCode(t, err, "23503")
+
+	_, err = env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "blank-partition-key",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceProvisionRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  "   ",
+		Payload:       map[string]any{"operation_id": op.OperationID},
+		Status:        model.DeviceMessageOutboxStatusPending,
+		AvailableAt:   now,
+	})
+	requirePGErrorCode(t, err, "23514")
+
+	_, _, err = env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "invalid-inbox-type",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "video.account.events",
+		MessageType:   "UnknownMessageType",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"video_cloud_devid": "device-1"},
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		ReceivedAt:    now,
+	})
+	requirePGErrorCode(t, err, "23514")
 }
 
 func TestOutboxMessagePersistenceAndReadyList(t *testing.T) {
@@ -502,4 +578,16 @@ func TestCreateOrGetInboxMessageDeduplicates(t *testing.T) {
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+func requirePGErrorCode(t *testing.T, err error, want string) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("expected pg error %s, got %v", want, err)
+	}
+	if pgErr.Code != want {
+		t.Fatalf("expected pg error %s, got %s (%s)", want, pgErr.Code, pgErr.Message)
+	}
 }

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -1,0 +1,337 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"rtk_account_manager/internal/database"
+	"rtk_account_manager/internal/model"
+)
+
+type storeIntegrationEnv struct {
+	store *Store
+	db    *pgxpool.Pool
+}
+
+func newStoreIntegrationEnv(t *testing.T) storeIntegrationEnv {
+	t.Helper()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	db, err := database.Connect(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+
+	if err := database.Migrate(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `
+		TRUNCATE device_message_inbox, device_message_outbox, device_operations, refresh_tokens, devices, organization_members, organizations, users
+		RESTART IDENTITY CASCADE
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	return storeIntegrationEnv{store: New(db), db: db}
+}
+
+func createDeviceFixture(t *testing.T, env storeIntegrationEnv) (string, string, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "owner@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Owner Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device, err := env.store.CreateDevice(ctx, registered.Organization.ID, DeviceInput{
+		Name:     "Camera 1",
+		Category: model.DeviceCategoryIPCamera,
+		Metadata: map[string]any{"location": "lab"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return registered.Organization.ID, registered.User.ID, device.ID
+}
+
+func TestCreateOrGetDeviceOperationIsIdempotent(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	createdAt := time.Now().UTC().Truncate(time.Microsecond)
+	op, created, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-1",
+		CorrelationID:  "corr-1",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+		ResultPayload:  map[string]any{},
+		CompletedAt:    nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected first operation insert to create a row")
+	}
+	if op.OperationID != "op-1" || op.Status != model.DeviceOperationStatusPending {
+		t.Fatalf("unexpected operation: %+v", op)
+	}
+
+	same, created, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-1",
+		CorrelationID:  "corr-1",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created {
+		t.Fatal("expected duplicate operation_id to reuse the existing row")
+	}
+	if same.ID != op.ID {
+		t.Fatalf("expected same operation row, got %q want %q", same.ID, op.ID)
+	}
+
+	conflicting, created, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-1",
+		CorrelationID:  "corr-1",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-2"},
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected conflict error, got row=%+v created=%v err=%v", conflicting, created, err)
+	}
+
+	completedAt := createdAt.Add(5 * time.Minute)
+	result, err := env.store.UpdateDeviceOperation(ctx, op.OperationID, DeviceOperationUpdateInput{
+		Status:        model.DeviceOperationStatusSucceeded,
+		ResultPayload: map[string]any{"video_cloud_devid": "device-1"},
+		CompletedAt:   &completedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != model.DeviceOperationStatusSucceeded {
+		t.Fatalf("expected succeeded status, got %s", result.Status)
+	}
+	if result.CompletedAt == nil || !result.CompletedAt.Equal(completedAt) {
+		t.Fatalf("expected completed_at to be set, got %+v", result.CompletedAt)
+	}
+	if result.UpdatedAt.Before(op.UpdatedAt) {
+		t.Fatalf("expected updated_at to stay monotonic, before=%s after=%s", op.UpdatedAt, result.UpdatedAt)
+	}
+}
+
+func TestOutboxMessagePersistenceAndReadyList(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	op, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-outbox",
+		CorrelationID:  "corr-outbox",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	first, err := env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "msg-1",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceProvisionRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"operation_id": op.OperationID},
+		Status:        model.DeviceMessageOutboxStatusPending,
+		AvailableAt:   now.Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != model.DeviceMessageOutboxStatusPending {
+		t.Fatalf("unexpected outbox status: %+v", first)
+	}
+
+	if _, err := env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "msg-2",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceDeactivateRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"operation_id": op.OperationID},
+		Status:        model.DeviceMessageOutboxStatusRetrying,
+		AttemptCount:  2,
+		LastError:     stringPtr("temporary failure"),
+		AvailableAt:   now.Add(2 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ready, err := env.store.ListOutboxMessagesReady(ctx, now, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ready) != 1 || ready[0].MessageID != "msg-1" {
+		t.Fatalf("expected only ready msg-1, got %+v", ready)
+	}
+
+	publishedAt := now.Add(time.Second)
+	published, err := env.store.UpdateOutboxMessage(ctx, "msg-1", DeviceMessageOutboxUpdateInput{
+		Status:       model.DeviceMessageOutboxStatusPublished,
+		AttemptCount: 1,
+		AvailableAt:  first.AvailableAt,
+		PublishedAt:  &publishedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if published.PublishedAt == nil || !published.PublishedAt.Equal(publishedAt) {
+		t.Fatalf("expected published_at to be set, got %+v", published.PublishedAt)
+	}
+	if published.Status != model.DeviceMessageOutboxStatusPublished {
+		t.Fatalf("expected published status, got %s", published.Status)
+	}
+}
+
+func TestCreateOrGetInboxMessageDeduplicates(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	_, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-inbox",
+		CorrelationID:  "corr-inbox",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPublished,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receivedAt := time.Now().UTC().Truncate(time.Microsecond)
+	message, created, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-1",
+		OperationID:   "op-inbox",
+		CorrelationID: "corr-inbox",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"video_cloud_devid": "device-1"},
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		AttemptCount:  1,
+		LastError:     stringPtr("projection retry"),
+		ReceivedAt:    receivedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected first inbox insert to create a row")
+	}
+
+	same, created, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-1",
+		OperationID:   "op-inbox",
+		CorrelationID: "corr-inbox",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"video_cloud_devid": "device-1"},
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		AttemptCount:  1,
+		LastError:     stringPtr("projection retry"),
+		ReceivedAt:    receivedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || same.ID != message.ID {
+		t.Fatalf("expected duplicate message_id to reuse existing row, got created=%v message=%+v", created, same)
+	}
+
+	_, created, err = env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-1",
+		OperationID:   "op-inbox",
+		CorrelationID: "corr-inbox",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"video_cloud_devid": "device-2"},
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		AttemptCount:  1,
+		LastError:     stringPtr("projection retry"),
+		ReceivedAt:    receivedAt,
+	})
+	if !errors.Is(err, ErrConflict) || created {
+		t.Fatalf("expected conflicting inbox payload to fail with conflict, got created=%v err=%v", created, err)
+	}
+
+	processedAt := receivedAt.Add(3 * time.Minute)
+	processed, err := env.store.UpdateInboxMessage(ctx, "evt-1", DeviceMessageInboxUpdateInput{
+		Status:       model.DeviceMessageInboxStatusProcessed,
+		AttemptCount: 2,
+		ProcessedAt:  &processedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if processed.ProcessedAt == nil || !processed.ProcessedAt.Equal(processedAt) {
+		t.Fatalf("expected processed_at to be set, got %+v", processed.ProcessedAt)
+	}
+	if processed.Status != model.DeviceMessageInboxStatusProcessed {
+		t.Fatalf("expected processed status, got %s", processed.Status)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -122,6 +122,20 @@ func TestCreateOrGetDeviceOperationIsIdempotent(t *testing.T) {
 		t.Fatalf("expected same operation row, got %q want %q", same.ID, op.ID)
 	}
 
+	conflictingCorrelation, created, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-1",
+		CorrelationID:  "corr-2",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected correlation conflict error, got row=%+v created=%v err=%v", conflictingCorrelation, created, err)
+	}
+
 	conflicting, created, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
 		OperationID:    "op-1",
 		CorrelationID:  "corr-1",

--- a/internal/store/device_messages_test.go
+++ b/internal/store/device_messages_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestCompareOperationCreate(t *testing.T) {
 	existing := model.DeviceOperation{
+		CorrelationID:  "corr-1",
 		OrganizationID: "org-1",
 		DeviceID:       "device-1",
 		OperationType:  model.DeviceOperationTypeProvision,
@@ -21,6 +22,7 @@ func TestCompareOperationCreate(t *testing.T) {
 	}
 
 	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		CorrelationID:  "corr-1",
 		OrganizationID: "org-1",
 		DeviceID:       "device-1",
 		OperationType:  model.DeviceOperationTypeProvision,
@@ -29,6 +31,16 @@ func TestCompareOperationCreate(t *testing.T) {
 	}
 
 	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		CorrelationID:  "corr-2",
+		OrganizationID: "org-1",
+		DeviceID:       "device-1",
+		OperationType:  model.DeviceOperationTypeProvision,
+	}, requestPayload); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected correlation mismatch to conflict, got %v", err)
+	}
+
+	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		CorrelationID:  "corr-1",
 		OrganizationID: "org-2",
 		DeviceID:       "device-1",
 		OperationType:  model.DeviceOperationTypeProvision,
@@ -37,6 +49,7 @@ func TestCompareOperationCreate(t *testing.T) {
 	}
 
 	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		CorrelationID:  "corr-1",
 		OrganizationID: "org-1",
 		DeviceID:       "device-2",
 		OperationType:  model.DeviceOperationTypeProvision,
@@ -45,6 +58,7 @@ func TestCompareOperationCreate(t *testing.T) {
 	}
 
 	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		CorrelationID:  "corr-1",
 		OrganizationID: "org-1",
 		DeviceID:       "device-1",
 		OperationType:  model.DeviceOperationTypeDeactivate,
@@ -57,6 +71,7 @@ func TestCompareOperationCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		CorrelationID:  "corr-1",
 		OrganizationID: "org-1",
 		DeviceID:       "device-1",
 		OperationType:  model.DeviceOperationTypeProvision,

--- a/internal/store/device_messages_test.go
+++ b/internal/store/device_messages_test.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"rtk_account_manager/internal/model"
+)
+
+func TestCompareOperationCreate(t *testing.T) {
+	existing := model.DeviceOperation{
+		OrganizationID: "org-1",
+		DeviceID:       "device-1",
+		OperationType:  model.DeviceOperationTypeProvision,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	}
+	requestPayload, err := json.Marshal(map[string]any{"video_cloud_devid": "device-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		OrganizationID: "org-1",
+		DeviceID:       "device-1",
+		OperationType:  model.DeviceOperationTypeProvision,
+	}, requestPayload); err != nil {
+		t.Fatalf("expected identical operation create input to match, got %v", err)
+	}
+
+	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		OrganizationID: "org-2",
+		DeviceID:       "device-1",
+		OperationType:  model.DeviceOperationTypeProvision,
+	}, requestPayload); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected org mismatch to conflict, got %v", err)
+	}
+
+	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		OrganizationID: "org-1",
+		DeviceID:       "device-2",
+		OperationType:  model.DeviceOperationTypeProvision,
+	}, requestPayload); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected device mismatch to conflict, got %v", err)
+	}
+
+	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		OrganizationID: "org-1",
+		DeviceID:       "device-1",
+		OperationType:  model.DeviceOperationTypeDeactivate,
+	}, requestPayload); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected operation type mismatch to conflict, got %v", err)
+	}
+
+	differentPayload, err := json.Marshal(map[string]any{"video_cloud_devid": "device-2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compareOperationCreate(existing, DeviceOperationCreateInput{
+		OrganizationID: "org-1",
+		DeviceID:       "device-1",
+		OperationType:  model.DeviceOperationTypeProvision,
+	}, differentPayload); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected payload mismatch to conflict, got %v", err)
+	}
+}
+
+func TestJSONHelpers(t *testing.T) {
+	if !sameStringPtr(nil, nil) {
+		t.Fatal("expected nil pointers to match")
+	}
+	if sameStringPtr(stringPtr("left"), nil) {
+		t.Fatal("expected nil mismatch to fail")
+	}
+	if !sameStringPtr(stringPtr("same"), stringPtr("same")) {
+		t.Fatal("expected equal string pointers to match")
+	}
+	if sameStringPtr(stringPtr("left"), stringPtr("right")) {
+		t.Fatal("expected different string pointers to fail")
+	}
+
+	want, err := marshalJSONMap(map[string]any{"ok": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameJSONMap(map[string]any{"ok": true}, want) {
+		t.Fatal("expected equivalent JSON maps to match")
+	}
+	if sameJSONMap(map[string]any{"bad": make(chan int)}, want) {
+		t.Fatal("expected invalid JSON input to fail comparison")
+	}
+
+	decoded, err := unmarshalJSONMap(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 0 {
+		t.Fatalf("expected empty map for nil payload, got %+v", decoded)
+	}
+
+	decoded, err = unmarshalJSONMap([]byte("null"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 0 {
+		t.Fatalf("expected empty map for null payload, got %+v", decoded)
+	}
+
+	decoded, err = unmarshalJSONMap([]byte(`{"key":"value"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded["key"] != "value" {
+		t.Fatalf("expected decoded value, got %+v", decoded)
+	}
+
+	if _, err := unmarshalJSONMap([]byte("{")); err == nil {
+		t.Fatal("expected invalid JSON payload to fail")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,6 +16,7 @@ var (
 	ErrNotFound  = errors.New("not found")
 	ErrLastOwner = errors.New("last owner cannot be removed or downgraded")
 	ErrDisabled  = errors.New("resource is disabled")
+	ErrConflict  = errors.New("conflict")
 )
 
 type Store struct {

--- a/internal/testutil/integration_db.go
+++ b/internal/testutil/integration_db.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const integrationDBLockKey int64 = 104729
+
+// LockIntegrationDatabase serializes tests that share TEST_DATABASE_URL so
+// package-level go test parallelism does not make them clobber each other's
+// fixtures and truncation.
+func LockIntegrationDatabase(t *testing.T, db *pgxpool.Pool) {
+	t.Helper()
+
+	ctx := context.Background()
+	conn, err := db.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, integrationDBLockKey); err != nil {
+		conn.Release()
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, integrationDBLockKey); err != nil {
+			t.Errorf("unlock integration database: %v", err)
+		}
+		conn.Release()
+	})
+}

--- a/migrations/006_device_message_persistence.sql
+++ b/migrations/006_device_message_persistence.sql
@@ -1,0 +1,94 @@
+CREATE TABLE IF NOT EXISTS device_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    operation_id TEXT NOT NULL UNIQUE,
+    correlation_id TEXT NOT NULL,
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    device_id UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    operation_type TEXT NOT NULL CHECK (operation_type IN ('provision', 'deactivate')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'published', 'succeeded', 'failed', 'retrying', 'dead_lettered')),
+    requested_by TEXT,
+    request_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    result_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    error_code TEXT,
+    error_message TEXT,
+    retryable BOOLEAN,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS device_operations_org_device_created_idx
+    ON device_operations (organization_id, device_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS device_operations_status_created_idx
+    ON device_operations (status, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS device_message_outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id TEXT NOT NULL UNIQUE,
+    operation_id TEXT NOT NULL REFERENCES device_operations(operation_id) ON DELETE CASCADE,
+    correlation_id TEXT NOT NULL,
+    causation_id TEXT,
+    stream TEXT NOT NULL CHECK (stream = 'account.video.commands'),
+    message_type TEXT NOT NULL CHECK (message_type IN ('DeviceProvisionRequested', 'DeviceDeactivateRequested')),
+    schema_version TEXT NOT NULL CHECK (schema_version IN ('1.0')),
+    partition_key TEXT NOT NULL CHECK (btrim(partition_key) <> ''),
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'published', 'retrying', 'dead_lettered')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error TEXT,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS device_message_outbox_status_available_idx
+    ON device_message_outbox (status, available_at ASC, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS device_message_outbox_operation_idx
+    ON device_message_outbox (operation_id);
+
+CREATE TABLE IF NOT EXISTS device_message_inbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id TEXT NOT NULL UNIQUE,
+    operation_id TEXT NOT NULL,
+    correlation_id TEXT NOT NULL,
+    causation_id TEXT,
+    stream TEXT NOT NULL CHECK (stream = 'video.account.events'),
+    message_type TEXT NOT NULL CHECK (message_type IN ('DeviceProvisionSucceeded', 'DeviceProvisionFailed', 'DeviceDeactivateSucceeded', 'DeviceDeactivateFailed', 'DeviceOnlineChanged', 'DeviceMetadataChanged')),
+    schema_version TEXT NOT NULL CHECK (schema_version IN ('1.0')),
+    partition_key TEXT NOT NULL CHECK (btrim(partition_key) <> ''),
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL CHECK (status IN ('processed', 'failed', 'retrying', 'dead_lettered')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error TEXT,
+    received_at TIMESTAMPTZ NOT NULL,
+    processed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS device_message_inbox_status_received_idx
+    ON device_message_inbox (status, received_at ASC, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS device_message_inbox_operation_idx
+    ON device_message_inbox (operation_id);
+
+DROP TRIGGER IF EXISTS device_operations_set_updated_at ON device_operations;
+CREATE TRIGGER device_operations_set_updated_at
+    BEFORE UPDATE ON device_operations
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS device_message_outbox_set_updated_at ON device_message_outbox;
+CREATE TRIGGER device_message_outbox_set_updated_at
+    BEFORE UPDATE ON device_message_outbox
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS device_message_inbox_set_updated_at ON device_message_inbox;
+CREATE TRIGGER device_message_inbox_set_updated_at
+    BEFORE UPDATE ON device_message_inbox
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Summary
- add the v2 persistence migration for `device_operations`, `device_message_outbox`, and `device_message_inbox`
- add model and store support for operation idempotency, outbox readiness/state transitions, and inbox dedupe/state transitions
- add Postgres-backed store tests for the new persistence flows and mark the issue-plan entry as `in_progress`

## Validation
- `go test ./...`
- `go build ./...`
- GitHub Actions CI run `25057856470`: `make test-report` with hosted Postgres plus `go build ./...`
  - total statement coverage `83.7%` against the repo `80.0%` minimum

Refs #3
