### PR TITLE
[Worker] Implement inbox consumer and account projection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tidy test integration-test test-report run run-outbox-worker db-up db-down migrate cleanup-tokens
+.PHONY: tidy test integration-test test-report run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
 
 tidy:
 	go mod tidy
@@ -17,6 +17,9 @@ run:
 
 run-outbox-worker:
 	go run ./cmd/outbox-worker
+
+run-inbox-worker:
+	go run ./cmd/inbox-worker
 
 db-up:
 	docker compose up -d postgres

--- a/cmd/inbox-worker/main.go
+++ b/cmd/inbox-worker/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"rtk_account_manager/internal/broker"
+	"rtk_account_manager/internal/config"
+	"rtk_account_manager/internal/database"
+	"rtk_account_manager/internal/store"
+	"rtk_account_manager/internal/worker/inbox"
+)
+
+func main() {
+	cfg, err := config.LoadWorker()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	db, err := database.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	consumer, err := broker.NewConsumer(cfg.CrossServiceBroker, os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	service := inbox.NewService(store.New(db), consumer, inbox.Options{
+		Stream:        cfg.VideoAccountEventsStream,
+		ConsumerGroup: cfg.CrossServiceConsumerGroup,
+		MaxAttempts:   cfg.CrossServiceMaxAttempts,
+		PollInterval:  cfg.CrossServicePollInterval,
+	})
+
+	log.Printf("starting inbox worker with broker=%s stream=%s consumer_group=%s poll_interval=%s", cfg.CrossServiceBroker, cfg.VideoAccountEventsStream, cfg.CrossServiceConsumerGroup, cfg.CrossServicePollInterval)
+	if err := service.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -42,7 +42,7 @@ Milestone: `v2-provisioning-event-channel`
 | `[Device] Add metadata merge and projection primitives` | P1 | `backend`, `v2` | DB, Domain | in_progress | Store-level partial metadata merge and projection helpers for video metadata and online status. |
 | `[API] Add provisioning and deactivation endpoints` | P1 | `api`, `backend`, `v2` | DB, Domain, Device | in_progress | HTTP endpoints create/reuse operations and enqueue lifecycle command messages. |
 | `[Worker] Implement outbox publisher with local broker adapter` | P1 | `worker`, `backend`, `v2` | DB, Domain | in_progress | Independent worker publishes pending command messages and records retry/dead-letter state. |
-| `[Worker] Implement inbox consumer and account projection` | P1 | `worker`, `backend`, `v2` | DB, Domain, Device | planned | Independent worker deduplicates events and projects provisioning, deactivation, online, and metadata state. |
+| `[Worker] Implement inbox consumer and account projection` | P1 | `worker`, `backend`, `v2` | DB, Domain, Device | in_progress | Independent worker deduplicates events and projects provisioning, deactivation, online, and metadata state. |
 | `[Broker] Add Azure Event Hubs adapter and runtime config` | P2 | `worker`, `backend`, `v2` | Local workers | planned | Event Hubs adapter and configuration without making local tests depend on Azure. |
 | `[Testing] Extend automated test report for v2` | P2 | `testing`, `v2` | API, Workers | planned | `make test-report` includes v2 behavior evidence and keeps coverage at or above 80%. |
 | `[Docs] Add local runbook for provisioning/event workers` | P2 | `docs`, `v2` | API, Workers, Broker config | planned | Local runbook for Postgres, API server, outbox worker, inbox worker, and local broker flow. |

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,6 +15,15 @@ type Publisher interface {
 	Publish(ctx context.Context, stream string, envelope channel.Envelope) error
 }
 
+type Message struct {
+	Stream   string
+	Envelope channel.Envelope
+}
+
+type Consumer interface {
+	Receive(ctx context.Context, limit int) ([]Message, error)
+}
+
 type publishError struct {
 	err       error
 	transient bool
@@ -54,6 +63,15 @@ func NewPublisher(kind string, writer io.Writer) (Publisher, error) {
 	switch kind {
 	case "", AdapterLog:
 		return NewLogPublisher(writer), nil
+	default:
+		return nil, fmt.Errorf("unsupported cross-service broker %q", kind)
+	}
+}
+
+func NewConsumer(kind string, reader io.Reader) (Consumer, error) {
+	switch kind {
+	case "", AdapterLog:
+		return NewLogConsumer(reader), nil
 	default:
 		return nil, fmt.Errorf("unsupported cross-service broker %q", kind)
 	}

--- a/internal/broker/log.go
+++ b/internal/broker/log.go
@@ -1,6 +1,8 @@
 package broker
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -14,6 +16,12 @@ type LogPublisher struct {
 	writer io.Writer
 }
 
+type LogConsumer struct {
+	mu        sync.Mutex
+	scanner   *bufio.Scanner
+	exhausted bool
+}
+
 type logRecord struct {
 	Stream   string           `json:"stream"`
 	Envelope channel.Envelope `json:"envelope"`
@@ -24,6 +32,15 @@ func NewLogPublisher(writer io.Writer) *LogPublisher {
 		writer = io.Discard
 	}
 	return &LogPublisher{writer: writer}
+}
+
+func NewLogConsumer(reader io.Reader) *LogConsumer {
+	if reader == nil {
+		reader = bytes.NewReader(nil)
+	}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return &LogConsumer{scanner: scanner}
 }
 
 func (p *LogPublisher) Publish(ctx context.Context, stream string, envelope channel.Envelope) error {
@@ -46,4 +63,45 @@ func (p *LogPublisher) Publish(ctx context.Context, stream string, envelope chan
 		return err
 	}
 	return nil
+}
+
+func (c *LogConsumer) Receive(ctx context.Context, limit int) ([]Message, error) {
+	if limit <= 0 {
+		limit = 1
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.exhausted {
+		return nil, nil
+	}
+
+	messages := make([]Message, 0, limit)
+	for len(messages) < limit {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !c.scanner.Scan() {
+			if err := c.scanner.Err(); err != nil {
+				return nil, err
+			}
+			c.exhausted = true
+			break
+		}
+
+		var record logRecord
+		if err := json.Unmarshal(c.scanner.Bytes(), &record); err != nil {
+			return nil, err
+		}
+		messages = append(messages, Message{
+			Stream:   record.Stream,
+			Envelope: record.Envelope,
+		})
+	}
+
+	return messages, nil
 }

--- a/internal/broker/log_test.go
+++ b/internal/broker/log_test.go
@@ -41,6 +41,25 @@ func TestLogPublisherWritesEnvelopeJSON(t *testing.T) {
 	}
 }
 
+func TestLogConsumerReadsEnvelopeJSON(t *testing.T) {
+	input := bytes.NewBufferString(`{"stream":"video.account.events","envelope":{"message_id":"msg-1","correlation_id":"corr-1","operation_id":"op-1","source_service":"realtek_video_server","target_service":"rtk_account_manager","message_type":"DeviceOnlineChanged","schema_version":"1.0","partition_key":"11111111-1111-1111-1111-111111111111","occurred_at":"2026-04-29T10:00:00Z","payload":{"org_id":"00000000-0000-0000-0000-000000000001","account_device_id":"11111111-1111-1111-1111-111111111111","video_cloud_devid":"video-1","status":"online","last_seen_at":"2026-04-29T10:00:00Z"}}}` + "\n")
+	consumer := NewLogConsumer(input)
+
+	messages, err := consumer.Receive(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected one message, got %d", len(messages))
+	}
+	if messages[0].Stream != channel.StreamVideoAccountEvents {
+		t.Fatalf("unexpected stream: %s", messages[0].Stream)
+	}
+	if messages[0].Envelope.MessageType != channel.MessageTypeDeviceOnlineChanged {
+		t.Fatalf("unexpected message type: %s", messages[0].Envelope.MessageType)
+	}
+}
+
 func TestTransientMarker(t *testing.T) {
 	err := Transient(errors.New("temporary"))
 	if !IsTransient(err) {

--- a/internal/store/device_projection.go
+++ b/internal/store/device_projection.go
@@ -112,6 +112,18 @@ func (s *Store) ProjectDevice(ctx context.Context, orgID, deviceID string, in De
 	}
 	defer tx.Rollback(ctx)
 
+	projected, err := projectDeviceTx(ctx, tx, orgID, deviceID, in)
+	if err != nil {
+		return model.Device{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.Device{}, err
+	}
+	return projected, nil
+}
+
+func projectDeviceTx(ctx context.Context, tx pgx.Tx, orgID, deviceID string, in DeviceProjectionInput) (model.Device, error) {
 	device, err := scanDevice(tx.QueryRow(ctx, `
 		SELECT id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
 		FROM devices
@@ -151,10 +163,6 @@ func (s *Store) ProjectDevice(ctx context.Context, orgID, deviceID string, in De
 		RETURNING id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
 	`, orgID, deviceID, status, lastSeenAt, metadata))
 	if err != nil {
-		return model.Device{}, err
-	}
-
-	if err := tx.Commit(ctx); err != nil {
 		return model.Device{}, err
 	}
 	return projected, nil

--- a/internal/store/inbox_worker.go
+++ b/internal/store/inbox_worker.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type InboxProcessTransitionInput struct {
+	MessageID             string
+	MessageStatus         model.DeviceMessageInboxStatus
+	AttemptCount          int
+	LastError             *string
+	ProcessedAt           *time.Time
+	OperationStatus       *model.DeviceOperationStatus
+	OperationResult       map[string]any
+	OperationErrorCode    *string
+	OperationErrorMessage *string
+	OperationRetryable    *bool
+	OperationCompletedAt  *time.Time
+	OrganizationID        string
+	DeviceID              string
+	Projection            *DeviceProjectionInput
+}
+
+type InboxProcessTransitionResult struct {
+	Message   model.DeviceMessageInbox
+	Operation *model.DeviceOperation
+	Device    *model.Device
+}
+
+func (s *Store) RecordInboxProcessTransition(ctx context.Context, in InboxProcessTransitionInput) (InboxProcessTransitionResult, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return InboxProcessTransitionResult{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	message, err := scanDeviceMessageInbox(tx.QueryRow(ctx, `
+		UPDATE device_message_inbox
+		SET status = $2,
+			attempt_count = $3,
+			last_error = $4,
+			processed_at = $5
+		WHERE message_id = $1
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+	`, in.MessageID, in.MessageStatus, in.AttemptCount, in.LastError, in.ProcessedAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return InboxProcessTransitionResult{}, ErrNotFound
+	}
+	if err != nil {
+		return InboxProcessTransitionResult{}, err
+	}
+
+	result := InboxProcessTransitionResult{Message: message}
+
+	if in.OperationStatus != nil {
+		resultPayload, err := marshalJSONMap(in.OperationResult)
+		if err != nil {
+			return InboxProcessTransitionResult{}, err
+		}
+
+		operation, err := scanDeviceOperation(tx.QueryRow(ctx, `
+			UPDATE device_operations
+			SET status = $2,
+				result_payload = $3::jsonb,
+				error_code = $4,
+				error_message = $5,
+				retryable = $6,
+				completed_at = $7
+			WHERE operation_id = $1
+			RETURNING id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+		`, message.OperationID, in.OperationStatus, resultPayload, in.OperationErrorCode, in.OperationErrorMessage, in.OperationRetryable, in.OperationCompletedAt))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return InboxProcessTransitionResult{}, ErrNotFound
+		}
+		if err != nil {
+			return InboxProcessTransitionResult{}, err
+		}
+		if operation.OrganizationID != in.OrganizationID || operation.DeviceID != in.DeviceID {
+			return InboxProcessTransitionResult{}, ErrConflict
+		}
+		result.Operation = &operation
+	}
+
+	if in.Projection != nil {
+		projected, err := projectDeviceTx(ctx, tx, in.OrganizationID, in.DeviceID, *in.Projection)
+		if err != nil {
+			return InboxProcessTransitionResult{}, err
+		}
+		result.Device = &projected
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return InboxProcessTransitionResult{}, err
+	}
+	return result, nil
+}

--- a/internal/worker/inbox/service.go
+++ b/internal/worker/inbox/service.go
@@ -1,0 +1,377 @@
+package inbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"rtk_account_manager/internal/broker"
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type messageStore interface {
+	CreateOrGetInboxMessage(ctx context.Context, in store.DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error)
+	RecordInboxProcessTransition(ctx context.Context, in store.InboxProcessTransitionInput) (store.InboxProcessTransitionResult, error)
+}
+
+type Options struct {
+	Stream        string
+	ConsumerGroup string
+	MaxAttempts   int
+	PollInterval  time.Duration
+	BatchSize     int
+	Now           func() time.Time
+}
+
+type Service struct {
+	store         messageStore
+	consumer      broker.Consumer
+	stream        string
+	consumerGroup string
+	maxAttempts   int
+	pollInterval  time.Duration
+	batchSize     int
+	now           func() time.Time
+}
+
+type Stats struct {
+	Received     int
+	Processed    int
+	Retrying     int
+	DeadLettered int
+	Skipped      int
+}
+
+var transitionForPayloadFunc = buildTransitionForPayload
+
+func NewService(store messageStore, consumer broker.Consumer, opts Options) *Service {
+	nowFn := opts.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+
+	pollInterval := opts.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = 20
+	}
+
+	maxAttempts := opts.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+
+	stream := opts.Stream
+	if stream == "" {
+		stream = channel.StreamVideoAccountEvents
+	}
+
+	return &Service{
+		store:         store,
+		consumer:      consumer,
+		stream:        stream,
+		consumerGroup: opts.ConsumerGroup,
+		maxAttempts:   maxAttempts,
+		pollInterval:  pollInterval,
+		batchSize:     batchSize,
+		now:           nowFn,
+	}
+}
+
+func (s *Service) Run(ctx context.Context) error {
+	for {
+		if _, err := s.RunOnce(ctx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+
+		timer := time.NewTimer(s.pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *Service) RunOnce(ctx context.Context) (Stats, error) {
+	records, err := s.consumer.Receive(ctx, s.batchSize)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	stats := Stats{Received: len(records)}
+	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+
+		outcome, err := s.processMessage(ctx, record)
+		if err != nil {
+			return stats, err
+		}
+
+		switch outcome {
+		case model.DeviceMessageInboxStatusProcessed:
+			stats.Processed++
+		case model.DeviceMessageInboxStatusRetrying:
+			stats.Retrying++
+		case model.DeviceMessageInboxStatusDeadLettered:
+			stats.DeadLettered++
+		case "":
+			stats.Skipped++
+		}
+	}
+
+	return stats, nil
+}
+
+func (s *Service) processMessage(ctx context.Context, record broker.Message) (model.DeviceMessageInboxStatus, error) {
+	receivedAt := s.receivedAt(record.Envelope)
+	payloadMap, err := payloadMapFromEnvelope(record.Envelope)
+	if err != nil {
+		payloadMap = map[string]any{}
+	}
+
+	message, created, err := s.store.CreateOrGetInboxMessage(ctx, store.DeviceMessageInboxCreateInput{
+		MessageID:     record.Envelope.MessageID,
+		OperationID:   record.Envelope.OperationID,
+		CorrelationID: record.Envelope.CorrelationID,
+		CausationID:   causationIDPtr(record.Envelope.CausationID),
+		Stream:        record.Stream,
+		MessageType:   string(record.Envelope.MessageType),
+		SchemaVersion: record.Envelope.SchemaVersion,
+		PartitionKey:  record.Envelope.PartitionKey,
+		Payload:       payloadMap,
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		AttemptCount:  0,
+		ReceivedAt:    receivedAt,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if !created {
+		switch message.Status {
+		case model.DeviceMessageInboxStatusProcessed, model.DeviceMessageInboxStatusDeadLettered:
+			return "", nil
+		}
+	}
+
+	attemptCount := message.AttemptCount + 1
+
+	if record.Stream != s.stream {
+		return model.DeviceMessageInboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, fmt.Errorf("unexpected stream %q", record.Stream))
+	}
+
+	payload, err := record.Envelope.ValidateAndDecode(s.stream)
+	if err != nil {
+		return model.DeviceMessageInboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, err)
+	}
+
+	transition, err := transitionForPayloadFunc(record.Envelope, payload)
+	if err != nil {
+		if isTransientProcessingError(err) && attemptCount < s.maxAttempts {
+			return model.DeviceMessageInboxStatusRetrying, s.recordRetry(ctx, message, attemptCount, err)
+		}
+		return model.DeviceMessageInboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, err)
+	}
+
+	transition.MessageID = message.MessageID
+	transition.MessageStatus = model.DeviceMessageInboxStatusProcessed
+	transition.AttemptCount = attemptCount
+	processedAt := s.currentTime()
+	transition.ProcessedAt = &processedAt
+
+	if _, err := s.store.RecordInboxProcessTransition(ctx, transition); err != nil {
+		return "", err
+	}
+	return model.DeviceMessageInboxStatusProcessed, nil
+}
+
+func (s *Service) recordRetry(ctx context.Context, message model.DeviceMessageInbox, attemptCount int, cause error) error {
+	lastError := cause.Error()
+	_, err := s.store.RecordInboxProcessTransition(ctx, store.InboxProcessTransitionInput{
+		MessageID:     message.MessageID,
+		MessageStatus: model.DeviceMessageInboxStatusRetrying,
+		AttemptCount:  attemptCount,
+		LastError:     &lastError,
+	})
+	return err
+}
+
+func (s *Service) recordDeadLetter(ctx context.Context, message model.DeviceMessageInbox, attemptCount int, cause error) error {
+	lastError := cause.Error()
+	processedAt := s.currentTime()
+	_, err := s.store.RecordInboxProcessTransition(ctx, store.InboxProcessTransitionInput{
+		MessageID:     message.MessageID,
+		MessageStatus: model.DeviceMessageInboxStatusDeadLettered,
+		AttemptCount:  attemptCount,
+		LastError:     &lastError,
+		ProcessedAt:   &processedAt,
+	})
+	return err
+}
+
+func buildTransitionForPayload(envelope channel.Envelope, payload channel.Payload) (store.InboxProcessTransitionInput, error) {
+	switch typed := payload.(type) {
+	case *channel.DeviceProvisionSucceededPayload:
+		return successTransition(
+			typed.OrgID,
+			typed.AccountDeviceID,
+			typed.ActivatedAt.UTC(),
+			store.ProvisionSucceededProjection(*typed),
+			map[string]any{
+				"video_cloud_devid": typed.VideoCloudDevid,
+				"activity_id":       typed.ActivityID,
+				"activated_at":      typed.ActivatedAt.UTC(),
+			},
+		), nil
+	case *channel.DeviceProvisionFailedPayload:
+		return failureTransition(
+			typed.OrgID,
+			typed.AccountDeviceID,
+			typed.FailedAt.UTC(),
+			store.ProvisionFailedProjection(*typed),
+			map[string]any{
+				"video_cloud_devid": typed.VideoCloudDevid,
+				"activity_id":       typed.ActivityID,
+				"error_code":        typed.ErrorCode,
+				"error_message":     typed.ErrorMessage,
+				"retryable":         typed.Retryable,
+				"failed_at":         typed.FailedAt.UTC(),
+			},
+			typed.ErrorCode,
+			typed.ErrorMessage,
+			typed.Retryable,
+		), nil
+	case *channel.DeviceDeactivateSucceededPayload:
+		return successTransition(
+			typed.OrgID,
+			typed.AccountDeviceID,
+			typed.DeactivatedAt.UTC(),
+			store.DeactivateSucceededProjection(*typed),
+			map[string]any{
+				"video_cloud_devid": typed.VideoCloudDevid,
+				"deactivated_at":    typed.DeactivatedAt.UTC(),
+			},
+		), nil
+	case *channel.DeviceDeactivateFailedPayload:
+		return failureTransition(
+			typed.OrgID,
+			typed.AccountDeviceID,
+			typed.FailedAt.UTC(),
+			store.DeactivateFailedProjection(*typed),
+			map[string]any{
+				"video_cloud_devid": typed.VideoCloudDevid,
+				"error_code":        typed.ErrorCode,
+				"error_message":     typed.ErrorMessage,
+				"retryable":         typed.Retryable,
+				"failed_at":         typed.FailedAt.UTC(),
+			},
+			typed.ErrorCode,
+			typed.ErrorMessage,
+			typed.Retryable,
+		), nil
+	case *channel.DeviceOnlineChangedPayload:
+		return store.InboxProcessTransitionInput{
+			OrganizationID: typed.OrgID,
+			DeviceID:       typed.AccountDeviceID,
+			Projection:     projectionPtr(store.OnlineChangedProjection(*typed)),
+		}, nil
+	case *channel.DeviceMetadataChangedPayload:
+		return store.InboxProcessTransitionInput{
+			OrganizationID: typed.OrgID,
+			DeviceID:       typed.AccountDeviceID,
+			Projection:     projectionPtr(store.MetadataChangedProjection(*typed)),
+		}, nil
+	default:
+		return store.InboxProcessTransitionInput{}, fmt.Errorf("unsupported message type %q", envelope.MessageType)
+	}
+}
+
+func successTransition(orgID, deviceID string, completedAt time.Time, projection store.DeviceProjectionInput, result map[string]any) store.InboxProcessTransitionInput {
+	status := model.DeviceOperationStatusSucceeded
+	return store.InboxProcessTransitionInput{
+		OperationStatus:      &status,
+		OperationResult:      result,
+		OperationCompletedAt: &completedAt,
+		OrganizationID:       orgID,
+		DeviceID:             deviceID,
+		Projection:           projectionPtr(projection),
+	}
+}
+
+func failureTransition(orgID, deviceID string, completedAt time.Time, projection store.DeviceProjectionInput, result map[string]any, errorCode, errorMessage string, retryable bool) store.InboxProcessTransitionInput {
+	status := model.DeviceOperationStatusFailed
+	return store.InboxProcessTransitionInput{
+		OperationStatus:       &status,
+		OperationResult:       result,
+		OperationErrorCode:    stringPtr(errorCode),
+		OperationErrorMessage: stringPtr(errorMessage),
+		OperationRetryable:    boolPtr(retryable),
+		OperationCompletedAt:  &completedAt,
+		OrganizationID:        orgID,
+		DeviceID:              deviceID,
+		Projection:            projectionPtr(projection),
+	}
+}
+
+func payloadMapFromEnvelope(envelope channel.Envelope) (map[string]any, error) {
+	if len(envelope.Payload) == 0 {
+		return map[string]any{}, nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		return map[string]any{}, nil
+	}
+	return payload, nil
+}
+
+func projectionPtr(projection store.DeviceProjectionInput) *store.DeviceProjectionInput {
+	return &projection
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func causationIDPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func (s *Service) currentTime() time.Time {
+	return s.now().UTC().Truncate(time.Microsecond)
+}
+
+func (s *Service) receivedAt(envelope channel.Envelope) time.Time {
+	if envelope.OccurredAt.IsZero() {
+		return s.currentTime()
+	}
+	return envelope.OccurredAt.UTC().Truncate(time.Microsecond)
+}
+
+func isTransientProcessingError(err error) bool {
+	return broker.IsTransient(err)
+}

--- a/internal/worker/inbox/service_test.go
+++ b/internal/worker/inbox/service_test.go
@@ -1,0 +1,189 @@
+package inbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"rtk_account_manager/internal/broker"
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type fakeStore struct {
+	message      model.DeviceMessageInbox
+	created      bool
+	createInputs []store.DeviceMessageInboxCreateInput
+	transitions  []store.InboxProcessTransitionInput
+}
+
+func (s *fakeStore) CreateOrGetInboxMessage(_ context.Context, in store.DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error) {
+	s.createInputs = append(s.createInputs, in)
+	if s.message.MessageID == "" {
+		s.message = model.DeviceMessageInbox{
+			MessageID:     in.MessageID,
+			OperationID:   in.OperationID,
+			CorrelationID: in.CorrelationID,
+			Stream:        in.Stream,
+			MessageType:   in.MessageType,
+			SchemaVersion: in.SchemaVersion,
+			PartitionKey:  in.PartitionKey,
+			Payload:       in.Payload,
+			Status:        in.Status,
+		}
+	}
+	return s.message, s.created, nil
+}
+
+func (s *fakeStore) RecordInboxProcessTransition(_ context.Context, in store.InboxProcessTransitionInput) (store.InboxProcessTransitionResult, error) {
+	s.transitions = append(s.transitions, in)
+	return store.InboxProcessTransitionResult{}, nil
+}
+
+type fakeConsumer struct {
+	messages []broker.Message
+	err      error
+}
+
+func (c fakeConsumer) Receive(context.Context, int) ([]broker.Message, error) {
+	return append([]broker.Message(nil), c.messages...), c.err
+}
+
+func TestRunOnceProcessesProvisionSuccess(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{created: true}
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{validProvisionSucceededMessage(now)},
+	}, Options{
+		Now: func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Processed != 1 || stats.DeadLettered != 0 || stats.Retrying != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if len(inboxStore.transitions) != 1 {
+		t.Fatalf("expected one transition, got %d", len(inboxStore.transitions))
+	}
+	transition := inboxStore.transitions[0]
+	if transition.MessageStatus != model.DeviceMessageInboxStatusProcessed {
+		t.Fatalf("expected processed status, got %s", transition.MessageStatus)
+	}
+	if transition.OperationStatus == nil || *transition.OperationStatus != model.DeviceOperationStatusSucceeded {
+		t.Fatalf("expected succeeded operation status, got %+v", transition.OperationStatus)
+	}
+	if transition.Projection == nil {
+		t.Fatal("expected device projection")
+	}
+}
+
+func TestRunOnceSkipsPreviouslyProcessedDuplicates(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{
+		created: false,
+		message: model.DeviceMessageInbox{
+			MessageID:    "msg-1",
+			Status:       model.DeviceMessageInboxStatusProcessed,
+			AttemptCount: 1,
+		},
+	}
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{validProvisionSucceededMessage(now)},
+	}, Options{
+		Now: func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Skipped != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if len(inboxStore.transitions) != 0 {
+		t.Fatalf("expected no transitions, got %d", len(inboxStore.transitions))
+	}
+}
+
+func TestRunOnceDeadLettersInvalidMessages(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	message := validProvisionSucceededMessage(now)
+	message.Stream = "wrong.stream"
+	inboxStore := &fakeStore{created: true}
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{message},
+	}, Options{
+		Now: func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.DeadLettered != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if got := inboxStore.transitions[0].MessageStatus; got != model.DeviceMessageInboxStatusDeadLettered {
+		t.Fatalf("expected dead-lettered status, got %s", got)
+	}
+}
+
+func TestRunOnceRetriesTransientProjectionFailures(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{created: true}
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{validProvisionSucceededMessage(now)},
+	}, Options{
+		Now:         func() time.Time { return now },
+		MaxAttempts: 3,
+	})
+
+	original := transitionForPayloadFunc
+	defer func() { transitionForPayloadFunc = original }()
+	transitionForPayloadFunc = func(channel.Envelope, channel.Payload) (store.InboxProcessTransitionInput, error) {
+		return store.InboxProcessTransitionInput{}, broker.Transient(errors.New("temporary projection failure"))
+	}
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Retrying != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if got := inboxStore.transitions[0].MessageStatus; got != model.DeviceMessageInboxStatusRetrying {
+		t.Fatalf("expected retrying status, got %s", got)
+	}
+}
+
+func validProvisionSucceededMessage(now time.Time) broker.Message {
+	payload := channel.DeviceProvisionSucceededPayload{
+		OrgID:           "00000000-0000-0000-0000-000000000001",
+		AccountDeviceID: "11111111-1111-1111-1111-111111111111",
+		VideoCloudDevid: "video-1",
+		ActivityID:      "activity-1",
+		ActivatedAt:     now,
+	}
+	rawPayload, _ := json.Marshal(payload)
+	return broker.Message{
+		Stream: channel.StreamVideoAccountEvents,
+		Envelope: channel.Envelope{
+			MessageID:     "msg-1",
+			CorrelationID: "corr-1",
+			OperationID:   "op-1",
+			SourceService: channel.ServiceRealtekVideoCloud,
+			TargetService: channel.ServiceAccountManager,
+			MessageType:   channel.MessageTypeDeviceProvisionSucceeded,
+			SchemaVersion: channel.SchemaVersionV1,
+			PartitionKey:  payload.AccountDeviceID,
+			OccurredAt:    now,
+			Payload:       rawPayload,
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add `cmd/inbox-worker` plus an inbox worker service that consumes local broker records, deduplicates inbox rows, and applies account-side projections
- extend the local `log` broker adapter with consumer support and add transactional store transitions for inbox processing, operation updates, and device projections
- mark issue `#8` as `in_progress` in the implementation plan and cover processed, duplicate, retry, and dead-letter flows with worker/broker tests

## Validation
- `go test ./internal/worker/inbox ./internal/broker ./internal/store`
- `go test ./...`
- `go build ./...`

## Notes
- `TEST_DATABASE_URL` was unset in this runtime, so env-gated Postgres integration tests remained skipped locally
- this PR is stacked on top of PR #18 (`codex/issue-7-outbox-worker`) and should retarget to `main` after that branch merges

Refs #8
