### PR TITLE
[Device] Fix failed deactivation projection assertion

### DIFF
--- a/internal/store/device_projection_integration_test.go
+++ b/internal/store/device_projection_integration_test.go
@@ -226,8 +226,8 @@ func TestProjectDeviceRejectsDisabledDevicesExceptDeactivateResults(t *testing.T
 	if got := lastError["code"]; got != "upstream_timeout" {
 		t.Fatalf("expected failure code in last_error metadata, got %+v", got)
 	}
-	if got, ok := lastError["failed_at"].(time.Time); !ok || !got.Equal(failedAt) {
-		t.Fatalf("expected failure timestamp in last_error metadata, got %+v", lastError["failed_at"])
+	if got := lastError["failed_at"]; got != failedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("expected failure timestamp in last_error metadata, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix the disabled-device deactivation regression test to match JSONB metadata decoding behavior
- compare `video_cloud_last_error.failed_at` against the stored RFC3339 string shape returned by `ProjectDevice`
- keep the follow-up explicitly linked to the residual issue #5 cleanup

## Validation
- `go test ./internal/store/...`
- `go test ./...`
- `go build ./...`

Refs #5
