### PR TITLE
[Device] Add metadata merge and projection primitives

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -39,7 +39,7 @@ Milestone: `v2-provisioning-event-channel`
 | `[Docs] Add v2 implementation checklist and issue map` | P0 | `docs`, `v2` | None | planned | This document contains the issue map, dependency order, and status tracking. |
 | `[DB] Add device operations, outbox, and inbox persistence` | P1 | `database`, `backend`, `v2` | Docs issues | planned | Migrations and store methods for operation tracking, outbox publication state, and inbox dedupe. |
 | `[Domain] Add cross-service message envelope and payload validation` | P1 | `backend`, `v2` | Docs issues | in_progress | Envelope and payload types validate contract-required fields, stream/message types, schema version, and partition key. |
-| `[Device] Add metadata merge and projection primitives` | P1 | `backend`, `v2` | DB, Domain | planned | Store-level partial metadata merge and projection helpers for video metadata and online status. |
+| `[Device] Add metadata merge and projection primitives` | P1 | `backend`, `v2` | DB, Domain | in_progress | Store-level partial metadata merge and projection helpers for video metadata and online status. |
 | `[API] Add provisioning and deactivation endpoints` | P1 | `api`, `backend`, `v2` | DB, Domain, Device | planned | HTTP endpoints create/reuse operations and enqueue lifecycle command messages. |
 | `[Worker] Implement outbox publisher with local broker adapter` | P1 | `worker`, `backend`, `v2` | DB, Domain | planned | Independent worker publishes pending command messages and records retry/dead-letter state. |
 | `[Worker] Implement inbox consumer and account projection` | P1 | `worker`, `backend`, `v2` | DB, Domain, Device | planned | Independent worker deduplicates events and projects provisioning, deactivation, online, and metadata state. |

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -27,6 +27,23 @@ const (
 	DeviceStatusDisabled DeviceStatus = "disabled"
 )
 
+type VideoCloudActivationStatus string
+
+const (
+	VideoCloudActivationStatusActivated   VideoCloudActivationStatus = "activated"
+	VideoCloudActivationStatusFailed      VideoCloudActivationStatus = "failed"
+	VideoCloudActivationStatusDeactivated VideoCloudActivationStatus = "deactivated"
+)
+
+const (
+	DeviceMetadataVideoCloudDevid            = "video_cloud_devid"
+	DeviceMetadataVideoCloudActivationStatus = "video_cloud_activation_status"
+	DeviceMetadataVideoCloudActivityID       = "video_cloud_activity_id"
+	DeviceMetadataVideoCloudActivatedAt      = "video_cloud_activated_at"
+	DeviceMetadataVideoCloudDeactivatedAt    = "video_cloud_deactivated_at"
+	DeviceMetadataVideoCloudLastError        = "video_cloud_last_error"
+)
+
 type User struct {
 	ID          string     `json:"id"`
 	Email       string     `json:"email"`

--- a/internal/store/device_projection.go
+++ b/internal/store/device_projection.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/model"
+)
+
+const projectionMetadataPrefix = "video_cloud_"
+
+type DeviceProjectionInput struct {
+	Metadata      map[string]any
+	Status        *model.DeviceStatus
+	LastSeenAt    *time.Time
+	AllowDisabled bool
+}
+
+func ProvisionSucceededProjection(payload channel.DeviceProvisionSucceededPayload) DeviceProjectionInput {
+	return DeviceProjectionInput{
+		Metadata: map[string]any{
+			model.DeviceMetadataVideoCloudDevid:            payload.VideoCloudDevid,
+			model.DeviceMetadataVideoCloudActivityID:       payload.ActivityID,
+			model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusActivated,
+			model.DeviceMetadataVideoCloudActivatedAt:      payload.ActivatedAt.UTC(),
+			model.DeviceMetadataVideoCloudLastError:        nil,
+		},
+	}
+}
+
+func ProvisionFailedProjection(payload channel.DeviceProvisionFailedPayload) DeviceProjectionInput {
+	return DeviceProjectionInput{
+		Metadata: map[string]any{
+			model.DeviceMetadataVideoCloudDevid:            payload.VideoCloudDevid,
+			model.DeviceMetadataVideoCloudActivityID:       payload.ActivityID,
+			model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusFailed,
+			model.DeviceMetadataVideoCloudLastError: map[string]any{
+				"code":       payload.ErrorCode,
+				"message":    payload.ErrorMessage,
+				"retryable":  payload.Retryable,
+				"failed_at":  payload.FailedAt.UTC(),
+				"operation":  channel.MessageTypeDeviceProvisionFailed,
+				"service":    channel.ServiceRealtekVideoCloud,
+				"updated_at": payload.FailedAt.UTC(),
+			},
+		},
+	}
+}
+
+func DeactivateSucceededProjection(payload channel.DeviceDeactivateSucceededPayload) DeviceProjectionInput {
+	return DeviceProjectionInput{
+		AllowDisabled: true,
+		Metadata: map[string]any{
+			model.DeviceMetadataVideoCloudDevid:            payload.VideoCloudDevid,
+			model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusDeactivated,
+			model.DeviceMetadataVideoCloudDeactivatedAt:    payload.DeactivatedAt.UTC(),
+			model.DeviceMetadataVideoCloudLastError:        nil,
+		},
+	}
+}
+
+func DeactivateFailedProjection(payload channel.DeviceDeactivateFailedPayload) DeviceProjectionInput {
+	return DeviceProjectionInput{
+		Metadata: map[string]any{
+			model.DeviceMetadataVideoCloudDevid: payload.VideoCloudDevid,
+			model.DeviceMetadataVideoCloudLastError: map[string]any{
+				"code":       payload.ErrorCode,
+				"message":    payload.ErrorMessage,
+				"retryable":  payload.Retryable,
+				"failed_at":  payload.FailedAt.UTC(),
+				"operation":  channel.MessageTypeDeviceDeactivateFailed,
+				"service":    channel.ServiceRealtekVideoCloud,
+				"updated_at": payload.FailedAt.UTC(),
+			},
+		},
+	}
+}
+
+func OnlineChangedProjection(payload channel.DeviceOnlineChangedPayload) DeviceProjectionInput {
+	status := model.DeviceStatus(payload.Status)
+	lastSeenAt := payload.LastSeenAt.UTC()
+	return DeviceProjectionInput{
+		Metadata: map[string]any{
+			model.DeviceMetadataVideoCloudDevid: payload.VideoCloudDevid,
+		},
+		Status:     &status,
+		LastSeenAt: &lastSeenAt,
+	}
+}
+
+func MetadataChangedProjection(payload channel.DeviceMetadataChangedPayload) DeviceProjectionInput {
+	return DeviceProjectionInput{
+		Metadata: selectProjectionMetadata(payload.Metadata),
+	}
+}
+
+func (s *Store) MergeDeviceMetadata(ctx context.Context, orgID, deviceID string, patch map[string]any) (model.Device, error) {
+	return s.ProjectDevice(ctx, orgID, deviceID, DeviceProjectionInput{Metadata: patch})
+}
+
+func (s *Store) ProjectDevice(ctx context.Context, orgID, deviceID string, in DeviceProjectionInput) (model.Device, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.Device{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	device, err := scanDevice(tx.QueryRow(ctx, `
+		SELECT id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
+		FROM devices
+		WHERE organization_id = $1 AND id = $2
+		FOR UPDATE
+	`, orgID, deviceID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.Device{}, ErrNotFound
+	}
+	if err != nil {
+		return model.Device{}, err
+	}
+
+	if device.DisabledAt != nil && (!in.AllowDisabled || in.Status != nil || in.LastSeenAt != nil) {
+		return model.Device{}, ErrDisabled
+	}
+
+	metadata, err := json.Marshal(applyProjectionMetadata(device.Metadata, in.Metadata))
+	if err != nil {
+		return model.Device{}, err
+	}
+
+	status := device.Status
+	if in.Status != nil {
+		status = *in.Status
+	}
+
+	lastSeenAt := device.LastSeenAt
+	if in.LastSeenAt != nil {
+		lastSeenAt = in.LastSeenAt
+	}
+
+	projected, err := scanDevice(tx.QueryRow(ctx, `
+		UPDATE devices
+		SET status = $3, last_seen_at = $4, metadata = $5, updated_at = now()
+		WHERE organization_id = $1 AND id = $2
+		RETURNING id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
+	`, orgID, deviceID, status, lastSeenAt, metadata))
+	if err != nil {
+		return model.Device{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.Device{}, err
+	}
+	return projected, nil
+}
+
+func selectProjectionMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	selected := make(map[string]any)
+	for key, value := range metadata {
+		if strings.HasPrefix(key, projectionMetadataPrefix) {
+			selected[key] = value
+		}
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+	return selected
+}
+
+func applyProjectionMetadata(existing, patch map[string]any) map[string]any {
+	merged := make(map[string]any, len(existing)+len(patch))
+	for key, value := range defaultMetadata(existing) {
+		merged[key] = value
+	}
+	for key, value := range selectProjectionMetadata(patch) {
+		if value == nil {
+			delete(merged, key)
+			continue
+		}
+		merged[key] = value
+	}
+	return merged
+}

--- a/internal/store/device_projection_integration_test.go
+++ b/internal/store/device_projection_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -13,9 +12,8 @@ import (
 	"rtk_account_manager/internal/channel"
 	"rtk_account_manager/internal/database"
 	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/testutil"
 )
-
-var projectionIntegrationLock sync.Mutex
 
 type projectionIntegrationEnv struct {
 	db    *pgxpool.Pool
@@ -37,14 +35,13 @@ func newProjectionIntegrationEnv(t *testing.T) projectionIntegrationEnv {
 	}
 	t.Cleanup(db.Close)
 
-	projectionIntegrationLock.Lock()
-	t.Cleanup(projectionIntegrationLock.Unlock)
+	testutil.LockIntegrationDatabase(t, db)
 
 	if err := database.Migrate(ctx, db); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-		TRUNCATE refresh_tokens, devices, organization_members, organizations, users
+		TRUNCATE device_message_inbox, device_message_outbox, device_operations, refresh_tokens, devices, organization_members, organizations, users
 		RESTART IDENTITY CASCADE
 	`); err != nil {
 		t.Fatal(err)

--- a/internal/store/device_projection_integration_test.go
+++ b/internal/store/device_projection_integration_test.go
@@ -1,0 +1,211 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/database"
+	"rtk_account_manager/internal/model"
+)
+
+var projectionIntegrationLock sync.Mutex
+
+type projectionIntegrationEnv struct {
+	db    *pgxpool.Pool
+	store *Store
+}
+
+func newProjectionIntegrationEnv(t *testing.T) projectionIntegrationEnv {
+	t.Helper()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	db, err := database.Connect(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+
+	projectionIntegrationLock.Lock()
+	t.Cleanup(projectionIntegrationLock.Unlock)
+
+	if err := database.Migrate(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `
+		TRUNCATE refresh_tokens, devices, organization_members, organizations, users
+		RESTART IDENTITY CASCADE
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	return projectionIntegrationEnv{db: db, store: New(db)}
+}
+
+func createProjectionDevice(t *testing.T, env projectionIntegrationEnv, metadata map[string]any) (RegisterResult, model.Device) {
+	t.Helper()
+
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "owner@example.com",
+		PasswordHash:     "hashed-password",
+		OrganizationName: "Owner Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device, err := env.store.CreateDevice(ctx, registered.Organization.ID, DeviceInput{
+		Name:         "camera-1",
+		Category:     model.DeviceCategoryIPCamera,
+		SerialNumber: strPtr("SERIAL-001"),
+		Metadata:     metadata,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registered, device
+}
+
+func TestMergeDeviceMetadataPreservesUnrelatedFields(t *testing.T) {
+	env := newProjectionIntegrationEnv(t)
+	registered, device := createProjectionDevice(t, env, map[string]any{
+		"location": "lab",
+		model.DeviceMetadataVideoCloudLastError: map[string]any{
+			"code": "stale",
+		},
+	})
+
+	merged, err := env.store.MergeDeviceMetadata(context.Background(), registered.Organization.ID, device.ID, map[string]any{
+		model.DeviceMetadataVideoCloudDevid:            "video-001",
+		model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusActivated,
+		model.DeviceMetadataVideoCloudLastError:        nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := merged.Metadata["location"]; got != "lab" {
+		t.Fatalf("expected unrelated metadata to remain, got %+v", got)
+	}
+	if got := merged.Metadata[model.DeviceMetadataVideoCloudDevid]; got != "video-001" {
+		t.Fatalf("expected merged devid, got %+v", got)
+	}
+	if got := merged.Metadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusActivated) {
+		t.Fatalf("expected activation metadata, got %+v", got)
+	}
+	if _, exists := merged.Metadata[model.DeviceMetadataVideoCloudLastError]; exists {
+		t.Fatalf("expected last_error to be cleared, got %+v", merged.Metadata[model.DeviceMetadataVideoCloudLastError])
+	}
+	if merged.Status != model.DeviceStatusUnknown {
+		t.Fatalf("expected status to remain unknown, got %s", merged.Status)
+	}
+}
+
+func TestProjectDeviceProvisioningAndOnlineRules(t *testing.T) {
+	env := newProjectionIntegrationEnv(t)
+	registered, device := createProjectionDevice(t, env, map[string]any{"location": "rack-a"})
+
+	failedAt := time.Date(2026, 4, 28, 9, 30, 0, 0, time.UTC)
+	failed, err := env.store.ProjectDevice(context.Background(), registered.Organization.ID, device.ID, ProvisionFailedProjection(channel.DeviceProvisionFailedPayload{
+		VideoCloudDevid: "video-002",
+		ActivityID:      "activity-1",
+		ErrorCode:       "upstream_timeout",
+		ErrorMessage:    "worker timed out",
+		Retryable:       true,
+		FailedAt:        failedAt,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.Status != model.DeviceStatusUnknown {
+		t.Fatalf("expected failed projection to leave device status unchanged, got %s", failed.Status)
+	}
+	if got := failed.Metadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusFailed) {
+		t.Fatalf("expected failed activation metadata, got %+v", got)
+	}
+
+	succeeded, err := env.store.ProjectDevice(context.Background(), registered.Organization.ID, device.ID, ProvisionSucceededProjection(channel.DeviceProvisionSucceededPayload{
+		VideoCloudDevid: "video-002",
+		ActivityID:      "activity-1",
+		ActivatedAt:     time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if succeeded.Status != model.DeviceStatusUnknown {
+		t.Fatalf("expected provision success not to set account status online, got %s", succeeded.Status)
+	}
+	if _, exists := succeeded.Metadata[model.DeviceMetadataVideoCloudLastError]; exists {
+		t.Fatalf("expected success projection to clear last_error, got %+v", succeeded.Metadata[model.DeviceMetadataVideoCloudLastError])
+	}
+	if got := succeeded.Metadata["location"]; got != "rack-a" {
+		t.Fatalf("expected unrelated metadata to remain, got %+v", got)
+	}
+
+	lastSeenAt := time.Date(2026, 4, 28, 11, 15, 0, 0, time.FixedZone("CST", 8*60*60))
+	online, err := env.store.ProjectDevice(context.Background(), registered.Organization.ID, device.ID, OnlineChangedProjection(channel.DeviceOnlineChangedPayload{
+		VideoCloudDevid: "video-002",
+		Status:          channel.OnlineStatusOnline,
+		LastSeenAt:      lastSeenAt,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if online.Status != model.DeviceStatusOnline {
+		t.Fatalf("expected online projection to update status, got %s", online.Status)
+	}
+	if online.LastSeenAt == nil || !online.LastSeenAt.Equal(lastSeenAt.UTC()) {
+		t.Fatalf("expected online projection to update last_seen_at, got %+v", online.LastSeenAt)
+	}
+}
+
+func TestProjectDeviceRejectsDisabledDevicesExceptDeactivateResults(t *testing.T) {
+	env := newProjectionIntegrationEnv(t)
+	registered, device := createProjectionDevice(t, env, map[string]any{"location": "rack-b"})
+
+	if err := env.store.DeleteDevice(context.Background(), registered.Organization.ID, device.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := env.store.ProjectDevice(context.Background(), registered.Organization.ID, device.ID, ProvisionSucceededProjection(channel.DeviceProvisionSucceededPayload{
+		VideoCloudDevid: "video-disabled",
+		ActivityID:      "activity-disabled",
+		ActivatedAt:     time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+	}))
+	if !errors.Is(err, ErrDisabled) {
+		t.Fatalf("expected disabled error for non-deactivation projection, got %v", err)
+	}
+
+	projected, err := env.store.ProjectDevice(context.Background(), registered.Organization.ID, device.ID, DeactivateSucceededProjection(channel.DeviceDeactivateSucceededPayload{
+		VideoCloudDevid: "video-disabled",
+		DeactivatedAt:   time.Date(2026, 4, 28, 12, 30, 0, 0, time.UTC),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projected.Status != model.DeviceStatusDisabled {
+		t.Fatalf("expected disabled device status to remain disabled, got %s", projected.Status)
+	}
+	if got := projected.Metadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusDeactivated) {
+		t.Fatalf("expected deactivated metadata, got %+v", got)
+	}
+	if got := projected.Metadata["location"]; got != "rack-b" {
+		t.Fatalf("expected unrelated metadata to remain, got %+v", got)
+	}
+}
+
+func strPtr(value string) *string {
+	return &value
+}

--- a/internal/store/device_projection_test.go
+++ b/internal/store/device_projection_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/model"
+)
+
+func TestMetadataChangedProjectionFiltersNonVideoCloudKeys(t *testing.T) {
+	projection := MetadataChangedProjection(channel.DeviceMetadataChangedPayload{
+		Metadata: map[string]any{
+			"location":                               "lab",
+			model.DeviceMetadataVideoCloudDevid:      "devid-1",
+			model.DeviceMetadataVideoCloudActivityID: "activity-1",
+		},
+	})
+
+	want := map[string]any{
+		model.DeviceMetadataVideoCloudDevid:      "devid-1",
+		model.DeviceMetadataVideoCloudActivityID: "activity-1",
+	}
+	if !reflect.DeepEqual(projection.Metadata, want) {
+		t.Fatalf("unexpected filtered metadata: %+v", projection.Metadata)
+	}
+}
+
+func TestApplyProjectionMetadataPreservesExistingFieldsAndClearsNil(t *testing.T) {
+	merged := applyProjectionMetadata(
+		map[string]any{
+			"location":                              "lab",
+			model.DeviceMetadataVideoCloudDevid:     "old-device",
+			model.DeviceMetadataVideoCloudLastError: "stale",
+		},
+		map[string]any{
+			model.DeviceMetadataVideoCloudDevid:            "new-device",
+			model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusActivated,
+			model.DeviceMetadataVideoCloudLastError:        nil,
+			"ignored":                                      "value",
+		},
+	)
+
+	want := map[string]any{
+		"location":                                     "lab",
+		model.DeviceMetadataVideoCloudDevid:            "new-device",
+		model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusActivated,
+	}
+	if !reflect.DeepEqual(merged, want) {
+		t.Fatalf("unexpected merged metadata: %+v", merged)
+	}
+}
+
+func TestOnlineChangedProjectionSetsStatusAndLastSeenAt(t *testing.T) {
+	lastSeenAt := time.Date(2026, 4, 28, 12, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+
+	projection := OnlineChangedProjection(channel.DeviceOnlineChangedPayload{
+		VideoCloudDevid: "video-device",
+		Status:          channel.OnlineStatusOnline,
+		LastSeenAt:      lastSeenAt,
+	})
+
+	if projection.Status == nil || *projection.Status != model.DeviceStatusOnline {
+		t.Fatalf("expected online status, got %+v", projection.Status)
+	}
+	if projection.LastSeenAt == nil || !projection.LastSeenAt.Equal(lastSeenAt.UTC()) {
+		t.Fatalf("expected UTC last_seen_at, got %+v", projection.LastSeenAt)
+	}
+	if got := projection.Metadata[model.DeviceMetadataVideoCloudDevid]; got != "video-device" {
+		t.Fatalf("unexpected devid metadata: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add store-level projection primitives for partial `video_cloud_*` metadata merges and online-state updates
- encode v2 projection rules for provisioning, deactivation, online, and metadata change events
- add focused unit and env-gated Postgres integration coverage for metadata preservation, disabled-device rules, and `DeviceOnlineChanged`
- mark the v2 implementation plan entry for issue #5 as `in_progress`

## Validation
- `go test ./...`
- `go build ./...`
- Postgres-backed projection integration tests are included and will run when `TEST_DATABASE_URL` is available; this local runtime had no `TEST_DATABASE_URL` and no reachable Docker daemon for spinning up Postgres

Refs #5
