### PR TITLE
[DB] Guard device message persistence boundaries

### DIFF
--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -175,6 +175,9 @@ func (s *Store) CreateOutboxMessage(ctx context.Context, in DeviceMessageOutboxC
 	if err != nil {
 		return model.DeviceMessageOutbox{}, err
 	}
+	if err := s.validatePartitionKeyMatchesOperation(ctx, in.OperationID, in.PartitionKey); err != nil && !errors.Is(err, ErrNotFound) {
+		return model.DeviceMessageOutbox{}, err
+	}
 
 	message, err := scanDeviceMessageOutbox(s.db.QueryRow(ctx, `
 		INSERT INTO device_message_outbox (
@@ -302,6 +305,9 @@ func (s *Store) CreateOrGetInboxMessage(ctx context.Context, in DeviceMessageInb
 	if err != nil {
 		return model.DeviceMessageInbox{}, false, err
 	}
+	if err := s.validatePartitionKeyMatchesOperation(ctx, in.OperationID, in.PartitionKey); err != nil && !errors.Is(err, ErrNotFound) {
+		return model.DeviceMessageInbox{}, false, err
+	}
 
 	row := s.db.QueryRow(ctx, `
 		INSERT INTO device_message_inbox (
@@ -391,6 +397,25 @@ func compareInboxCreate(existing model.DeviceMessageInbox, in DeviceMessageInbox
 		existing.SchemaVersion != in.SchemaVersion ||
 		existing.PartitionKey != in.PartitionKey ||
 		!sameJSONMap(existing.Payload, payload) {
+		return ErrConflict
+	}
+	return nil
+}
+
+func (s *Store) validatePartitionKeyMatchesOperation(ctx context.Context, operationID, partitionKey string) error {
+	var deviceID string
+	err := s.db.QueryRow(ctx, `
+		SELECT device_id::text
+		FROM device_operations
+		WHERE operation_id = $1
+	`, operationID).Scan(&deviceID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if deviceID != partitionKey {
 		return ErrConflict
 	}
 	return nil

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -55,9 +55,15 @@ func newStoreIntegrationEnv(t *testing.T) storeIntegrationEnv {
 func createDeviceFixture(t *testing.T, env storeIntegrationEnv) (string, string, string) {
 	t.Helper()
 
+	return createDeviceFixtureForEmail(t, env, "owner@example.com")
+}
+
+func createDeviceFixtureForEmail(t *testing.T, env storeIntegrationEnv, email string) (string, string, string) {
+	t.Helper()
+
 	ctx := context.Background()
 	registered, err := env.store.Register(ctx, RegisterInput{
-		Email:            "owner@example.com",
+		Email:            email,
 		PasswordHash:     "hash",
 		OrganizationName: "Owner Org",
 	})
@@ -190,6 +196,25 @@ func TestCreateOrGetDeviceOperationIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestCreateOrGetDeviceOperationRejectsMismatchedDeviceOrganization(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, _ := createDeviceFixtureForEmail(t, env, "owner-one@example.com")
+	_, _, otherDeviceID := createDeviceFixtureForEmail(t, env, "owner-two@example.com")
+
+	ctx := context.Background()
+	_, _, err := env.store.CreateOrGetDeviceOperation(ctx, DeviceOperationCreateInput{
+		OperationID:    "op-org-mismatch",
+		CorrelationID:  "corr-org-mismatch",
+		OrganizationID: orgID,
+		DeviceID:       otherDeviceID,
+		OperationType:  model.DeviceOperationTypeProvision,
+		Status:         model.DeviceOperationStatusPending,
+		RequestedBy:    &userID,
+		RequestPayload: map[string]any{"video_cloud_devid": "device-1"},
+	})
+	requirePGErrorCode(t, err, "23503")
+}
+
 func TestDeviceMessagePersistenceRejectsInvalidSchemaValues(t *testing.T) {
 	env := newStoreIntegrationEnv(t)
 	orgID, userID, deviceID := createDeviceFixture(t, env)
@@ -250,6 +275,22 @@ func TestDeviceMessagePersistenceRejectsInvalidSchemaValues(t *testing.T) {
 	})
 	requirePGErrorCode(t, err, "23514")
 
+	_, err = env.store.CreateOutboxMessage(ctx, DeviceMessageOutboxCreateInput{
+		MessageID:     "wrong-device-partition-key",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "account.video.commands",
+		MessageType:   "DeviceProvisionRequested",
+		SchemaVersion: "1.0",
+		PartitionKey:  "device-other",
+		Payload:       map[string]any{"operation_id": op.OperationID},
+		Status:        model.DeviceMessageOutboxStatusPending,
+		AvailableAt:   now,
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected outbox partition-key conflict, got %v", err)
+	}
+
 	_, _, err = env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
 		MessageID:     "invalid-inbox-type",
 		OperationID:   op.OperationID,
@@ -263,6 +304,22 @@ func TestDeviceMessagePersistenceRejectsInvalidSchemaValues(t *testing.T) {
 		ReceivedAt:    now,
 	})
 	requirePGErrorCode(t, err, "23514")
+
+	_, _, err = env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "wrong-inbox-partition-key",
+		OperationID:   op.OperationID,
+		CorrelationID: op.CorrelationID,
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  "device-other",
+		Payload:       map[string]any{"video_cloud_devid": "device-1"},
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		ReceivedAt:    now,
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected inbox partition-key conflict, got %v", err)
+	}
 }
 
 func TestOutboxMessagePersistenceAndReadyList(t *testing.T) {

--- a/migrations/007_device_message_integrity_guards.sql
+++ b/migrations/007_device_message_integrity_guards.sql
@@ -1,0 +1,20 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'devices_org_id_unique'
+    ) THEN
+        ALTER TABLE devices
+            ADD CONSTRAINT devices_org_id_unique
+            UNIQUE (organization_id, id);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'device_operations_org_device_fkey'
+    ) THEN
+        ALTER TABLE device_operations
+            ADD CONSTRAINT device_operations_org_device_fkey
+            FOREIGN KEY (organization_id, device_id)
+            REFERENCES devices (organization_id, id)
+            ON DELETE CASCADE;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a migration that enforces `(organization_id, device_id)` ownership for `device_operations`
- validate outbox and inbox lifecycle `partition_key` values against the referenced operation device
- add focused store regressions for org/device mismatch and partition-key mismatch cases

## Validation
- `go test ./internal/store -count=1`
- `go test ./... -count=1`
- Postgres-backed integration regressions are present in `internal/store/device_messages_integration_test.go`, but they skip locally here because `TEST_DATABASE_URL` is not set

Refs #3