### PR TITLE
[Worker] Keep legacy inbox payload snapshots compatible

### DIFF
--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -3,9 +3,12 @@ package store
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -78,6 +81,12 @@ type DeviceMessageInboxCreateInput struct {
 	ReceivedAt    time.Time
 	ProcessedAt   *time.Time
 }
+
+const (
+	inboxPayloadSnapshotRawKey    = "_raw_payload"
+	inboxPayloadSnapshotBase64Key = "_raw_payload_base64"
+	inboxPayloadSnapshotErrorKey  = "_payload_decode_error"
+)
 
 type DeviceMessageInboxUpdateInput struct {
 	Status       model.DeviceMessageInboxStatus
@@ -396,7 +405,7 @@ func compareInboxCreate(existing model.DeviceMessageInbox, in DeviceMessageInbox
 		existing.MessageType != in.MessageType ||
 		existing.SchemaVersion != in.SchemaVersion ||
 		existing.PartitionKey != in.PartitionKey ||
-		!sameJSONMap(existing.Payload, payload) {
+		!sameInboxPayload(existing.Payload, payload) {
 		return ErrConflict
 	}
 	return nil
@@ -434,6 +443,82 @@ func sameJSONMap(existing map[string]any, want []byte) bool {
 		return false
 	}
 	return bytes.Equal(got, want)
+}
+
+func sameInboxPayload(existing map[string]any, want []byte) bool {
+	if sameJSONMap(existing, want) {
+		return true
+	}
+
+	decoded, err := unmarshalJSONMap(want)
+	if err != nil {
+		return false
+	}
+
+	return sameLegacyMalformedInboxPayload(existing, decoded)
+}
+
+func sameLegacyMalformedInboxPayload(existing, want map[string]any) bool {
+	if !hasOnlyJSONKeys(existing, inboxPayloadSnapshotRawKey, inboxPayloadSnapshotErrorKey) {
+		return false
+	}
+	if !hasOnlyJSONKeys(want, inboxPayloadSnapshotRawKey, inboxPayloadSnapshotBase64Key, inboxPayloadSnapshotErrorKey) &&
+		!hasOnlyJSONKeys(want, inboxPayloadSnapshotBase64Key, inboxPayloadSnapshotErrorKey) {
+		return false
+	}
+
+	existingRaw, ok := jsonStringValue(existing, inboxPayloadSnapshotRawKey)
+	if !ok {
+		return false
+	}
+	existingError, ok := jsonStringValue(existing, inboxPayloadSnapshotErrorKey)
+	if !ok {
+		return false
+	}
+	wantError, ok := jsonStringValue(want, inboxPayloadSnapshotErrorKey)
+	if !ok || wantError != existingError {
+		return false
+	}
+
+	if wantRaw, ok := jsonStringValue(want, inboxPayloadSnapshotRawKey); ok {
+		return wantRaw == existingRaw
+	}
+
+	wantBase64, ok := jsonStringValue(want, inboxPayloadSnapshotBase64Key)
+	if !ok {
+		return false
+	}
+	payloadBytes, err := base64.StdEncoding.DecodeString(wantBase64)
+	if err != nil {
+		return false
+	}
+
+	return strings.ToValidUTF8(string(payloadBytes), string(utf8.RuneError)) == existingRaw
+}
+
+func hasOnlyJSONKeys(value map[string]any, allowed ...string) bool {
+	if len(value) != len(allowed) {
+		return false
+	}
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		allowedSet[key] = struct{}{}
+	}
+	for key := range value {
+		if _, ok := allowedSet[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func jsonStringValue(value map[string]any, key string) (string, bool) {
+	raw, ok := value[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := raw.(string)
+	return text, ok
 }
 
 func marshalJSONMap(value map[string]any) ([]byte, error) {

--- a/internal/store/device_messages_test.go
+++ b/internal/store/device_messages_test.go
@@ -1,9 +1,12 @@
 package store
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"rtk_account_manager/internal/model"
 )
@@ -77,6 +80,76 @@ func TestCompareOperationCreate(t *testing.T) {
 		OperationType:  model.DeviceOperationTypeProvision,
 	}, differentPayload); !errors.Is(err, ErrConflict) {
 		t.Fatalf("expected payload mismatch to conflict, got %v", err)
+	}
+}
+
+func TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshot(t *testing.T) {
+	existing := model.DeviceMessageInbox{
+		OperationID:   "op-1",
+		CorrelationID: "corr-1",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  "device-1",
+		Payload: map[string]any{
+			inboxPayloadSnapshotRawKey:   "{not-json",
+			inboxPayloadSnapshotErrorKey: "invalid character 'n' looking for beginning of object key string",
+		},
+	}
+
+	wantPayload, err := json.Marshal(map[string]any{
+		inboxPayloadSnapshotRawKey:    "{not-json",
+		inboxPayloadSnapshotBase64Key: base64.StdEncoding.EncodeToString([]byte("{not-json")),
+		inboxPayloadSnapshotErrorKey:  "invalid character 'n' looking for beginning of object key string",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compareInboxCreate(existing, DeviceMessageInboxCreateInput{
+		OperationID:   "op-1",
+		CorrelationID: "corr-1",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  "device-1",
+	}, wantPayload); err != nil {
+		t.Fatalf("expected legacy malformed payload snapshot to match, got %v", err)
+	}
+}
+
+func TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshotWithLossyUTF8(t *testing.T) {
+	legacyBytes := []byte{0xff, 0xfe, '{', 'b', 'a', 'd', '}'}
+	existing := model.DeviceMessageInbox{
+		OperationID:   "op-1",
+		CorrelationID: "corr-1",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  "device-1",
+		Payload: map[string]any{
+			inboxPayloadSnapshotRawKey:   strings.ToValidUTF8(string(legacyBytes), string(utf8.RuneError)),
+			inboxPayloadSnapshotErrorKey: "invalid character 'ÿ' looking for beginning of value",
+		},
+	}
+
+	wantPayload, err := json.Marshal(map[string]any{
+		inboxPayloadSnapshotBase64Key: base64.StdEncoding.EncodeToString(legacyBytes),
+		inboxPayloadSnapshotErrorKey:  "invalid character 'ÿ' looking for beginning of value",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compareInboxCreate(existing, DeviceMessageInboxCreateInput{
+		OperationID:   "op-1",
+		CorrelationID: "corr-1",
+		Stream:        "video.account.events",
+		MessageType:   "DeviceProvisionSucceeded",
+		SchemaVersion: "1.0",
+		PartitionKey:  "device-1",
+	}, wantPayload); err != nil {
+		t.Fatalf("expected legacy lossy UTF-8 payload snapshot to match, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep `CreateOrGetInboxMessage` compatible with malformed inbox rows written before `_raw_payload_base64` existed
- accept both the older UTF-8 raw snapshot shape and the lossy invalid-UTF-8 legacy shape when the new replay payload only adds the newer base64 bytes snapshot
- add focused store regressions for both legacy replay paths so duplicate dead-letter deliveries do not fail with `ErrConflict`

## Validation
- `go test ./internal/store -run 'TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshot|TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshotWithLossyUTF8|TestJSONHelpers' -count=1`
- `go test ./internal/store ./internal/worker/inbox -count=1`
- `go build ./...`
- `go test ./... -count=1`

Refs #8
