### PR TITLE
[API] Persist pending video_cloud_devid mapping on provisioning request

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -262,6 +262,7 @@ Rules:
 - `member` may read provisioning state but may not initiate lifecycle commands.
 - Device must exist in the organization.
 - Disabled devices cannot be provisioned.
+- Accepting provisioning immediately exposes pending `video_cloud_devid`, `video_cloud_activity_id`, and `video_cloud_activation_status=pending` in projected device metadata.
 - Duplicate `operation_id` with the same payload returns the existing operation.
 - Duplicate `operation_id` with a conflicting payload returns `409 Conflict`.
 - The API must not directly call Realtek video server.

--- a/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
+++ b/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
@@ -152,7 +152,16 @@ DEVICE_ID=$(echo "$DEVICE_RESPONSE" | jq -r '.device.id')
    LIMIT 5;"
    ```
 
-4. Inject a matching video-side success event into the inbox worker:
+4. Confirm the accepted request already exposes pending video metadata:
+
+   ```sh
+   curl -sS "http://localhost:8080/v1/orgs/$ORG_ID/devices/$DEVICE_ID/provisioning" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
+   ```
+
+   The `video_metadata` block should already show `video_cloud_devid`, `video_cloud_activity_id`, and `video_cloud_activation_status=pending` even before any video-side success or failure event arrives.
+
+5. Inject a matching video-side success event into the inbox worker:
 
    ```sh
    cat <<EOF >&3
@@ -160,7 +169,7 @@ DEVICE_ID=$(echo "$DEVICE_RESPONSE" | jq -r '.device.id')
    EOF
    ```
 
-5. Verify projected state:
+6. Verify projected state:
 
    ```sh
    curl -sS "http://localhost:8080/v1/orgs/$ORG_ID/devices/$DEVICE_ID/provisioning" \

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -450,6 +450,7 @@ Provisioning-state response body for `GET .../provisioning`:
 Provisioning rules:
 
 - The API writes the operation row and outbox row transactionally.
+- Accepting a provisioning request immediately merges pending `video_cloud_devid`, `video_cloud_activity_id`, and `video_cloud_activation_status=pending` into device metadata without implying activation success.
 - Disabled devices cannot be provisioned.
 - The API must not directly call Realtek video server.
 - Product-level deactivation and account registry soft-delete are distinct operations.
@@ -457,7 +458,7 @@ Provisioning rules:
 - Omitting the deactivation `reason` defaults the outbox payload to `account_device_disabled`.
 - Reusing an explicit `operation_id` returns the existing operation when the normalized request matches and returns `409 Conflict` when it does not.
 - Operation responses may also include `error_code`, `error_message`, `retryable`, and `completed_at` once the inbox projection records a terminal result.
-- `DeviceProvisionSucceeded` sets video activation metadata but does not set account-manager `status=online`.
+- `DeviceProvisionSucceeded` replaces the pending activation metadata with the terminal activation result but does not set account-manager `status=online`.
 - `DeviceOnlineChanged` is the only video-side event that may project account-manager `status=online|offline`.
 
 ## 8. API Conventions

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -968,8 +968,22 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 	if memberState.Operation.OperationID != "provision-op-1" {
 		t.Fatalf("unexpected provisioning state operation: %+v", memberState.Operation)
 	}
-	if len(memberState.VideoMetadata) != 0 {
-		t.Fatalf("expected empty projected metadata before inbox projection, got %+v", memberState.VideoMetadata)
+	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudDevid]; got != "video-device-1" {
+		t.Fatalf("expected pending devid in provisioning state, got %+v", got)
+	}
+	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudActivityID]; got != "activity-1" {
+		t.Fatalf("expected pending activity id in provisioning state, got %+v", got)
+	}
+	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusPending) {
+		t.Fatalf("expected pending activation status in provisioning state, got %+v", got)
+	}
+
+	pendingDevice, err := store.New(env.db).GetDevice(context.Background(), owner.Organization.ID, device.Device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pendingDevice.Status != model.DeviceStatusUnknown {
+		t.Fatalf("expected accepted provisioning not to set device online, got %s", pendingDevice.Status)
 	}
 
 	outsiderStateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, outsider.Tokens.AccessToken)

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -61,14 +61,6 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	provisioningRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, registered.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", provisioningRes)
 
-	if _, err := env.db.Exec(context.Background(), `
-		UPDATE devices
-		SET metadata = metadata || jsonb_build_object('video_cloud_devid', 'contract-video-1')
-		WHERE id = $1
-	`, device.Device.ID); err != nil {
-		t.Fatal(err)
-	}
-
 	deactivateRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/deactivate", map[string]any{
 		"operation_id": "contract-deactivate-op-1",
 		"reason":       "contract-test",

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -123,7 +123,8 @@ func (s *Server) provisionDevice(c *gin.Context) {
 			"clip_public_key":   clipPublicKey,
 			"requested_by":      currentUserID(c),
 		},
-		Now: time.Now().UTC().Truncate(time.Microsecond),
+		MetadataPatch: store.PendingProvisionMetadata(videoCloudDevid, activityID),
+		Now:           time.Now().UTC().Truncate(time.Microsecond),
 	})
 	if err != nil {
 		writeStoreError(c, err)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -30,6 +30,7 @@ const (
 type VideoCloudActivationStatus string
 
 const (
+	VideoCloudActivationStatusPending     VideoCloudActivationStatus = "pending"
 	VideoCloudActivationStatusActivated   VideoCloudActivationStatus = "activated"
 	VideoCloudActivationStatusFailed      VideoCloudActivationStatus = "failed"
 	VideoCloudActivationStatusDeactivated VideoCloudActivationStatus = "deactivated"

--- a/internal/store/device_lifecycle.go
+++ b/internal/store/device_lifecycle.go
@@ -23,6 +23,7 @@ type DeviceLifecycleOperationInput struct {
 	RequestPayload    map[string]any
 	OutboxMessageType string
 	OutboxPayload     map[string]any
+	MetadataPatch     map[string]any
 	AllowDisabled     bool
 	Now               time.Time
 }
@@ -116,6 +117,16 @@ func startDeviceLifecycleOperationTx(ctx context.Context, tx pgx.Tx, device mode
 	}
 	if err != nil {
 		return DeviceLifecycleOperationResult{}, err
+	}
+
+	if created && len(in.MetadataPatch) > 0 {
+		device, err = projectDeviceTx(ctx, tx, device.OrganizationID, device.ID, DeviceProjectionInput{
+			Metadata:      in.MetadataPatch,
+			AllowDisabled: in.AllowDisabled,
+		})
+		if err != nil {
+			return DeviceLifecycleOperationResult{}, err
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/store/device_lifecycle_integration_test.go
+++ b/internal/store/device_lifecycle_integration_test.go
@@ -6,8 +6,86 @@ import (
 	"testing"
 	"time"
 
+	"rtk_account_manager/internal/channel"
 	"rtk_account_manager/internal/model"
 )
+
+func TestStartDeviceLifecycleOperationPersistsPendingProvisionMetadata(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	orgID, userID, deviceID := createDeviceFixture(t, env)
+
+	ctx := context.Background()
+	if _, err := env.db.Exec(ctx, `
+		UPDATE devices
+		SET metadata = metadata
+			|| jsonb_build_object(
+				'video_cloud_activation_status', 'deactivated',
+				'video_cloud_activated_at', '2026-04-28T09:00:00Z',
+				'video_cloud_deactivated_at', '2026-04-28T10:00:00Z',
+				'video_cloud_last_error', jsonb_build_object('code', 'stale_error')
+			)
+		WHERE id = $1
+	`, deviceID); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := env.store.StartDeviceLifecycleOperation(ctx, DeviceLifecycleOperationInput{
+		OperationID:       "provision-op-1",
+		CorrelationID:     "provision-op-1",
+		MessageID:         "provision-message-1",
+		OrganizationID:    orgID,
+		DeviceID:          deviceID,
+		OperationType:     model.DeviceOperationTypeProvision,
+		RequestedBy:       &userID,
+		RequestPayload:    map[string]any{"video_cloud_devid": "video-device-1", "activity_id": "activity-1", "clip_public_key": "clip-key-1"},
+		OutboxMessageType: string(channel.MessageTypeDeviceProvisionRequested),
+		OutboxPayload: map[string]any{
+			"org_id":            orgID,
+			"account_device_id": deviceID,
+			"video_cloud_devid": "video-device-1",
+			"activity_id":       "activity-1",
+			"clip_public_key":   "clip-key-1",
+			"requested_by":      userID,
+		},
+		MetadataPatch: PendingProvisionMetadata("video-device-1", "activity-1"),
+		Now:           time.Now().UTC().Truncate(time.Microsecond),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Created {
+		t.Fatal("expected provisioning operation to be created")
+	}
+	if got := result.Device.Metadata["location"]; got != "lab" {
+		t.Fatalf("expected unrelated metadata to remain, got %+v", got)
+	}
+	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudDevid]; got != "video-device-1" {
+		t.Fatalf("expected pending metadata to expose requested devid, got %+v", got)
+	}
+	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudActivityID]; got != "activity-1" {
+		t.Fatalf("expected pending metadata to expose requested activity id, got %+v", got)
+	}
+	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusPending) {
+		t.Fatalf("expected pending activation status, got %+v", got)
+	}
+	if _, exists := result.Device.Metadata[model.DeviceMetadataVideoCloudActivatedAt]; exists {
+		t.Fatalf("expected pending metadata to clear activated_at, got %+v", result.Device.Metadata[model.DeviceMetadataVideoCloudActivatedAt])
+	}
+	if _, exists := result.Device.Metadata[model.DeviceMetadataVideoCloudDeactivatedAt]; exists {
+		t.Fatalf("expected pending metadata to clear deactivated_at, got %+v", result.Device.Metadata[model.DeviceMetadataVideoCloudDeactivatedAt])
+	}
+	if _, exists := result.Device.Metadata[model.DeviceMetadataVideoCloudLastError]; exists {
+		t.Fatalf("expected pending metadata to clear last_error, got %+v", result.Device.Metadata[model.DeviceMetadataVideoCloudLastError])
+	}
+
+	persisted, err := env.store.GetDevice(ctx, orgID, deviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := persisted.Metadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusPending) {
+		t.Fatalf("expected persisted pending activation status, got %+v", got)
+	}
+}
 
 func TestStartDeviceDeactivationOperationUsesProjectedMetadata(t *testing.T) {
 	env := newStoreIntegrationEnv(t)

--- a/internal/store/device_projection.go
+++ b/internal/store/device_projection.go
@@ -15,6 +15,17 @@ import (
 
 const projectionMetadataPrefix = "video_cloud_"
 
+func PendingProvisionMetadata(videoCloudDevid, activityID string) map[string]any {
+	return map[string]any{
+		model.DeviceMetadataVideoCloudDevid:            videoCloudDevid,
+		model.DeviceMetadataVideoCloudActivityID:       activityID,
+		model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusPending,
+		model.DeviceMetadataVideoCloudActivatedAt:      nil,
+		model.DeviceMetadataVideoCloudDeactivatedAt:    nil,
+		model.DeviceMetadataVideoCloudLastError:        nil,
+	}
+}
+
 type DeviceProjectionInput struct {
 	Metadata      map[string]any
 	Status        *model.DeviceStatus


### PR DESCRIPTION
## Summary
- persist pending `video_cloud_*` metadata in the same transaction as accepted provisioning operations and outbox rows
- expose pending provisioning metadata through `GET /provisioning` without implying `status=online`
- update focused tests and provisioning docs/runbook for the new pending-metadata window

## Validation
- `go test ./internal/store ./internal/api -count=1`
- `go test ./... -run 'TestStartDeviceLifecycleOperationPersistsPendingProvisionMetadata|TestIntegrationProvisioningEndpoints|TestIntegrationResponsesMatchOpenAPIContract' -count=1`\n- `go test ./... -count=1`\n- `go build ./...`\n\nRefs #43