### PR TITLE
[Worker] Guard outbox publish transitions against stale leases

### DIFF
--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -501,6 +501,9 @@ func TestRecordOutboxPublishTransitionUpdatesOperationState(t *testing.T) {
 	retryable := false
 	result, err := env.store.RecordOutboxPublishTransition(ctx, OutboxPublishTransitionInput{
 		MessageID:             "transition-msg",
+		ExpectedMessageStatus: model.DeviceMessageOutboxStatusPending,
+		ExpectedAttemptCount:  0,
+		ExpectedAvailableAt:   now,
 		MessageStatus:         model.DeviceMessageOutboxStatusDeadLettered,
 		AttemptCount:          3,
 		LastError:             stringPtr("publish failed"),
@@ -522,6 +525,124 @@ func TestRecordOutboxPublishTransitionUpdatesOperationState(t *testing.T) {
 	}
 	if result.Operation.CompletedAt == nil || !result.Operation.CompletedAt.Equal(deadLetterAt) {
 		t.Fatalf("expected completed_at to be set, got %+v", result.Operation.CompletedAt)
+	}
+}
+
+func TestRecordOutboxPublishTransitionRejectsStaleLease(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	op, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-stale-transition",
+		CorrelationID:  "corr-stale-transition",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readyAt := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "stale-transition-msg",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceProvisionRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"operation_id": op.OperationID},
+		Status:        model.DeviceMessageOutboxStatusPending,
+		AvailableAt:   readyAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	firstLeaseUntil := readyAt.Add(30 * time.Second)
+	firstClaim, err := env.store.ClaimOutboxMessagesReady(ctx, readyAt, firstLeaseUntil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstClaim) != 1 {
+		t.Fatalf("expected one first claim, got %+v", firstClaim)
+	}
+
+	secondLeaseUntil := firstLeaseUntil.Add(30 * time.Second)
+	secondClaim, err := env.store.ClaimOutboxMessagesReady(ctx, firstLeaseUntil, secondLeaseUntil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondClaim) != 1 {
+		t.Fatalf("expected lease-expired row to be reclaimable, got %+v", secondClaim)
+	}
+
+	publishedAt := secondLeaseUntil.Add(time.Second)
+	result, err := env.store.RecordOutboxPublishTransition(ctx, OutboxPublishTransitionInput{
+		MessageID:             secondClaim[0].MessageID,
+		ExpectedMessageStatus: secondClaim[0].Status,
+		ExpectedAttemptCount:  secondClaim[0].AttemptCount,
+		ExpectedAvailableAt:   secondClaim[0].AvailableAt,
+		MessageStatus:         model.DeviceMessageOutboxStatusPublished,
+		AttemptCount:          secondClaim[0].AttemptCount + 1,
+		AvailableAt:           publishedAt,
+		PublishedAt:           &publishedAt,
+		OperationStatus:       model.DeviceOperationStatusPublished,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Message.Status != model.DeviceMessageOutboxStatusPublished {
+		t.Fatalf("expected published result, got %+v", result.Message)
+	}
+
+	retryable := false
+	_, staleErr := env.store.RecordOutboxPublishTransition(ctx, OutboxPublishTransitionInput{
+		MessageID:             firstClaim[0].MessageID,
+		ExpectedMessageStatus: firstClaim[0].Status,
+		ExpectedAttemptCount:  firstClaim[0].AttemptCount,
+		ExpectedAvailableAt:   firstClaim[0].AvailableAt,
+		MessageStatus:         model.DeviceMessageOutboxStatusDeadLettered,
+		AttemptCount:          firstClaim[0].AttemptCount + 1,
+		LastError:             stringPtr("stale worker lost lease"),
+		AvailableAt:           publishedAt,
+		OperationStatus:       model.DeviceOperationStatusDeadLettered,
+		OperationErrorCode:    stringPtr("publish_failed"),
+		OperationErrorMessage: stringPtr("stale worker lost lease"),
+		OperationRetryable:    &retryable,
+		OperationCompletedAt:  &publishedAt,
+	})
+	if !errors.Is(staleErr, ErrConflict) {
+		t.Fatalf("expected stale lease conflict, got %v", staleErr)
+	}
+
+	storedMessage, err := env.store.GetOutboxMessage(ctx, "stale-transition-msg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedMessage.Status != model.DeviceMessageOutboxStatusPublished {
+		t.Fatalf("expected published message to remain intact, got %+v", storedMessage)
+	}
+	if storedMessage.AttemptCount != 1 {
+		t.Fatalf("expected published attempt count to stay 1, got %+v", storedMessage)
+	}
+	if storedMessage.PublishedAt == nil || !storedMessage.PublishedAt.Equal(publishedAt) {
+		t.Fatalf("expected published timestamp to be preserved, got %+v", storedMessage.PublishedAt)
+	}
+
+	storedOperation, err := env.store.GetDeviceOperation(ctx, op.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedOperation.Status != model.DeviceOperationStatusPublished {
+		t.Fatalf("expected published operation to remain intact, got %+v", storedOperation)
+	}
+	if storedOperation.CompletedAt != nil {
+		t.Fatalf("expected published operation to remain incomplete, got %+v", storedOperation.CompletedAt)
 	}
 }
 

--- a/internal/store/outbox_worker.go
+++ b/internal/store/outbox_worker.go
@@ -12,6 +12,9 @@ import (
 
 type OutboxPublishTransitionInput struct {
 	MessageID             string
+	ExpectedMessageStatus model.DeviceMessageOutboxStatus
+	ExpectedAttemptCount  int
+	ExpectedAvailableAt   time.Time
 	MessageStatus         model.DeviceMessageOutboxStatus
 	AttemptCount          int
 	LastError             *string
@@ -39,15 +42,18 @@ func (s *Store) RecordOutboxPublishTransition(ctx context.Context, in OutboxPubl
 	message, err := scanDeviceMessageOutbox(tx.QueryRow(ctx, `
 		UPDATE device_message_outbox
 		SET status = $2,
-			attempt_count = $3,
-			last_error = $4,
-			available_at = $5,
-			published_at = $6
+			attempt_count = $6,
+			last_error = $7,
+			available_at = $8,
+			published_at = $9
 		WHERE message_id = $1
+			AND status = $3
+			AND attempt_count = $4
+			AND available_at = $5
 		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
-	`, in.MessageID, in.MessageStatus, in.AttemptCount, in.LastError, in.AvailableAt, in.PublishedAt))
+	`, in.MessageID, in.MessageStatus, in.ExpectedMessageStatus, in.ExpectedAttemptCount, in.ExpectedAvailableAt, in.AttemptCount, in.LastError, in.AvailableAt, in.PublishedAt))
 	if errors.Is(err, pgx.ErrNoRows) {
-		return OutboxPublishTransitionResult{}, ErrNotFound
+		return OutboxPublishTransitionResult{}, classifyOutboxPublishTransitionError(ctx, tx, in.MessageID)
 	}
 	if err != nil {
 		return OutboxPublishTransitionResult{}, err
@@ -84,4 +90,21 @@ func (s *Store) RecordOutboxPublishTransition(ctx context.Context, in OutboxPubl
 		Message:   message,
 		Operation: operation,
 	}, nil
+}
+
+func classifyOutboxPublishTransitionError(ctx context.Context, tx pgx.Tx, messageID string) error {
+	var exists bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM device_message_outbox
+			WHERE message_id = $1
+		)
+	`, messageID).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return ErrNotFound
+	}
+	return ErrConflict
 }

--- a/internal/worker/outbox/service.go
+++ b/internal/worker/outbox/service.go
@@ -146,7 +146,14 @@ func (s *Service) publishMessage(ctx context.Context, message model.DeviceMessag
 
 	envelope, err := envelopeFromMessage(message)
 	if err != nil {
-		return model.DeviceMessageOutboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, attemptedAt, fmt.Errorf("invalid outbox message: %w", err))
+		applied, err := s.recordDeadLetter(ctx, message, attemptCount, attemptedAt, fmt.Errorf("invalid outbox message: %w", err))
+		if err != nil {
+			return "", err
+		}
+		if !applied {
+			return "", nil
+		}
+		return model.DeviceMessageOutboxStatusDeadLettered, nil
 	}
 
 	if err := s.publisher.Publish(ctx, message.Stream, envelope); err != nil {
@@ -154,13 +161,26 @@ func (s *Service) publishMessage(ctx context.Context, message model.DeviceMessag
 			return "", err
 		}
 		if broker.IsTransient(err) && attemptCount < s.maxAttempts {
-			return model.DeviceMessageOutboxStatusRetrying, s.recordRetry(ctx, message, attemptCount, attemptedAt, err)
+			applied, err := s.recordRetry(ctx, message, attemptCount, attemptedAt, err)
+			if err != nil {
+				return "", err
+			}
+			if !applied {
+				return "", nil
+			}
+			return model.DeviceMessageOutboxStatusRetrying, nil
 		}
-		return model.DeviceMessageOutboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, attemptedAt, err)
+		applied, err := s.recordDeadLetter(ctx, message, attemptCount, attemptedAt, err)
+		if err != nil {
+			return "", err
+		}
+		if !applied {
+			return "", nil
+		}
+		return model.DeviceMessageOutboxStatusDeadLettered, nil
 	}
 
-	_, err = s.store.RecordOutboxPublishTransition(ctx, store.OutboxPublishTransitionInput{
-		MessageID:       message.MessageID,
+	applied, err := s.recordTransition(ctx, message, store.OutboxPublishTransitionInput{
 		MessageStatus:   model.DeviceMessageOutboxStatusPublished,
 		AttemptCount:    attemptCount,
 		AvailableAt:     attemptedAt,
@@ -170,14 +190,16 @@ func (s *Service) publishMessage(ctx context.Context, message model.DeviceMessag
 	if err != nil {
 		return "", err
 	}
+	if !applied {
+		return "", nil
+	}
 	return model.DeviceMessageOutboxStatusPublished, nil
 }
 
-func (s *Service) recordRetry(ctx context.Context, message model.DeviceMessageOutbox, attemptCount int, attemptedAt time.Time, cause error) error {
+func (s *Service) recordRetry(ctx context.Context, message model.DeviceMessageOutbox, attemptCount int, attemptedAt time.Time, cause error) (bool, error) {
 	lastError := cause.Error()
 	retryable := true
-	_, err := s.store.RecordOutboxPublishTransition(ctx, store.OutboxPublishTransitionInput{
-		MessageID:             message.MessageID,
+	return s.recordTransition(ctx, message, store.OutboxPublishTransitionInput{
 		MessageStatus:         model.DeviceMessageOutboxStatusRetrying,
 		AttemptCount:          attemptCount,
 		LastError:             &lastError,
@@ -187,14 +209,12 @@ func (s *Service) recordRetry(ctx context.Context, message model.DeviceMessageOu
 		OperationErrorMessage: &lastError,
 		OperationRetryable:    &retryable,
 	})
-	return err
 }
 
-func (s *Service) recordDeadLetter(ctx context.Context, message model.DeviceMessageOutbox, attemptCount int, attemptedAt time.Time, cause error) error {
+func (s *Service) recordDeadLetter(ctx context.Context, message model.DeviceMessageOutbox, attemptCount int, attemptedAt time.Time, cause error) (bool, error) {
 	lastError := cause.Error()
 	retryable := false
-	_, err := s.store.RecordOutboxPublishTransition(ctx, store.OutboxPublishTransitionInput{
-		MessageID:             message.MessageID,
+	return s.recordTransition(ctx, message, store.OutboxPublishTransitionInput{
 		MessageStatus:         model.DeviceMessageOutboxStatusDeadLettered,
 		AttemptCount:          attemptCount,
 		LastError:             &lastError,
@@ -205,7 +225,22 @@ func (s *Service) recordDeadLetter(ctx context.Context, message model.DeviceMess
 		OperationRetryable:    &retryable,
 		OperationCompletedAt:  &attemptedAt,
 	})
-	return err
+}
+
+func (s *Service) recordTransition(ctx context.Context, message model.DeviceMessageOutbox, in store.OutboxPublishTransitionInput) (bool, error) {
+	in.MessageID = message.MessageID
+	in.ExpectedMessageStatus = message.Status
+	in.ExpectedAttemptCount = message.AttemptCount
+	in.ExpectedAvailableAt = message.AvailableAt
+
+	_, err := s.store.RecordOutboxPublishTransition(ctx, in)
+	if errors.Is(err, store.ErrConflict) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func envelopeFromMessage(message model.DeviceMessageOutbox) (channel.Envelope, error) {

--- a/internal/worker/outbox/service_test.go
+++ b/internal/worker/outbox/service_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 type fakeStore struct {
-	claimed     []model.DeviceMessageOutbox
-	transitions []store.OutboxPublishTransitionInput
+	claimed       []model.DeviceMessageOutbox
+	transitions   []store.OutboxPublishTransitionInput
+	transitionErr error
 }
 
 func (s *fakeStore) ClaimOutboxMessagesReady(_ context.Context, _ time.Time, _ time.Time, _ int) ([]model.DeviceMessageOutbox, error) {
@@ -23,7 +24,7 @@ func (s *fakeStore) ClaimOutboxMessagesReady(_ context.Context, _ time.Time, _ t
 
 func (s *fakeStore) RecordOutboxPublishTransition(_ context.Context, in store.OutboxPublishTransitionInput) (store.OutboxPublishTransitionResult, error) {
 	s.transitions = append(s.transitions, in)
-	return store.OutboxPublishTransitionResult{}, nil
+	return store.OutboxPublishTransitionResult{}, s.transitionErr
 }
 
 type fakePublisher struct {
@@ -61,6 +62,15 @@ func TestRunOnceMarksSuccessfulPublishes(t *testing.T) {
 	transition := outboxStore.transitions[0]
 	if transition.MessageStatus != model.DeviceMessageOutboxStatusPublished {
 		t.Fatalf("expected published status, got %s", transition.MessageStatus)
+	}
+	if transition.ExpectedMessageStatus != model.DeviceMessageOutboxStatusPending {
+		t.Fatalf("expected pending claim status, got %s", transition.ExpectedMessageStatus)
+	}
+	if transition.ExpectedAttemptCount != 0 {
+		t.Fatalf("expected prior attempt count 0, got %d", transition.ExpectedAttemptCount)
+	}
+	if !transition.ExpectedAvailableAt.Equal(now) {
+		t.Fatalf("expected claim lease timestamp %s, got %s", now, transition.ExpectedAvailableAt)
 	}
 	if transition.OperationStatus != model.DeviceOperationStatusPublished {
 		t.Fatalf("expected operation published status, got %s", transition.OperationStatus)
@@ -149,6 +159,31 @@ func TestRunOnceDeadLettersInvalidOutboxPayload(t *testing.T) {
 	}
 	if stats.DeadLettered != 1 {
 		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestRunOnceIgnoresStaleLeaseTransitionConflict(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	outboxStore := &fakeStore{
+		claimed:       []model.DeviceMessageOutbox{validMessage(now)},
+		transitionErr: store.ErrConflict,
+	}
+
+	service := NewService(outboxStore, fakePublisher{}, Options{
+		MaxAttempts:   5,
+		LeaseDuration: 30 * time.Second,
+		Now:           func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Claimed != 1 || stats.Published != 0 || stats.Retrying != 0 || stats.DeadLettered != 0 {
+		t.Fatalf("expected stale-lease conflict to be a no-op, got %+v", stats)
+	}
+	if len(outboxStore.transitions) != 1 {
+		t.Fatalf("expected one attempted transition, got %d", len(outboxStore.transitions))
 	}
 }
 


### PR DESCRIPTION
## Summary
- guard `RecordOutboxPublishTransition` with the claimed outbox row state so stale leases cannot overwrite a newer terminal publish result
- treat stale-lease `ErrConflict` outcomes as benign no-ops in the outbox worker instead of failing the run
- add regression coverage for the guarded transition path in the worker tests and store integration tests

## Validation
- `go test ./internal/worker/outbox/...`
- `go test ./internal/store/...`
- `go test ./internal/store/... -run 'TestRecordOutboxPublishTransition(UpdatesOperationState|RejectsStaleLease)$' -v` (`TEST_DATABASE_URL` unset locally, so the DB-backed cases skipped)
- `go test ./...`
- `docker compose up -d postgres` (failed locally: Docker daemon not running)

Refs #7
