### PR TITLE
[Device] Allow failed deactivation projection on disabled devices

### DIFF
--- a/internal/store/device_projection.go
+++ b/internal/store/device_projection.go
@@ -67,6 +67,7 @@ func DeactivateSucceededProjection(payload channel.DeviceDeactivateSucceededPayl
 
 func DeactivateFailedProjection(payload channel.DeviceDeactivateFailedPayload) DeviceProjectionInput {
 	return DeviceProjectionInput{
+		AllowDisabled: true,
 		Metadata: map[string]any{
 			model.DeviceMetadataVideoCloudDevid: payload.VideoCloudDevid,
 			model.DeviceMetadataVideoCloudLastError: map[string]any{

--- a/internal/store/device_projection_integration_test.go
+++ b/internal/store/device_projection_integration_test.go
@@ -201,6 +201,34 @@ func TestProjectDeviceRejectsDisabledDevicesExceptDeactivateResults(t *testing.T
 	if got := projected.Metadata["location"]; got != "rack-b" {
 		t.Fatalf("expected unrelated metadata to remain, got %+v", got)
 	}
+
+	failedAt := time.Date(2026, 4, 28, 12, 45, 0, 0, time.UTC)
+	failedProjection, err := env.store.ProjectDevice(context.Background(), registered.Organization.ID, device.ID, DeactivateFailedProjection(channel.DeviceDeactivateFailedPayload{
+		VideoCloudDevid: "video-disabled",
+		ErrorCode:       "upstream_timeout",
+		ErrorMessage:    "worker timed out",
+		Retryable:       true,
+		FailedAt:        failedAt,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failedProjection.Status != model.DeviceStatusDisabled {
+		t.Fatalf("expected disabled device status to remain disabled after failed deactivation, got %s", failedProjection.Status)
+	}
+	if got := failedProjection.Metadata["location"]; got != "rack-b" {
+		t.Fatalf("expected unrelated metadata to remain after failed deactivation, got %+v", got)
+	}
+	lastError, ok := failedProjection.Metadata[model.DeviceMetadataVideoCloudLastError].(map[string]any)
+	if !ok {
+		t.Fatalf("expected failed deactivation to record last_error metadata, got %+v", failedProjection.Metadata[model.DeviceMetadataVideoCloudLastError])
+	}
+	if got := lastError["code"]; got != "upstream_timeout" {
+		t.Fatalf("expected failure code in last_error metadata, got %+v", got)
+	}
+	if got, ok := lastError["failed_at"].(time.Time); !ok || !got.Equal(failedAt) {
+		t.Fatalf("expected failure timestamp in last_error metadata, got %+v", lastError["failed_at"])
+	}
 }
 
 func strPtr(value string) *string {


### PR DESCRIPTION
## Summary
- allow `DeactivateFailedProjection` to project onto already-disabled devices
- add regression coverage proving disabled-device deactivation failures still preserve disabled status and unrelated metadata
- keep the deactivation failure timestamp and error details visible in projected metadata

## Validation
- `go test ./internal/store/...`
- `go test ./...`

Refs #5
