### PR TITLE
[Worker] Preserve published outbox outcomes

### DIFF
--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -647,6 +647,121 @@ func TestRecordOutboxPublishTransitionRejectsStaleLease(t *testing.T) {
 	}
 }
 
+func TestRecordOutboxPublishTransitionLetsPublishedOutcomeOverrideLaterFailure(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	op, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-stale-published",
+		CorrelationID:  "corr-stale-published",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readyAt := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "stale-published-msg",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceProvisionRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload:       map[string]any{"operation_id": op.OperationID},
+		Status:        model.DeviceMessageOutboxStatusPending,
+		AvailableAt:   readyAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	firstLeaseUntil := readyAt.Add(30 * time.Second)
+	firstClaim, err := env.store.ClaimOutboxMessagesReady(ctx, readyAt, firstLeaseUntil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstClaim) != 1 {
+		t.Fatalf("expected one first claim, got %+v", firstClaim)
+	}
+
+	secondLeaseUntil := firstLeaseUntil.Add(30 * time.Second)
+	secondClaim, err := env.store.ClaimOutboxMessagesReady(ctx, firstLeaseUntil, secondLeaseUntil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondClaim) != 1 {
+		t.Fatalf("expected lease-expired row to be reclaimable, got %+v", secondClaim)
+	}
+
+	publishedAt := firstLeaseUntil.Add(time.Second)
+	result, err := env.store.RecordOutboxPublishTransition(ctx, OutboxPublishTransitionInput{
+		MessageID:             firstClaim[0].MessageID,
+		ExpectedMessageStatus: firstClaim[0].Status,
+		ExpectedAttemptCount:  firstClaim[0].AttemptCount,
+		ExpectedAvailableAt:   firstClaim[0].AvailableAt,
+		MessageStatus:         model.DeviceMessageOutboxStatusPublished,
+		AttemptCount:          firstClaim[0].AttemptCount + 1,
+		AvailableAt:           publishedAt,
+		PublishedAt:           &publishedAt,
+		OperationStatus:       model.DeviceOperationStatusPublished,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Message.Status != model.DeviceMessageOutboxStatusPublished {
+		t.Fatalf("expected published result, got %+v", result.Message)
+	}
+
+	retryable := false
+	_, conflictErr := env.store.RecordOutboxPublishTransition(ctx, OutboxPublishTransitionInput{
+		MessageID:             secondClaim[0].MessageID,
+		ExpectedMessageStatus: secondClaim[0].Status,
+		ExpectedAttemptCount:  secondClaim[0].AttemptCount,
+		ExpectedAvailableAt:   secondClaim[0].AvailableAt,
+		MessageStatus:         model.DeviceMessageOutboxStatusDeadLettered,
+		AttemptCount:          secondClaim[0].AttemptCount + 1,
+		LastError:             stringPtr("duplicate claimant observed publish failure"),
+		AvailableAt:           secondLeaseUntil.Add(time.Second),
+		OperationStatus:       model.DeviceOperationStatusDeadLettered,
+		OperationErrorCode:    stringPtr("publish_failed"),
+		OperationErrorMessage: stringPtr("duplicate claimant observed publish failure"),
+		OperationRetryable:    &retryable,
+		OperationCompletedAt:  &publishedAt,
+	})
+	if !errors.Is(conflictErr, ErrConflict) {
+		t.Fatalf("expected later failure to conflict with published outcome, got %v", conflictErr)
+	}
+
+	storedMessage, err := env.store.GetOutboxMessage(ctx, "stale-published-msg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedMessage.Status != model.DeviceMessageOutboxStatusPublished {
+		t.Fatalf("expected published message to remain intact, got %+v", storedMessage)
+	}
+	if storedMessage.PublishedAt == nil || !storedMessage.PublishedAt.Equal(publishedAt) {
+		t.Fatalf("expected published timestamp to be preserved, got %+v", storedMessage.PublishedAt)
+	}
+
+	storedOperation, err := env.store.GetDeviceOperation(ctx, op.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedOperation.Status != model.DeviceOperationStatusPublished {
+		t.Fatalf("expected published operation to remain intact, got %+v", storedOperation)
+	}
+	if storedOperation.CompletedAt != nil {
+		t.Fatalf("expected published operation to remain incomplete, got %+v", storedOperation.CompletedAt)
+	}
+}
+
 func TestRecordInboxProcessTransitionUpdatesOperationAndProjection(t *testing.T) {
 	env := newStoreIntegrationEnv(t)
 	orgID, userID, deviceID := createDeviceFixture(t, env)

--- a/internal/store/outbox_worker.go
+++ b/internal/store/outbox_worker.go
@@ -39,22 +39,38 @@ func (s *Store) RecordOutboxPublishTransition(ctx context.Context, in OutboxPubl
 	}
 	defer tx.Rollback(ctx)
 
+	current, err := scanDeviceMessageOutbox(tx.QueryRow(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+		FROM device_message_outbox
+		WHERE message_id = $1
+		FOR UPDATE
+	`, in.MessageID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return OutboxPublishTransitionResult{}, ErrNotFound
+	}
+	if err != nil {
+		return OutboxPublishTransitionResult{}, err
+	}
+
+	if !shouldApplyOutboxPublishTransition(current, in) {
+		return OutboxPublishTransitionResult{}, ErrConflict
+	}
+
+	attemptCount := in.AttemptCount
+	if in.MessageStatus == model.DeviceMessageOutboxStatusPublished && current.AttemptCount > attemptCount {
+		attemptCount = current.AttemptCount
+	}
+
 	message, err := scanDeviceMessageOutbox(tx.QueryRow(ctx, `
 		UPDATE device_message_outbox
 		SET status = $2,
-			attempt_count = $6,
-			last_error = $7,
-			available_at = $8,
-			published_at = $9
+			attempt_count = $3,
+			last_error = $4,
+			available_at = $5,
+			published_at = $6
 		WHERE message_id = $1
-			AND status = $3
-			AND attempt_count = $4
-			AND available_at = $5
 		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
-	`, in.MessageID, in.MessageStatus, in.ExpectedMessageStatus, in.ExpectedAttemptCount, in.ExpectedAvailableAt, in.AttemptCount, in.LastError, in.AvailableAt, in.PublishedAt))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return OutboxPublishTransitionResult{}, classifyOutboxPublishTransitionError(ctx, tx, in.MessageID)
-	}
+	`, in.MessageID, in.MessageStatus, attemptCount, in.LastError, in.AvailableAt, in.PublishedAt))
 	if err != nil {
 		return OutboxPublishTransitionResult{}, err
 	}
@@ -92,19 +108,12 @@ func (s *Store) RecordOutboxPublishTransition(ctx context.Context, in OutboxPubl
 	}, nil
 }
 
-func classifyOutboxPublishTransitionError(ctx context.Context, tx pgx.Tx, messageID string) error {
-	var exists bool
-	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS(
-			SELECT 1
-			FROM device_message_outbox
-			WHERE message_id = $1
-		)
-	`, messageID).Scan(&exists); err != nil {
-		return err
+func shouldApplyOutboxPublishTransition(current model.DeviceMessageOutbox, in OutboxPublishTransitionInput) bool {
+	if current.Status == in.ExpectedMessageStatus &&
+		current.AttemptCount == in.ExpectedAttemptCount &&
+		current.AvailableAt.Equal(in.ExpectedAvailableAt) {
+		return true
 	}
-	if !exists {
-		return ErrNotFound
-	}
-	return ErrConflict
+	return in.MessageStatus == model.DeviceMessageOutboxStatusPublished &&
+		current.Status != model.DeviceMessageOutboxStatusPublished
 }

--- a/internal/worker/outbox/service_test.go
+++ b/internal/worker/outbox/service_test.go
@@ -191,6 +191,34 @@ func TestRunOnceIgnoresStaleLeaseTransitionConflict(t *testing.T) {
 	}
 }
 
+func TestRunOnceIgnoresConflictWhenRetryLosesToPublished(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	outboxStore := &fakeStore{
+		claimed:       []model.DeviceMessageOutbox{validMessage(now)},
+		transitionErr: store.ErrConflict,
+	}
+
+	service := NewService(outboxStore, fakePublisher{err: broker.Transient(errors.New("publish already succeeded elsewhere"))}, Options{
+		MaxAttempts: 5,
+		RetryDelay:  time.Minute,
+		Now:         func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Claimed != 1 || stats.Published != 0 || stats.Retrying != 0 || stats.DeadLettered != 0 {
+		t.Fatalf("expected conflicting retry transition to be a no-op, got %+v", stats)
+	}
+	if len(outboxStore.transitions) != 1 {
+		t.Fatalf("expected one attempted transition, got %d", len(outboxStore.transitions))
+	}
+	if outboxStore.transitions[0].MessageStatus != model.DeviceMessageOutboxStatusRetrying {
+		t.Fatalf("expected retry transition attempt, got %+v", outboxStore.transitions[0])
+	}
+}
+
 func validMessage(createdAt time.Time) model.DeviceMessageOutbox {
 	return model.DeviceMessageOutbox{
 		MessageID:     "msg-1",


### PR DESCRIPTION
## Summary
- let `RecordOutboxPublishTransition` lock the current outbox row first so a successful publish can still be recorded after the original lease snapshot goes stale
- keep `published` as the winning terminal outcome over later retry/dead-letter writes, while still rejecting conflicting non-published transitions once the row is published
- add regression coverage for the stale-success-first ordering in both the store integration tests and the outbox worker conflict handling

## Validation
- `go test ./internal/worker/outbox -count=1`
- `go test ./internal/store -run 'TestRecordOutboxPublishTransition(UpdatesOperationState|RejectsStaleLease|LetsPublishedOutcomeOverrideLaterFailure)$' -count=1`\n- `go test ./internal/store -count=1`\n- `go test ./... -count=1`\n\nRefs #7