### PR TITLE
[Docs] Clarify Azure checkpoint runbook details

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Testing policy and report maintenance are documented in `docs/TESTING.md`.
 The current v2 provisioning and account/video event-channel surface is documented in `docs/SPEC.md`; rollout tracking and dependency history live in `docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md`.
 The implementation stays aligned with the `contracts/` submodule for provisioning and cross-service channel boundaries.
 The local provisioning and worker flow, including the `log` broker adapter runbook, is documented in `docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md`.
-Set `CROSS_SERVICE_BROKER=azure_eventhubs` plus `AZURE_EVENTHUB_CONNECTION_STRING` to run the workers against Azure Event Hubs instead of the local `log` adapter. The inbox worker persists Azure consumer checkpoints under `.state/azure_eventhubs/` by default; set `AZURE_EVENTHUB_CHECKPOINT_FILE` to override that path.
+Set `CROSS_SERVICE_BROKER=azure_eventhubs` plus `AZURE_EVENTHUB_CONNECTION_STRING` to run the workers against Azure Event Hubs instead of the local `log` adapter. The inbox worker persists Azure consumer checkpoints at `.state/azure_eventhubs/<stream>__<consumer-group>.json` by default; set `AZURE_EVENTHUB_CHECKPOINT_FILE` to override that path.
 
 ## Smoke Test
 

--- a/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
+++ b/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
@@ -44,6 +44,9 @@ The local `log` broker adapter is intentionally simple:
 | `CROSS_SERVICE_MAX_ATTEMPTS` | workers | Retry / dead-letter threshold. |
 | `CROSS_SERVICE_POLL_INTERVAL` | workers | Poll interval and local retry delay. |
 | `AZURE_EVENTHUB_CONNECTION_STRING` | workers | Leave empty for the local `log` adapter. |
+| `AZURE_EVENTHUB_CHECKPOINT_FILE` | inbox worker | Optional Azure-only override for the durable checkpoint file. Defaults to `.state/azure_eventhubs/<stream>__<consumer-group>.json` so restarts resume after the last acknowledged sequence number. |
+
+This runbook uses `CROSS_SERVICE_BROKER=log`, so no Azure checkpoint file is needed for the local FIFO-based flow. If you switch the inbox worker to `azure_eventhubs`, keep the default checkpoint path on persistent storage or set `AZURE_EVENTHUB_CHECKPOINT_FILE` explicitly before restarting workers.
 
 ## Start The Local Stack
 


### PR DESCRIPTION
## Summary
- add the missing `AZURE_EVENTHUB_CHECKPOINT_FILE` env var to the local provisioning/worker runbook
- explain that the local `log` broker flow does not need Azure checkpoints, but Azure inbox workers should keep the durable checkpoint file on persistent storage
- align the top-level README with the concrete default checkpoint file path used on `main`

## Validation
- `git diff --check`
- `go test ./internal/config -count=1`

Refs #11
