### PR TITLE
[Broker] Preserve Azure checkpoint order within partitions

### DIFF
--- a/internal/broker/azure_eventhubs.go
+++ b/internal/broker/azure_eventhubs.go
@@ -184,8 +184,9 @@ func (p *AzureEventHubsPublisher) Close(ctx context.Context) error {
 }
 
 type azurePartitionReceiver struct {
-	id     string
-	client azurePartitionClient
+	id      string
+	client  azurePartitionClient
+	tracker *azurePartitionCheckpointTracker
 }
 
 type azureCheckpointStore interface {
@@ -200,6 +201,21 @@ type azureCheckpointFile struct {
 type azureCheckpoint struct {
 	SequenceNumber int64     `json:"sequence_number"`
 	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type azureDeliveredSequence struct {
+	sequenceNumber int64
+	acknowledged   bool
+}
+
+type azurePartitionCheckpointTracker struct {
+	partitionID string
+	store       azureCheckpointStore
+
+	mu           sync.Mutex
+	committedSet bool
+	committedSeq int64
+	delivered    []azureDeliveredSequence
 }
 
 type azureFileCheckpointStore struct {
@@ -274,16 +290,19 @@ func openAzurePartitions(ctx context.Context, client azureConsumerClient, checkp
 
 	partitions := make([]azurePartitionReceiver, 0, len(partitionIDs))
 	for _, partitionID := range partitionIDs {
+		startPosition := startPositionForPartition(checkpoints, partitionID)
+		tracker := newAzurePartitionCheckpointTracker(partitionID, checkpoints, startPosition)
 		partitionClient, err := client.NewPartitionClient(partitionID, &azeventhubs.PartitionClientOptions{
-			StartPosition: startPositionForPartition(checkpoints, partitionID),
+			StartPosition: startPosition,
 		})
 		if err != nil {
 			closeAzurePartitions(context.Background(), partitions)
 			return nil, err
 		}
 		partitions = append(partitions, azurePartitionReceiver{
-			id:     partitionID,
-			client: partitionClient,
+			id:      partitionID,
+			client:  partitionClient,
+			tracker: tracker,
 		})
 	}
 	return partitions, nil
@@ -316,7 +335,7 @@ func (c *AzureEventHubsConsumer) Receive(ctx context.Context, limit int) ([]Mess
 		}
 
 		for _, event := range events {
-			message, err := messageFromAzureEvent(c.stream, partition.id, event, c.checkpoints)
+			message, err := messageFromAzureEvent(c.stream, event, partition.tracker)
 			if err != nil {
 				return nil, err
 			}
@@ -364,9 +383,12 @@ func closeAzurePartitions(ctx context.Context, partitions []azurePartitionReceiv
 	}
 }
 
-func messageFromAzureEvent(defaultStream, partitionID string, event *azeventhubs.ReceivedEventData, checkpoints azureCheckpointStore) (Message, error) {
+func messageFromAzureEvent(defaultStream string, event *azeventhubs.ReceivedEventData, tracker *azurePartitionCheckpointTracker) (Message, error) {
 	if event == nil {
 		return Message{}, errors.New("received nil azure event")
+	}
+	if tracker != nil {
+		tracker.track(event.SequenceNumber)
 	}
 
 	var record logRecord
@@ -380,10 +402,10 @@ func messageFromAzureEvent(defaultStream, partitionID string, event *azeventhubs
 		Stream:   record.Stream,
 		Envelope: record.Envelope,
 		ack: func(ctx context.Context) error {
-			if checkpoints == nil {
+			if tracker == nil {
 				return nil
 			}
-			return checkpoints.record(ctx, partitionID, event.SequenceNumber)
+			return tracker.acknowledge(ctx, event.SequenceNumber)
 		},
 	}, nil
 }
@@ -420,6 +442,90 @@ func classifyAzureReceiveError(err error) error {
 
 func boolPtr(value bool) *bool {
 	return &value
+}
+
+func newAzurePartitionCheckpointTracker(partitionID string, store azureCheckpointStore, startPosition azeventhubs.StartPosition) *azurePartitionCheckpointTracker {
+	tracker := &azurePartitionCheckpointTracker{
+		partitionID: partitionID,
+		store:       store,
+	}
+	if startPosition.SequenceNumber != nil && !startPosition.Inclusive {
+		tracker.committedSet = true
+		tracker.committedSeq = *startPosition.SequenceNumber
+	}
+	return tracker
+}
+
+func (t *azurePartitionCheckpointTracker) track(sequenceNumber int64) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.committedSet && sequenceNumber <= t.committedSeq {
+		return
+	}
+	for _, delivered := range t.delivered {
+		if delivered.sequenceNumber == sequenceNumber {
+			return
+		}
+	}
+	t.delivered = append(t.delivered, azureDeliveredSequence{sequenceNumber: sequenceNumber})
+}
+
+func (t *azurePartitionCheckpointTracker) acknowledge(ctx context.Context, sequenceNumber int64) error {
+	if t == nil {
+		return nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.committedSet && sequenceNumber <= t.committedSeq {
+		return nil
+	}
+
+	found := false
+	for i := range t.delivered {
+		if t.delivered[i].sequenceNumber == sequenceNumber {
+			t.delivered[i].acknowledged = true
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.delivered = append(t.delivered, azureDeliveredSequence{
+			sequenceNumber: sequenceNumber,
+			acknowledged:   true,
+		})
+	}
+
+	commitSequence, prefixLen, ok := t.acknowledgedPrefixLocked()
+	if !ok {
+		return nil
+	}
+	if t.store != nil {
+		if err := t.store.record(ctx, t.partitionID, commitSequence); err != nil {
+			return err
+		}
+	}
+
+	t.delivered = append([]azureDeliveredSequence(nil), t.delivered[prefixLen:]...)
+	t.committedSet = true
+	t.committedSeq = commitSequence
+	return nil
+}
+
+func (t *azurePartitionCheckpointTracker) acknowledgedPrefixLocked() (int64, int, bool) {
+	prefixLen := 0
+	var commitSequence int64
+	for prefixLen < len(t.delivered) && t.delivered[prefixLen].acknowledged {
+		commitSequence = t.delivered[prefixLen].sequenceNumber
+		prefixLen++
+	}
+	return commitSequence, prefixLen, prefixLen > 0
 }
 
 func startPositionForPartition(checkpoints azureCheckpointStore, partitionID string) azeventhubs.StartPosition {

--- a/internal/broker/azure_eventhubs_test.go
+++ b/internal/broker/azure_eventhubs_test.go
@@ -354,6 +354,73 @@ func TestAzureEventHubsConsumerAcknowledgesAndResumesFromCheckpoint(t *testing.T
 	}
 }
 
+func TestAzureEventHubsConsumerDoesNotAdvanceCheckpointPastEarlierUnacknowledgedMessage(t *testing.T) {
+	checkpointFile := filepath.Join(t.TempDir(), "consumer-checkpoints.json")
+	if err := os.WriteFile(checkpointFile, []byte("{\n  \"partitions\": {\n    \"0\": {\n      \"sequence_number\": 40,\n      \"updated_at\": \"2026-04-29T12:00:00Z\"\n    }\n  }\n}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeAzureConsumerClient{
+		properties: azeventhubs.EventHubProperties{PartitionIDs: []string{"0"}},
+		partitions: map[string]*fakeAzurePartitionClient{
+			"0": {
+				events: []*azeventhubs.ReceivedEventData{
+					{
+						EventData:      azeventhubs.EventData{Body: []byte(`{"stream":"video.account.events","envelope":{"message_id":"msg-41","correlation_id":"corr-41","operation_id":"op-41","source_service":"realtek_video_server","target_service":"rtk_account_manager","message_type":"DeviceOnlineChanged","schema_version":"1.0","partition_key":"device-1","occurred_at":"2026-04-29T12:00:00Z","payload":{"status":"online"}}}`)},
+						SequenceNumber: 41,
+					},
+					{
+						EventData:      azeventhubs.EventData{Body: []byte(`{"stream":"video.account.events","envelope":{"message_id":"msg-42","correlation_id":"corr-42","operation_id":"op-42","source_service":"realtek_video_server","target_service":"rtk_account_manager","message_type":"DeviceMetadataChanged","schema_version":"1.0","partition_key":"device-1","occurred_at":"2026-04-29T12:00:01Z","payload":{"video_cloud_devid":"vc-42"}}}`)},
+						SequenceNumber: 42,
+					},
+				},
+			},
+		},
+	}
+
+	consumer, err := newAzureEventHubsConsumer(
+		client,
+		channel.StreamVideoAccountEvents,
+		50*time.Millisecond,
+		newAzureFileCheckpointStore(checkpointFile),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	messages, err := consumer.Receive(context.Background(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected two messages, got %d", len(messages))
+	}
+
+	if err := messages[1].Acknowledge(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(checkpointFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"sequence_number": 40`) {
+		t.Fatalf("expected checkpoint to remain at 40 until the earlier message is acknowledged, got %s", string(data))
+	}
+
+	if err := messages[0].Acknowledge(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err = os.ReadFile(checkpointFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"sequence_number": 42`) {
+		t.Fatalf("expected checkpoint to advance to 42 after the ordered prefix is acknowledged, got %s", string(data))
+	}
+}
+
 func TestOpenAzurePartitionsUsesStoredCheckpointWhenPresent(t *testing.T) {
 	checkpointFile := filepath.Join(t.TempDir(), "consumer-checkpoints.json")
 	if err := os.WriteFile(checkpointFile, []byte("{\n  \"partitions\": {\n    \"1\": {\n      \"sequence_number\": 17,\n      \"updated_at\": \"2026-04-29T12:00:00Z\"\n    }\n  }\n}\n"), 0o600); err != nil {
@@ -512,7 +579,7 @@ func TestAzureEventHubsPublisherRejectsUnexpectedStream(t *testing.T) {
 }
 
 func TestAzureMessageDecodeRejectsInvalidJSON(t *testing.T) {
-	_, err := messageFromAzureEvent(channel.StreamVideoAccountEvents, "0", &azeventhubs.ReceivedEventData{
+	_, err := messageFromAzureEvent(channel.StreamVideoAccountEvents, &azeventhubs.ReceivedEventData{
 		EventData: azeventhubs.EventData{Body: []byte("not-json")},
 	}, nil)
 	if err == nil {
@@ -521,7 +588,7 @@ func TestAzureMessageDecodeRejectsInvalidJSON(t *testing.T) {
 }
 
 func TestAzureMessageDecodeRejectsNilEvent(t *testing.T) {
-	if _, err := messageFromAzureEvent(channel.StreamVideoAccountEvents, "0", nil, nil); err == nil {
+	if _, err := messageFromAzureEvent(channel.StreamVideoAccountEvents, nil, nil); err == nil {
 		t.Fatal("expected nil event error")
 	}
 }


### PR DESCRIPTION
## Summary
- keep Azure Event Hubs checkpoints ordered within each broker partition instead of persisting the highest acknowledged sequence unconditionally
- track delivered sequence order per partition so acknowledging a later message cannot advance the durable checkpoint past an earlier retrying message from the same partition
- add a focused regression proving a 1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
23
24
25
26
27
28
29
30
31
32
33
34
35
36
37
38
39
40
41
42 acknowledgment does not move the checkpoint beyond an unacknowledged 1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
23
24
25
26
27
28
29
30
31
32
33
34
35
36
37
38
39
40
41 from the same partition

## Validation
- \
- \ok  	rtk_account_manager/internal/broker	0.284s
ok  	rtk_account_manager/internal/worker/inbox	0.443s
- \?   	rtk_account_manager/cmd/cleanup-tokens	[no test files]
?   	rtk_account_manager/cmd/inbox-worker	[no test files]
?   	rtk_account_manager/cmd/migrate	[no test files]
?   	rtk_account_manager/cmd/outbox-worker	[no test files]
?   	rtk_account_manager/cmd/server	[no test files]
ok  	rtk_account_manager/internal/api	0.337s
ok  	rtk_account_manager/internal/auth	1.718s
ok  	rtk_account_manager/internal/broker	0.826s
ok  	rtk_account_manager/internal/channel	0.487s
ok  	rtk_account_manager/internal/config	0.644s
ok  	rtk_account_manager/internal/database	0.988s
?   	rtk_account_manager/internal/model	[no test files]
ok  	rtk_account_manager/internal/openapi	1.177s
ok  	rtk_account_manager/internal/store	1.357s
?   	rtk_account_manager/internal/testutil	[no test files]
ok  	rtk_account_manager/internal/worker/inbox	1.536s
ok  	rtk_account_manager/internal/worker/outbox	1.713s
- \

Refs #9
