### PR TITLE
[Broker] Keep Azure checkpoints on terminal inbox outcomes

### DIFF
--- a/internal/worker/inbox/service.go
+++ b/internal/worker/inbox/service.go
@@ -134,8 +134,10 @@ func (s *Service) RunOnce(ctx context.Context) (Stats, error) {
 		if err != nil {
 			return stats, err
 		}
-		if err := record.Acknowledge(ctx); err != nil {
-			return stats, err
+		if shouldAcknowledgeOutcome(outcome) {
+			if err := record.Acknowledge(ctx); err != nil {
+				return stats, err
+			}
 		}
 
 		switch outcome {
@@ -151,6 +153,12 @@ func (s *Service) RunOnce(ctx context.Context) (Stats, error) {
 	}
 
 	return stats, nil
+}
+
+func shouldAcknowledgeOutcome(outcome model.DeviceMessageInboxStatus) bool {
+	// Retrying outcomes must remain unacknowledged so broker-backed consumers
+	// such as Azure Event Hubs can redeliver transient failures.
+	return outcome != model.DeviceMessageInboxStatusRetrying
 }
 
 func (s *Service) processMessage(ctx context.Context, record broker.Message) (model.DeviceMessageInboxStatus, error) {

--- a/internal/worker/inbox/service_test.go
+++ b/internal/worker/inbox/service_test.go
@@ -166,6 +166,47 @@ func TestRunOnceDoesNotAcknowledgeWhenTransitionFails(t *testing.T) {
 	}
 }
 
+func TestRunOnceDoesNotAcknowledgeRetryingMessages(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	inboxStore := &fakeStore{
+		created: true,
+		operation: model.DeviceOperation{
+			OperationID: "op-1",
+			DeviceID:    "11111111-1111-1111-1111-111111111111",
+		},
+	}
+	acked := 0
+	service := NewService(inboxStore, fakeConsumer{
+		messages: []broker.Message{validProvisionSucceededMessage(now).WithAck(func(context.Context) error {
+			acked++
+			return nil
+		})},
+	}, Options{
+		Now:         func() time.Time { return now },
+		MaxAttempts: 3,
+	})
+
+	original := transitionForPayloadFunc
+	defer func() { transitionForPayloadFunc = original }()
+	transitionForPayloadFunc = func(channel.Envelope, channel.Payload) (store.InboxProcessTransitionInput, error) {
+		return store.InboxProcessTransitionInput{}, broker.Transient(errors.New("temporary projection failure"))
+	}
+
+	stats, err := service.RunOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Retrying != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if acked != 0 {
+		t.Fatalf("expected retrying message to remain unacknowledged, got %d", acked)
+	}
+	if got := inboxStore.transitions[0].MessageStatus; got != model.DeviceMessageInboxStatusRetrying {
+		t.Fatalf("expected retrying status, got %s", got)
+	}
+}
+
 func TestRunOnceSkipsPreviouslyProcessedDuplicates(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	inboxStore := &fakeStore{
@@ -176,8 +217,12 @@ func TestRunOnceSkipsPreviouslyProcessedDuplicates(t *testing.T) {
 			AttemptCount: 1,
 		},
 	}
+	acked := 0
 	service := NewService(inboxStore, fakeConsumer{
-		messages: []broker.Message{validProvisionSucceededMessage(now)},
+		messages: []broker.Message{validProvisionSucceededMessage(now).WithAck(func(context.Context) error {
+			acked++
+			return nil
+		})},
 	}, Options{
 		Now: func() time.Time { return now },
 	})
@@ -191,6 +236,9 @@ func TestRunOnceSkipsPreviouslyProcessedDuplicates(t *testing.T) {
 	}
 	if len(inboxStore.transitions) != 0 {
 		t.Fatalf("expected no transitions, got %d", len(inboxStore.transitions))
+	}
+	if acked != 1 {
+		t.Fatalf("expected skipped duplicate to be acknowledged once, got %d", acked)
 	}
 }
 
@@ -335,8 +383,12 @@ func TestRunOnceDeadLettersInvalidMessages(t *testing.T) {
 			DeviceID:    "11111111-1111-1111-1111-111111111111",
 		},
 	}
+	acked := 0
 	service := NewService(inboxStore, fakeConsumer{
-		messages: []broker.Message{message},
+		messages: []broker.Message{message.WithAck(func(context.Context) error {
+			acked++
+			return nil
+		})},
 	}, Options{
 		Now: func() time.Time { return now },
 	})
@@ -350,6 +402,9 @@ func TestRunOnceDeadLettersInvalidMessages(t *testing.T) {
 	}
 	if got := inboxStore.transitions[0].MessageStatus; got != model.DeviceMessageInboxStatusDeadLettered {
 		t.Fatalf("expected dead-lettered status, got %s", got)
+	}
+	if acked != 1 {
+		t.Fatalf("expected dead-lettered message to be acknowledged once, got %d", acked)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop acknowledging inbox messages when processing records a `retrying` outcome so Azure Event Hubs checkpoints do not advance on transient failures
- keep terminal outcomes acknowledged, including dead-lettered messages and duplicate deliveries that already resolved to a terminal inbox state
- add inbox worker regressions that lock the terminal-vs-retrying acknowledgment behavior

## Validation
- `git diff --check`
- `go test ./internal/worker/inbox ./internal/broker -count=1`
- `go test ./... -count=1`
- `go build ./...`

Refs #9
