### PR TITLE
[Worker] Guard inbox replays and preserve dead-letter payloads

### DIFF
--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -1113,6 +1113,63 @@ func TestCreateOrGetInboxMessageDeduplicates(t *testing.T) {
 	}
 }
 
+func TestCreateOrGetInboxMessagePreservesDeadLetterPayloadSnapshot(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	_, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-dead-letter-payload",
+		CorrelationID:  "corr-dead-letter-payload",
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPublished,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receivedAt := time.Now().UTC().Truncate(time.Microsecond)
+	message, created, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-dead-letter-payload",
+		OperationID:   "op-dead-letter-payload",
+		CorrelationID: "corr-dead-letter-payload",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  deviceID,
+		Payload: map[string]any{
+			"_raw_payload":          "{not-json",
+			"_payload_decode_error": "invalid character 'n' looking for beginning of object key string",
+		},
+		Status:       model.DeviceMessageInboxStatusDeadLettered,
+		AttemptCount: 1,
+		LastError:    stringPtr("invalid payload"),
+		ReceivedAt:   receivedAt,
+		ProcessedAt:  &receivedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected first inbox insert to create a row")
+	}
+
+	stored, err := env.store.GetInboxMessage(ctx, message.MessageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stored.Payload["_raw_payload"]; got != "{not-json" {
+		t.Fatalf("expected raw payload snapshot, got %+v", stored.Payload)
+	}
+	if got := stored.Payload["_payload_decode_error"]; got == nil {
+		t.Fatalf("expected payload decode error snapshot, got %+v", stored.Payload)
+	}
+}
+
 func stringPtr(value string) *string {
 	return &value
 }

--- a/internal/worker/inbox/service.go
+++ b/internal/worker/inbox/service.go
@@ -15,6 +15,7 @@ import (
 
 type messageStore interface {
 	CreateOrGetInboxMessage(ctx context.Context, in store.DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error)
+	GetDeviceOperation(ctx context.Context, operationID string) (model.DeviceOperation, error)
 	RecordInboxProcessTransition(ctx context.Context, in store.InboxProcessTransitionInput) (store.InboxProcessTransitionResult, error)
 }
 
@@ -47,6 +48,11 @@ type Stats struct {
 }
 
 var transitionForPayloadFunc = buildTransitionForPayload
+
+const (
+	payloadSnapshotRawKey   = "_raw_payload"
+	payloadSnapshotErrorKey = "_payload_decode_error"
+)
 
 func NewService(store messageStore, consumer broker.Consumer, opts Options) *Service {
 	nowFn := opts.Now
@@ -141,10 +147,7 @@ func (s *Service) RunOnce(ctx context.Context) (Stats, error) {
 
 func (s *Service) processMessage(ctx context.Context, record broker.Message) (model.DeviceMessageInboxStatus, error) {
 	receivedAt := s.receivedAt(record.Envelope)
-	payloadMap, err := payloadMapFromEnvelope(record.Envelope)
-	if err != nil {
-		payloadMap = map[string]any{}
-	}
+	payloadMap, payloadErr := payloadMapFromEnvelope(record.Envelope)
 
 	message, created, err := s.store.CreateOrGetInboxMessage(ctx, store.DeviceMessageInboxCreateInput{
 		MessageID:     record.Envelope.MessageID,
@@ -179,6 +182,9 @@ func (s *Service) processMessage(ctx context.Context, record broker.Message) (mo
 
 	payload, err := record.Envelope.ValidateAndDecode(s.stream)
 	if err != nil {
+		if payloadErr != nil {
+			err = payloadErr
+		}
 		return model.DeviceMessageInboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, err)
 	}
 
@@ -188,6 +194,19 @@ func (s *Service) processMessage(ctx context.Context, record broker.Message) (mo
 			return model.DeviceMessageInboxStatusRetrying, s.recordRetry(ctx, message, attemptCount, err)
 		}
 		return model.DeviceMessageInboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, err)
+	}
+
+	if created {
+		operation, err := s.store.GetDeviceOperation(ctx, message.OperationID)
+		switch {
+		case err == nil:
+			if isCompletedLifecycleOperation(operation) {
+				return model.DeviceMessageInboxStatusProcessed, s.markProcessedWithoutProjection(ctx, message, attemptCount)
+			}
+		case errors.Is(err, store.ErrNotFound):
+		default:
+			return "", err
+		}
 	}
 
 	transition.MessageID = message.MessageID
@@ -200,6 +219,17 @@ func (s *Service) processMessage(ctx context.Context, record broker.Message) (mo
 		return "", err
 	}
 	return model.DeviceMessageInboxStatusProcessed, nil
+}
+
+func (s *Service) markProcessedWithoutProjection(ctx context.Context, message model.DeviceMessageInbox, attemptCount int) error {
+	processedAt := s.currentTime()
+	_, err := s.store.RecordInboxProcessTransition(ctx, store.InboxProcessTransitionInput{
+		MessageID:     message.MessageID,
+		MessageStatus: model.DeviceMessageInboxStatusProcessed,
+		AttemptCount:  attemptCount,
+		ProcessedAt:   &processedAt,
+	})
+	return err
 }
 
 func (s *Service) recordRetry(ctx context.Context, message model.DeviceMessageInbox, attemptCount int, cause error) error {
@@ -348,12 +378,24 @@ func payloadMapFromEnvelope(envelope channel.Envelope) (map[string]any, error) {
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
-		return nil, err
+		return map[string]any{
+			payloadSnapshotRawKey:   string(envelope.Payload),
+			payloadSnapshotErrorKey: err.Error(),
+		}, err
 	}
 	if payload == nil {
 		return map[string]any{}, nil
 	}
 	return payload, nil
+}
+
+func isCompletedLifecycleOperation(operation model.DeviceOperation) bool {
+	switch operation.Status {
+	case model.DeviceOperationStatusSucceeded, model.DeviceOperationStatusFailed:
+		return operation.OperationType == model.DeviceOperationTypeProvision || operation.OperationType == model.DeviceOperationTypeDeactivate
+	default:
+		return false
+	}
 }
 
 func projectionPtr(projection store.DeviceProjectionInput) *store.DeviceProjectionInput {

--- a/internal/worker/inbox/service_test.go
+++ b/internal/worker/inbox/service_test.go
@@ -15,11 +15,13 @@ import (
 
 type fakeStore struct {
 	message       model.DeviceMessageInbox
+	operation     model.DeviceOperation
 	created       bool
 	createInputs  []store.DeviceMessageInboxCreateInput
 	transitions   []store.InboxProcessTransitionInput
 	createErr     error
 	transitionErr error
+	operationErr  error
 }
 
 func (s *fakeStore) CreateOrGetInboxMessage(_ context.Context, in store.DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error) {
@@ -49,6 +51,19 @@ func (s *fakeStore) RecordInboxProcessTransition(_ context.Context, in store.Inb
 	}
 	s.transitions = append(s.transitions, in)
 	return store.InboxProcessTransitionResult{}, nil
+}
+
+func (s *fakeStore) GetDeviceOperation(_ context.Context, operationID string) (model.DeviceOperation, error) {
+	if s.operationErr != nil {
+		return model.DeviceOperation{}, s.operationErr
+	}
+	if s.operation.OperationID == "" {
+		return model.DeviceOperation{}, store.ErrNotFound
+	}
+	if s.operation.OperationID != operationID {
+		return model.DeviceOperation{}, store.ErrNotFound
+	}
+	return s.operation, nil
 }
 
 type fakeConsumer struct {
@@ -143,6 +158,44 @@ func TestRunOnceSkipsPreviouslyProcessedDuplicates(t *testing.T) {
 	}
 	if len(inboxStore.transitions) != 0 {
 		t.Fatalf("expected no transitions, got %d", len(inboxStore.transitions))
+	}
+}
+
+func TestRunOnceSkipsCompletedLifecycleReplayWithNewMessageID(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{
+		created: true,
+		operation: model.DeviceOperation{
+			OperationID:   "op-1",
+			OperationType: model.DeviceOperationTypeProvision,
+			Status:        model.DeviceOperationStatusSucceeded,
+		},
+	}
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{validProvisionSucceededMessage(now)},
+	}, Options{
+		Now: func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Processed != 1 || stats.DeadLettered != 0 || stats.Retrying != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if len(inboxStore.transitions) != 1 {
+		t.Fatalf("expected one transition, got %d", len(inboxStore.transitions))
+	}
+	transition := inboxStore.transitions[0]
+	if transition.MessageStatus != model.DeviceMessageInboxStatusProcessed {
+		t.Fatalf("expected replay inbox row to be marked processed, got %s", transition.MessageStatus)
+	}
+	if transition.OperationStatus != nil {
+		t.Fatalf("expected completed operation replay to skip operation update, got %+v", transition.OperationStatus)
+	}
+	if transition.Projection != nil {
+		t.Fatalf("expected completed operation replay to skip device projection, got %+v", transition.Projection)
 	}
 }
 
@@ -375,8 +428,12 @@ func TestRunOnceDeadLettersMalformedAndUnmappedMessages(t *testing.T) {
 			},
 			assertion: func(t *testing.T, inboxStore *fakeStore) {
 				t.Helper()
-				if got := inboxStore.createInputs[0].Payload; len(got) != 0 {
-					t.Fatalf("expected malformed payload to persist as empty map, got %+v", got)
+				got := inboxStore.createInputs[0].Payload
+				if got[payloadSnapshotRawKey] != "{not-json" {
+					t.Fatalf("expected raw malformed payload to be preserved, got %+v", got)
+				}
+				if got[payloadSnapshotErrorKey] == nil {
+					t.Fatalf("expected payload decode error metadata, got %+v", got)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- guard inbox lifecycle replays by `operation_id` once the original provision/deactivate result has already completed
- preserve malformed raw payload bytes and decode errors in persisted inbox rows for dead-letter inspection
- add inbox worker and store coverage for both follow-up behaviors

## Validation
- `go test ./internal/worker/inbox -count=1`
- `go test ./internal/store -count=1`
- `go test ./... -count=1`
- `go build ./...`

Refs #8
