### PR TITLE
[DB] Keep malformed inbox partition keys dead-letterable

### DIFF
--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -403,6 +404,10 @@ func compareInboxCreate(existing model.DeviceMessageInbox, in DeviceMessageInbox
 }
 
 func (s *Store) validatePartitionKeyMatchesOperation(ctx context.Context, operationID, partitionKey string) error {
+	if strings.TrimSpace(partitionKey) == "" {
+		return nil
+	}
+
 	var deviceID string
 	err := s.db.QueryRow(ctx, `
 		SELECT device_id::text

--- a/internal/store/device_messages.go
+++ b/internal/store/device_messages.go
@@ -306,9 +306,6 @@ func (s *Store) CreateOrGetInboxMessage(ctx context.Context, in DeviceMessageInb
 	if err != nil {
 		return model.DeviceMessageInbox{}, false, err
 	}
-	if err := s.validatePartitionKeyMatchesOperation(ctx, in.OperationID, in.PartitionKey); err != nil && !errors.Is(err, ErrNotFound) {
-		return model.DeviceMessageInbox{}, false, err
-	}
 
 	row := s.db.QueryRow(ctx, `
 		INSERT INTO device_message_inbox (

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -305,7 +305,7 @@ func TestDeviceMessagePersistenceRejectsInvalidSchemaValues(t *testing.T) {
 	})
 	requirePGErrorCode(t, err, "23514")
 
-	_, _, err = env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+	inboxMessage, created, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
 		MessageID:     "wrong-inbox-partition-key",
 		OperationID:   op.OperationID,
 		CorrelationID: op.CorrelationID,
@@ -317,8 +317,14 @@ func TestDeviceMessagePersistenceRejectsInvalidSchemaValues(t *testing.T) {
 		Status:        model.DeviceMessageInboxStatusRetrying,
 		ReceivedAt:    now,
 	})
-	if !errors.Is(err, ErrConflict) {
-		t.Fatalf("expected inbox partition-key conflict, got %v", err)
+	if err != nil {
+		t.Fatalf("expected inbox partition-key mismatch to remain persistable for dead-lettering, got %v", err)
+	}
+	if !created {
+		t.Fatal("expected inbox partition-key mismatch to create a row")
+	}
+	if inboxMessage.PartitionKey != "device-other" {
+		t.Fatalf("expected inbox partition key to preserve malformed value, got %q", inboxMessage.PartitionKey)
 	}
 }
 

--- a/internal/worker/inbox/service.go
+++ b/internal/worker/inbox/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -52,9 +53,10 @@ type Stats struct {
 var transitionForPayloadFunc = buildTransitionForPayload
 
 const (
-	payloadSnapshotRawKey    = "_raw_payload"
-	payloadSnapshotBase64Key = "_raw_payload_base64"
-	payloadSnapshotErrorKey  = "_payload_decode_error"
+	payloadSnapshotRawKey               = "_raw_payload"
+	payloadSnapshotBase64Key            = "_raw_payload_base64"
+	payloadSnapshotErrorKey             = "_payload_decode_error"
+	payloadSnapshotEnvelopePartitionKey = "_envelope_partition_key"
 )
 
 func NewService(store messageStore, consumer broker.Consumer, opts Options) *Service {
@@ -155,7 +157,7 @@ func (s *Service) processMessage(ctx context.Context, record broker.Message) (mo
 	receivedAt := s.receivedAt(record.Envelope)
 	payloadMap, payloadErr := payloadMapFromEnvelope(record.Envelope)
 
-	message, created, err := s.store.CreateOrGetInboxMessage(ctx, store.DeviceMessageInboxCreateInput{
+	message, created, err := s.createInboxMessage(ctx, store.DeviceMessageInboxCreateInput{
 		MessageID:     record.Envelope.MessageID,
 		OperationID:   record.Envelope.OperationID,
 		CorrelationID: record.Envelope.CorrelationID,
@@ -225,6 +227,21 @@ func (s *Service) processMessage(ctx context.Context, record broker.Message) (mo
 		return "", err
 	}
 	return model.DeviceMessageInboxStatusProcessed, nil
+}
+
+func (s *Service) createInboxMessage(ctx context.Context, in store.DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error) {
+	if strings.TrimSpace(in.PartitionKey) == "" {
+		originalPartitionKey := in.PartitionKey
+		operation, err := s.store.GetDeviceOperation(ctx, in.OperationID)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return model.DeviceMessageInbox{}, false, err
+		}
+		if err == nil {
+			in.PartitionKey = operation.DeviceID
+			in.Payload = withEnvelopePartitionKeySnapshot(in.Payload, originalPartitionKey, in.PartitionKey)
+		}
+	}
+	return s.store.CreateOrGetInboxMessage(ctx, in)
 }
 
 func (s *Service) markProcessedWithoutProjection(ctx context.Context, message model.DeviceMessageInbox, attemptCount int) error {
@@ -397,6 +414,28 @@ func payloadMapFromEnvelope(envelope channel.Envelope) (map[string]any, error) {
 		return map[string]any{}, nil
 	}
 	return payload, nil
+}
+
+func withEnvelopePartitionKeySnapshot(payload map[string]any, originalPartitionKey, persistedPartitionKey string) map[string]any {
+	if originalPartitionKey == persistedPartitionKey {
+		return payload
+	}
+
+	snapshot := clonePayloadMap(payload)
+	snapshot[payloadSnapshotEnvelopePartitionKey] = originalPartitionKey
+	return snapshot
+}
+
+func clonePayloadMap(payload map[string]any) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+
+	cloned := make(map[string]any, len(payload))
+	for key, value := range payload {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func isCompletedLifecycleOperation(operation model.DeviceOperation) bool {

--- a/internal/worker/inbox/service_test.go
+++ b/internal/worker/inbox/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -630,6 +631,92 @@ func TestRunOnceDeadLettersMalformedAndUnmappedMessages(t *testing.T) {
 				t.Fatalf("expected dead-lettered status, got %s", got)
 			}
 			tc.assertion(t, inboxStore)
+		})
+	}
+}
+
+func TestRunOnceDeadLettersInvalidPartitionKeysAfterPersistingInboxRow(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	deviceID := "11111111-1111-1111-1111-111111111111"
+	tests := []struct {
+		name              string
+		message           broker.Message
+		store             *fakeStore
+		wantPartitionKey  string
+		wantSnapshotValue any
+		wantErrorFragment string
+	}{
+		{
+			name: "nonblank mismatched partition key dead-letters",
+			message: eventMessage(t, "msg-mismatch", channel.MessageTypeDeviceMetadataChanged, now, channel.DeviceMetadataChangedPayload{
+				OrgID:           "00000000-0000-0000-0000-000000000001",
+				AccountDeviceID: deviceID,
+				VideoCloudDevid: "video-1",
+				Metadata:        map[string]any{},
+			}),
+			store:             &fakeStore{created: true},
+			wantPartitionKey:  "22222222-2222-2222-2222-222222222222",
+			wantSnapshotValue: nil,
+			wantErrorFragment: "partition_key must equal payload.account_device_id",
+		},
+		{
+			name: "blank partition key is normalized for storage and dead-lettered",
+			message: eventMessage(t, "msg-blank", channel.MessageTypeDeviceMetadataChanged, now, channel.DeviceMetadataChangedPayload{
+				OrgID:           "00000000-0000-0000-0000-000000000001",
+				AccountDeviceID: deviceID,
+				VideoCloudDevid: "video-1",
+				Metadata:        map[string]any{},
+			}),
+			store: &fakeStore{
+				created: true,
+				operation: model.DeviceOperation{
+					OperationID: "op-msg-blank",
+					DeviceID:    deviceID,
+				},
+			},
+			wantPartitionKey:  deviceID,
+			wantSnapshotValue: "   ",
+			wantErrorFragment: "partition_key must be non-empty",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantSnapshotValue == nil {
+				tc.message.Envelope.PartitionKey = tc.wantPartitionKey
+			} else {
+				tc.message.Envelope.PartitionKey = tc.wantSnapshotValue.(string)
+			}
+
+			service := NewService(tc.store, fakeConsumer{messages: []broker.Message{tc.message}}, Options{
+				Now: func() time.Time { return now },
+			})
+
+			stats, err := service.RunOnce(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stats.DeadLettered != 1 || stats.Processed != 0 || stats.Retrying != 0 {
+				t.Fatalf("unexpected stats: %+v", stats)
+			}
+			if len(tc.store.createInputs) != 1 {
+				t.Fatalf("expected one create input, got %d", len(tc.store.createInputs))
+			}
+			if got := tc.store.createInputs[0].PartitionKey; got != tc.wantPartitionKey {
+				t.Fatalf("expected persisted partition key %q, got %q", tc.wantPartitionKey, got)
+			}
+			if got := tc.store.createInputs[0].Payload[payloadSnapshotEnvelopePartitionKey]; got != tc.wantSnapshotValue {
+				t.Fatalf("expected partition-key snapshot %+v, got %+v", tc.wantSnapshotValue, got)
+			}
+			if len(tc.store.transitions) != 1 {
+				t.Fatalf("expected one transition, got %d", len(tc.store.transitions))
+			}
+			if got := tc.store.transitions[0].MessageStatus; got != model.DeviceMessageInboxStatusDeadLettered {
+				t.Fatalf("expected dead-lettered status, got %s", got)
+			}
+			if tc.store.transitions[0].LastError == nil || !strings.Contains(*tc.store.transitions[0].LastError, tc.wantErrorFragment) {
+				t.Fatalf("expected dead-letter error containing %q, got %+v", tc.wantErrorFragment, tc.store.transitions[0].LastError)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- keep the outbox partition-key boundary strict while allowing malformed nonblank inbox partition keys to persist for later dead-letter handling
- normalize blank inbox partition keys only for inbox-row storage and snapshot the original envelope key under `_envelope_partition_key` so malformed external deliveries stay inspectable
- add store and inbox-worker regressions covering nonblank mismatch persistence plus blank and mismatched partition-key dead-letter paths

## Validation
- `go test ./internal/worker/inbox ./internal/store -count=1`
- `go test ./... -count=1`
- `go build ./...`

## Notes
- `TEST_DATABASE_URL` is unset in this local runtime, so the env-gated Postgres integration cases in `internal/store` still skip here; the new integration assertion will run in hosted CI

Refs #3
