### PR TITLE
[Worker] Refine inbox replay guards

### DIFF
--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"os"
 	"testing"
@@ -1143,6 +1144,7 @@ func TestCreateOrGetInboxMessagePreservesDeadLetterPayloadSnapshot(t *testing.T)
 		PartitionKey:  deviceID,
 		Payload: map[string]any{
 			"_raw_payload":          "{not-json",
+			"_raw_payload_base64":   base64.StdEncoding.EncodeToString([]byte("{not-json")),
 			"_payload_decode_error": "invalid character 'n' looking for beginning of object key string",
 		},
 		Status:       model.DeviceMessageInboxStatusDeadLettered,
@@ -1164,6 +1166,9 @@ func TestCreateOrGetInboxMessagePreservesDeadLetterPayloadSnapshot(t *testing.T)
 	}
 	if got := stored.Payload["_raw_payload"]; got != "{not-json" {
 		t.Fatalf("expected raw payload snapshot, got %+v", stored.Payload)
+	}
+	if got := stored.Payload["_raw_payload_base64"]; got != base64.StdEncoding.EncodeToString([]byte("{not-json")) {
+		t.Fatalf("expected raw payload bytes snapshot, got %+v", stored.Payload)
 	}
 	if got := stored.Payload["_payload_decode_error"]; got == nil {
 		t.Fatalf("expected payload decode error snapshot, got %+v", stored.Payload)

--- a/internal/worker/inbox/service.go
+++ b/internal/worker/inbox/service.go
@@ -2,10 +2,12 @@ package inbox
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"rtk_account_manager/internal/broker"
 	"rtk_account_manager/internal/channel"
@@ -50,8 +52,9 @@ type Stats struct {
 var transitionForPayloadFunc = buildTransitionForPayload
 
 const (
-	payloadSnapshotRawKey   = "_raw_payload"
-	payloadSnapshotErrorKey = "_payload_decode_error"
+	payloadSnapshotRawKey    = "_raw_payload"
+	payloadSnapshotBase64Key = "_raw_payload_base64"
+	payloadSnapshotErrorKey  = "_payload_decode_error"
 )
 
 func NewService(store messageStore, consumer broker.Consumer, opts Options) *Service {
@@ -378,10 +381,14 @@ func payloadMapFromEnvelope(envelope channel.Envelope) (map[string]any, error) {
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
-		return map[string]any{
-			payloadSnapshotRawKey:   string(envelope.Payload),
-			payloadSnapshotErrorKey: err.Error(),
-		}, err
+		snapshot := map[string]any{
+			payloadSnapshotBase64Key: base64.StdEncoding.EncodeToString(envelope.Payload),
+			payloadSnapshotErrorKey:  err.Error(),
+		}
+		if utf8.Valid(envelope.Payload) {
+			snapshot[payloadSnapshotRawKey] = string(envelope.Payload)
+		}
+		return snapshot, err
 	}
 	if payload == nil {
 		return map[string]any{}, nil

--- a/internal/worker/inbox/service.go
+++ b/internal/worker/inbox/service.go
@@ -199,7 +199,7 @@ func (s *Service) processMessage(ctx context.Context, record broker.Message) (mo
 		return model.DeviceMessageInboxStatusDeadLettered, s.recordDeadLetter(ctx, message, attemptCount, err)
 	}
 
-	if created {
+	if transition.OperationStatus != nil {
 		operation, err := s.store.GetDeviceOperation(ctx, message.OperationID)
 		switch {
 		case err == nil:

--- a/internal/worker/inbox/service_test.go
+++ b/internal/worker/inbox/service_test.go
@@ -200,6 +200,94 @@ func TestRunOnceSkipsCompletedLifecycleReplayWithNewMessageID(t *testing.T) {
 	}
 }
 
+func TestRunOnceProcessesOnlineProjectionWhenOperationAlreadyCompleted(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{
+		created: true,
+		operation: model.DeviceOperation{
+			OperationID:   "op-1",
+			OperationType: model.DeviceOperationTypeProvision,
+			Status:        model.DeviceOperationStatusSucceeded,
+		},
+	}
+	message := eventMessage(t, "msg-online-replay", channel.MessageTypeDeviceOnlineChanged, now, channel.DeviceOnlineChangedPayload{
+		OrgID:           "00000000-0000-0000-0000-000000000001",
+		AccountDeviceID: "11111111-1111-1111-1111-111111111111",
+		VideoCloudDevid: "video-1",
+		Status:          "online",
+		LastSeenAt:      now,
+	})
+	message.Envelope.OperationID = "op-1"
+
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{message},
+	}, Options{
+		Now: func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Processed != 1 || stats.DeadLettered != 0 || stats.Retrying != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if len(inboxStore.transitions) != 1 {
+		t.Fatalf("expected one transition, got %d", len(inboxStore.transitions))
+	}
+	transition := inboxStore.transitions[0]
+	if transition.OperationStatus != nil {
+		t.Fatalf("expected online projection to skip operation updates, got %+v", transition.OperationStatus)
+	}
+	if transition.Projection == nil {
+		t.Fatal("expected online projection to be applied")
+	}
+}
+
+func TestRunOnceSkipsCompletedLifecycleReplayForRetryingMessage(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{
+		created: false,
+		message: model.DeviceMessageInbox{
+			MessageID:    "msg-1",
+			OperationID:  "op-1",
+			Status:       model.DeviceMessageInboxStatusRetrying,
+			AttemptCount: 1,
+		},
+		operation: model.DeviceOperation{
+			OperationID:   "op-1",
+			OperationType: model.DeviceOperationTypeProvision,
+			Status:        model.DeviceOperationStatusSucceeded,
+		},
+	}
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{validProvisionSucceededMessage(now)},
+	}, Options{
+		Now: func() time.Time { return now },
+	})
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Processed != 1 || stats.DeadLettered != 0 || stats.Retrying != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if len(inboxStore.transitions) != 1 {
+		t.Fatalf("expected one transition, got %d", len(inboxStore.transitions))
+	}
+	transition := inboxStore.transitions[0]
+	if transition.MessageStatus != model.DeviceMessageInboxStatusProcessed {
+		t.Fatalf("expected retrying replay inbox row to be marked processed, got %s", transition.MessageStatus)
+	}
+	if transition.OperationStatus != nil {
+		t.Fatalf("expected completed operation replay to skip operation update, got %+v", transition.OperationStatus)
+	}
+	if transition.Projection != nil {
+		t.Fatalf("expected completed operation replay to skip device projection, got %+v", transition.Projection)
+	}
+}
+
 func TestRunOnceDeadLettersInvalidMessages(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	message := validProvisionSucceededMessage(now)

--- a/internal/worker/inbox/service_test.go
+++ b/internal/worker/inbox/service_test.go
@@ -2,6 +2,7 @@ package inbox
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -431,6 +432,40 @@ func TestRunOnceDeadLettersMalformedAndUnmappedMessages(t *testing.T) {
 				got := inboxStore.createInputs[0].Payload
 				if got[payloadSnapshotRawKey] != "{not-json" {
 					t.Fatalf("expected raw malformed payload to be preserved, got %+v", got)
+				}
+				if got[payloadSnapshotBase64Key] != base64.StdEncoding.EncodeToString([]byte("{not-json")) {
+					t.Fatalf("expected raw malformed payload bytes to be preserved, got %+v", got)
+				}
+				if got[payloadSnapshotErrorKey] == nil {
+					t.Fatalf("expected payload decode error metadata, got %+v", got)
+				}
+			},
+		},
+		{
+			name: "malformed payload with invalid utf-8 keeps exact bytes",
+			message: broker.Message{
+				Stream: channel.StreamVideoAccountEvents,
+				Envelope: channel.Envelope{
+					MessageID:     "msg-invalid-utf8",
+					CorrelationID: "corr-invalid-utf8",
+					OperationID:   "op-invalid-utf8",
+					SourceService: channel.ServiceRealtekVideoCloud,
+					TargetService: channel.ServiceAccountManager,
+					MessageType:   channel.MessageTypeDeviceProvisionSucceeded,
+					SchemaVersion: channel.SchemaVersionV1,
+					PartitionKey:  "11111111-1111-1111-1111-111111111111",
+					OccurredAt:    now,
+					Payload:       []byte{0xff, 0xfe, '{', 'b', 'a', 'd', '}'},
+				},
+			},
+			assertion: func(t *testing.T, inboxStore *fakeStore) {
+				t.Helper()
+				got := inboxStore.createInputs[0].Payload
+				if _, ok := got[payloadSnapshotRawKey]; ok {
+					t.Fatalf("expected lossy raw payload string to be omitted for invalid utf-8, got %+v", got)
+				}
+				if got[payloadSnapshotBase64Key] != base64.StdEncoding.EncodeToString([]byte{0xff, 0xfe, '{', 'b', 'a', 'd', '}'}) {
+					t.Fatalf("expected exact malformed payload bytes to be preserved, got %+v", got)
 				}
 				if got[payloadSnapshotErrorKey] == nil {
 					t.Fatalf("expected payload decode error metadata, got %+v", got)


### PR DESCRIPTION
## Summary
- preserve exact malformed inbox payload bytes via `_raw_payload_base64` while keeping `_raw_payload` only for valid UTF-8 snapshots
- narrow the completed-operation replay guard so it only suppresses lifecycle result messages that would mutate terminal operation state
- extend the guard to existing `retrying` inbox rows so stale lifecycle replays cannot reapply a completed transition

## Validation
- `go test ./internal/worker/inbox -count=1`
- `go test ./... -count=1`
- `go build ./...`

## Notes
- the earlier PR #28 merged at commit `2bd174d` before these follow-up fixes landed, so this PR carries the residual issue #8 scope on top of that merged base
- a Postgres-backed local run for `TestCreateOrGetInboxMessagePreservesDeadLetterPayloadSnapshot` still is not available in this workspace because nothing is listening on `localhost:5432`

Refs #8
