### PR TITLE
[Docs] Align current v2 lifecycle docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Backend account and device manager for organization-scoped users and registry-on
 The API listens on `http://localhost:8080` by default. The OpenAPI contract is in `openapi.yaml`.
 List endpoints accept `limit` and `offset` query parameters and return pagination metadata.
 Testing policy and report maintenance are documented in `docs/TESTING.md`.
-Provisioning and account/video EventHub-style integration are planned in `docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md` and aligned with the `contracts/` submodule.
+The current v2 provisioning and account/video event-channel surface is documented in `docs/SPEC.md`; rollout tracking and dependency history live in `docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md`.
+The implementation stays aligned with the `contracts/` submodule for provisioning and cross-service channel boundaries.
 The local provisioning and worker flow, including the `log` broker adapter runbook, is documented in `docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md`.
 Set `CROSS_SERVICE_BROKER=azure_eventhubs` plus `AZURE_EVENTHUB_CONNECTION_STRING` to run the workers against Azure Event Hubs instead of the local `log` adapter. The inbox worker persists Azure consumer checkpoints under `.state/azure_eventhubs/` by default; set `AZURE_EVENTHUB_CHECKPOINT_FILE` to override that path.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -6,7 +6,7 @@ Build a backend account and device manager similar in spirit to Amazon IoT Devic
 
 The v1 service is a REST API backend only. It stores account and device state in Postgres and provides authentication, organization membership, role-based authorization, and registry-only device management.
 
-Provisioning and account/video EventHub-style integration are the v2 scope. The implementation plan is maintained in [PROVISIONING_AND_EVENT_CHANNEL_PLAN.md](PROVISIONING_AND_EVENT_CHANNEL_PLAN.md) and must stay aligned with the shared contracts in `contracts/PROVISION.md` and `contracts/CROSS_SERVICE_CHANNEL.md`.
+Provisioning and account/video event-channel integration are the v2 surface implemented by this repository. [PROVISIONING_AND_EVENT_CHANNEL_PLAN.md](PROVISIONING_AND_EVENT_CHANNEL_PLAN.md) tracks rollout history and verification status, and this spec must stay aligned with the shared contracts in `contracts/PROVISION.md` and `contracts/CROSS_SERVICE_CHANNEL.md`.
 
 ## 2. V1 Scope
 
@@ -395,15 +395,54 @@ Provision request body:
 }
 ```
 
-Provision/deactivation response body:
+Deactivation request body:
+
+```json
+{
+  "reason": "user_request",
+  "operation_id": "optional-client-idempotency-key"
+}
+```
+
+Operation response body for `POST .../provision` and `POST .../deactivate`:
 
 ```json
 {
   "operation": {
     "operation_id": "op-01H...",
-    "status": "pending",
+    "correlation_id": "op-01H...",
+    "message_id": "msg-01H...",
     "device_id": "account-device-uuid",
-    "message_id": "msg-01H..."
+    "operation_type": "provision",
+    "status": "pending",
+    "requested_by": "user-uuid",
+    "created_at": "2026-04-29T04:00:00Z",
+    "updated_at": "2026-04-29T04:00:00Z"
+  }
+}
+```
+
+Provisioning-state response body for `GET .../provisioning`:
+
+```json
+{
+  "operation": {
+    "operation_id": "op-01H...",
+    "correlation_id": "op-01H...",
+    "message_id": "msg-01H...",
+    "device_id": "account-device-uuid",
+    "operation_type": "provision",
+    "status": "succeeded",
+    "requested_by": "user-uuid",
+    "created_at": "2026-04-29T04:00:00Z",
+    "updated_at": "2026-04-29T04:01:30Z",
+    "completed_at": "2026-04-29T04:01:30Z"
+  },
+  "video_metadata": {
+    "video_cloud_devid": "device-1",
+    "video_cloud_activation_status": "activated",
+    "video_cloud_activity_id": "activity-1",
+    "video_cloud_activated_at": "2026-04-29T04:01:30Z"
   }
 }
 ```
@@ -415,6 +454,9 @@ Provisioning rules:
 - The API must not directly call Realtek video server.
 - Product-level deactivation and account registry soft-delete are distinct operations.
 - `DELETE /devices/:deviceId` remains account-registry soft-disable unless product policy explicitly changes it later.
+- Omitting the deactivation `reason` defaults the outbox payload to `account_device_disabled`.
+- Reusing an explicit `operation_id` returns the existing operation when the normalized request matches and returns `409 Conflict` when it does not.
+- Operation responses may also include `error_code`, `error_message`, `retryable`, and `completed_at` once the inbox projection records a terminal result.
 - `DeviceProvisionSucceeded` sets video activation metadata but does not set account-manager `status=online`.
 - `DeviceOnlineChanged` is the only video-side event that may project account-manager `status=online|offline`.
 


### PR DESCRIPTION
## Summary
- update `docs/SPEC.md` so the documented lifecycle APIs match the current implemented request/response surface
- document the deactivation request shape, provisioning-state response shape, and idempotent/defaulted lifecycle API rules
- remove stale README wording that still described the v2 provisioning/event-channel flow as only planned

## Validation
- `git diff --check`

Refs #1