### PR TITLE
[Ops] Add lifecycle dead-letter and retry management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,20 @@ Backend account and device manager for organization-scoped users and registry-on
    make cleanup-tokens
    ```
 
-6. Run tests:
+6. Inspect or requeue lifecycle outbox/inbox rows when worker failures need investigation:
+
+   ```sh
+   go run ./cmd/lifecycle-admin outbox list
+   go run ./cmd/lifecycle-admin inbox list
+   ```
+
+7. Run tests:
 
    ```sh
    make test
    ```
 
-7. Run Postgres-backed integration tests:
+8. Run Postgres-backed integration tests:
 
    ```sh
    make integration-test
@@ -50,7 +57,7 @@ Backend account and device manager for organization-scoped users and registry-on
 
    These tests require the Docker Compose Postgres service to be running.
 
-8. Generate the maintained test report:
+9. Generate the maintained test report:
 
    ```sh
    make test-report
@@ -59,7 +66,7 @@ Backend account and device manager for organization-scoped users and registry-on
    The report is written to `docs/TEST_REPORT.md`. Report artifacts are written under `reports/`.
    This command also requires the Postgres service from `make db-up`.
 
-9. Stop local services:
+10. Stop local services:
 
    ```sh
    make db-down

--- a/cmd/lifecycle-admin/main.go
+++ b/cmd/lifecycle-admin/main.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"rtk_account_manager/internal/config"
+	"rtk_account_manager/internal/database"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type usageError struct {
+	message string
+}
+
+func (e usageError) Error() string {
+	return e.message
+}
+
+type outboxListOutput struct {
+	Statuses []string                    `json:"statuses"`
+	Limit    int                         `json:"limit"`
+	Offset   int                         `json:"offset"`
+	Messages []model.DeviceMessageOutbox `json:"messages"`
+}
+
+type inboxListOutput struct {
+	Statuses []string                   `json:"statuses"`
+	Limit    int                        `json:"limit"`
+	Offset   int                        `json:"offset"`
+	Messages []model.DeviceMessageInbox `json:"messages"`
+}
+
+type outboxRequeueOutput struct {
+	Changed   bool                      `json:"changed"`
+	Message   model.DeviceMessageOutbox `json:"message"`
+	Operation *model.DeviceOperation    `json:"operation,omitempty"`
+}
+
+type inboxRequeueOutput struct {
+	Changed   bool                     `json:"changed"`
+	Message   model.DeviceMessageInbox `json:"message"`
+	Operation *model.DeviceOperation   `json:"operation,omitempty"`
+	Note      string                   `json:"note,omitempty"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if _, ok := err.(usageError); ok {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(2)
+		}
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	if len(args) < 2 {
+		return usageError{message: usageText()}
+	}
+
+	cfg, err := config.LoadWorker()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	db, err := database.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	messageStore := store.New(db)
+
+	scope := args[0]
+	command := args[1]
+	rest := args[2:]
+
+	switch scope {
+	case "outbox":
+		return runOutboxCommand(ctx, messageStore, command, rest, stdout, stderr)
+	case "inbox":
+		return runInboxCommand(ctx, messageStore, command, rest, stdout, stderr)
+	default:
+		return usageError{message: fmt.Sprintf("unknown scope %q\n\n%s", scope, usageText())}
+	}
+}
+
+func runOutboxCommand(ctx context.Context, messageStore *store.Store, command string, args []string, stdout, stderr io.Writer) error {
+	switch command {
+	case "list":
+		flags := flag.NewFlagSet("outbox list", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		statusesArg := flags.String("status", "retrying,dead_lettered", "comma-separated outbox statuses")
+		limit := flags.Int("limit", 20, "max rows to return")
+		offset := flags.Int("offset", 0, "rows to skip before listing")
+		if err := flags.Parse(args); err != nil {
+			return usageError{message: err.Error()}
+		}
+		if *limit < 0 || *offset < 0 {
+			return usageError{message: "outbox list requires non-negative -limit and -offset"}
+		}
+
+		statuses, err := parseOutboxStatuses(*statusesArg)
+		if err != nil {
+			return usageError{message: err.Error()}
+		}
+
+		messages, err := messageStore.ListOutboxMessagesByStatus(ctx, statuses, *limit, *offset)
+		if err != nil {
+			return err
+		}
+		return writeJSON(stdout, outboxListOutput{
+			Statuses: outboxStatusStrings(statuses),
+			Limit:    *limit,
+			Offset:   *offset,
+			Messages: messages,
+		})
+	case "show":
+		flags := flag.NewFlagSet("outbox show", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		messageID := flags.String("message-id", "", "outbox message id")
+		if err := flags.Parse(args); err != nil {
+			return usageError{message: err.Error()}
+		}
+		if strings.TrimSpace(*messageID) == "" {
+			return usageError{message: "outbox show requires -message-id"}
+		}
+
+		detail, err := messageStore.GetOutboxMessageDetail(ctx, *messageID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("outbox message %q not found", *messageID)
+			}
+			return err
+		}
+		return writeJSON(stdout, detail)
+	case "requeue":
+		flags := flag.NewFlagSet("outbox requeue", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		messageID := flags.String("message-id", "", "outbox message id")
+		if err := flags.Parse(args); err != nil {
+			return usageError{message: err.Error()}
+		}
+		if strings.TrimSpace(*messageID) == "" {
+			return usageError{message: "outbox requeue requires -message-id"}
+		}
+
+		message, operation, changed, err := messageStore.RequeueOutboxMessage(ctx, *messageID, time.Now().UTC())
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("outbox message %q not found", *messageID)
+			}
+			if errors.Is(err, store.ErrConflict) {
+				return fmt.Errorf("outbox message %q is not eligible for requeue or its related lifecycle operation already completed", *messageID)
+			}
+			return err
+		}
+		return writeJSON(stdout, outboxRequeueOutput{
+			Changed:   changed,
+			Message:   message,
+			Operation: operation,
+		})
+	default:
+		return usageError{message: fmt.Sprintf("unknown outbox command %q\n\n%s", command, usageText())}
+	}
+}
+
+func runInboxCommand(ctx context.Context, messageStore *store.Store, command string, args []string, stdout, stderr io.Writer) error {
+	switch command {
+	case "list":
+		flags := flag.NewFlagSet("inbox list", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		statusesArg := flags.String("status", "retrying,dead_lettered", "comma-separated inbox statuses")
+		limit := flags.Int("limit", 20, "max rows to return")
+		offset := flags.Int("offset", 0, "rows to skip before listing")
+		if err := flags.Parse(args); err != nil {
+			return usageError{message: err.Error()}
+		}
+		if *limit < 0 || *offset < 0 {
+			return usageError{message: "inbox list requires non-negative -limit and -offset"}
+		}
+
+		statuses, err := parseInboxStatuses(*statusesArg)
+		if err != nil {
+			return usageError{message: err.Error()}
+		}
+
+		messages, err := messageStore.ListInboxMessagesByStatus(ctx, statuses, *limit, *offset)
+		if err != nil {
+			return err
+		}
+		return writeJSON(stdout, inboxListOutput{
+			Statuses: inboxStatusStrings(statuses),
+			Limit:    *limit,
+			Offset:   *offset,
+			Messages: messages,
+		})
+	case "show":
+		flags := flag.NewFlagSet("inbox show", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		messageID := flags.String("message-id", "", "inbox message id")
+		if err := flags.Parse(args); err != nil {
+			return usageError{message: err.Error()}
+		}
+		if strings.TrimSpace(*messageID) == "" {
+			return usageError{message: "inbox show requires -message-id"}
+		}
+
+		detail, err := messageStore.GetInboxMessageDetail(ctx, *messageID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("inbox message %q not found", *messageID)
+			}
+			return err
+		}
+		return writeJSON(stdout, detail)
+	case "requeue":
+		flags := flag.NewFlagSet("inbox requeue", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		messageID := flags.String("message-id", "", "inbox message id")
+		if err := flags.Parse(args); err != nil {
+			return usageError{message: err.Error()}
+		}
+		if strings.TrimSpace(*messageID) == "" {
+			return usageError{message: "inbox requeue requires -message-id"}
+		}
+
+		message, operation, changed, err := messageStore.RequeueInboxMessage(ctx, *messageID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("inbox message %q not found", *messageID)
+			}
+			if errors.Is(err, store.ErrConflict) {
+				return fmt.Errorf("inbox message %q is not eligible for requeue; only retrying or dead-lettered rows can be reopened", *messageID)
+			}
+			return err
+		}
+		return writeJSON(stdout, inboxRequeueOutput{
+			Changed:   changed,
+			Message:   message,
+			Operation: operation,
+			Note:      "inbox requeue reopens the persisted dedupe row; acknowledged broker messages still require replay or redelivery to be processed again",
+		})
+	default:
+		return usageError{message: fmt.Sprintf("unknown inbox command %q\n\n%s", command, usageText())}
+	}
+}
+
+func parseOutboxStatuses(raw string) ([]model.DeviceMessageOutboxStatus, error) {
+	parts := splitCSV(raw)
+	if len(parts) == 0 {
+		return nil, errors.New("at least one outbox status is required")
+	}
+
+	statuses := make([]model.DeviceMessageOutboxStatus, 0, len(parts))
+	for _, part := range parts {
+		status := model.DeviceMessageOutboxStatus(part)
+		switch status {
+		case model.DeviceMessageOutboxStatusPending,
+			model.DeviceMessageOutboxStatusPublished,
+			model.DeviceMessageOutboxStatusRetrying,
+			model.DeviceMessageOutboxStatusDeadLettered:
+			statuses = append(statuses, status)
+		default:
+			return nil, fmt.Errorf("unsupported outbox status %q", part)
+		}
+	}
+	return statuses, nil
+}
+
+func parseInboxStatuses(raw string) ([]model.DeviceMessageInboxStatus, error) {
+	parts := splitCSV(raw)
+	if len(parts) == 0 {
+		return nil, errors.New("at least one inbox status is required")
+	}
+
+	statuses := make([]model.DeviceMessageInboxStatus, 0, len(parts))
+	for _, part := range parts {
+		status := model.DeviceMessageInboxStatus(part)
+		switch status {
+		case model.DeviceMessageInboxStatusProcessed,
+			model.DeviceMessageInboxStatusFailed,
+			model.DeviceMessageInboxStatusRetrying,
+			model.DeviceMessageInboxStatusDeadLettered:
+			statuses = append(statuses, status)
+		default:
+			return nil, fmt.Errorf("unsupported inbox status %q", part)
+		}
+	}
+	return statuses, nil
+}
+
+func splitCSV(raw string) []string {
+	fields := strings.Split(raw, ",")
+	parts := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		parts = append(parts, field)
+	}
+	return parts
+}
+
+func outboxStatusStrings(statuses []model.DeviceMessageOutboxStatus) []string {
+	values := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		values = append(values, string(status))
+	}
+	return values
+}
+
+func inboxStatusStrings(statuses []model.DeviceMessageInboxStatus) []string {
+	values := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		values = append(values, string(status))
+	}
+	return values
+}
+
+func writeJSON(w io.Writer, value any) error {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	_, err = w.Write(encoded)
+	return err
+}
+
+func usageText() string {
+	return `usage:
+  lifecycle-admin outbox list [-status retrying,dead_lettered] [-limit 20] [-offset 0]
+  lifecycle-admin outbox show -message-id <id>
+  lifecycle-admin outbox requeue -message-id <id>
+  lifecycle-admin inbox list [-status retrying,dead_lettered] [-limit 20] [-offset 0]
+  lifecycle-admin inbox show -message-id <id>
+  lifecycle-admin inbox requeue -message-id <id>`
+}

--- a/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
+++ b/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
@@ -139,17 +139,8 @@ DEVICE_ID=$(echo "$DEVICE_RESPONSE" | jq -r '.device.id')
 3. Inspect the persisted operation and outbox row:
 
    ```sh
-   docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
-   SELECT operation_id, operation_type, status, retryable, error_code, created_at, completed_at
-   FROM device_operations
-   ORDER BY created_at DESC
-   LIMIT 5;"
-
-   docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
-   SELECT message_id, operation_id, status, attempt_count, last_error, available_at, published_at
-   FROM device_message_outbox
-   ORDER BY created_at DESC
-   LIMIT 5;"
+   go run ./cmd/lifecycle-admin outbox list | jq .
+   go run ./cmd/lifecycle-admin outbox show -message-id "$PROVISION_MESSAGE_ID" | jq .
    ```
 
 4. Inject a matching video-side success event into the inbox worker:
@@ -166,11 +157,7 @@ DEVICE_ID=$(echo "$DEVICE_RESPONSE" | jq -r '.device.id')
    curl -sS "http://localhost:8080/v1/orgs/$ORG_ID/devices/$DEVICE_ID/provisioning" \
      -H "Authorization: Bearer $ACCESS_TOKEN" | jq .
 
-   docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
-   SELECT message_id, operation_id, status, attempt_count, last_error, processed_at
-   FROM device_message_inbox
-   ORDER BY created_at DESC
-   LIMIT 5;"
+   go run ./cmd/lifecycle-admin inbox list | jq .
 
    docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
    SELECT status, last_seen_at, metadata
@@ -221,27 +208,35 @@ Re-run the device query above and confirm `status=online`.
 
 ## Inspect Retries And Dead Letters
 
-Use these queries while debugging worker failures:
+Use the maintenance CLI while debugging worker failures:
 
 ```sh
-docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
-SELECT operation_id, status, retryable, error_code, error_message, updated_at
-FROM device_operations
-WHERE status IN ('retrying', 'dead_lettered', 'failed')
-ORDER BY updated_at DESC;"
-
-docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
-SELECT message_id, status, attempt_count, last_error, available_at, published_at
-FROM device_message_outbox
-WHERE status IN ('retrying', 'dead_lettered')
-ORDER BY updated_at DESC;"
-
-docker compose exec postgres psql -U rtk -d rtk_account_manager -c "
-SELECT message_id, status, attempt_count, last_error, processed_at
-FROM device_message_inbox
-WHERE status IN ('retrying', 'dead_lettered')
-ORDER BY updated_at DESC;"
+go run ./cmd/lifecycle-admin outbox list | jq .
+go run ./cmd/lifecycle-admin inbox list | jq .
 ```
+
+Inspect a single failed row with its related operation:
+
+```sh
+go run ./cmd/lifecycle-admin outbox show -message-id "$PROVISION_MESSAGE_ID" | jq .
+go run ./cmd/lifecycle-admin inbox show -message-id "evt-bad-online-1" | jq .
+```
+
+Requeue a failed outbox row after fixing the publication problem:
+
+```sh
+go run ./cmd/lifecycle-admin outbox requeue -message-id "$PROVISION_MESSAGE_ID" | jq .
+```
+
+That resets the outbox row to `pending`, clears the publish error fields, and reopens the related lifecycle operation unless it already completed successfully or failed terminally.
+
+Requeue a dead-lettered inbox row when you are also replaying the broker message:
+
+```sh
+go run ./cmd/lifecycle-admin inbox requeue -message-id "evt-bad-online-1" | jq .
+```
+
+Inbox requeue only reopens the persisted deduplication row. If the worker already acknowledged the broker delivery, you still need a real broker replay or manual event reinjection before the inbox worker can process that message again.
 
 To force a local inbox dead-letter row, inject a structurally valid event with an invalid `DeviceOnlineChanged.status` value:
 

--- a/internal/store/lifecycle_admin.go
+++ b/internal/store/lifecycle_admin.go
@@ -1,0 +1,306 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type OutboxMessageDetail struct {
+	Message   model.DeviceMessageOutbox `json:"message"`
+	Operation *model.DeviceOperation    `json:"operation,omitempty"`
+}
+
+type InboxMessageDetail struct {
+	Message   model.DeviceMessageInbox `json:"message"`
+	Operation *model.DeviceOperation   `json:"operation,omitempty"`
+}
+
+func (s *Store) ListOutboxMessagesByStatus(ctx context.Context, statuses []model.DeviceMessageOutboxStatus, limit, offset int) ([]model.DeviceMessageOutbox, error) {
+	if len(statuses) == 0 {
+		return []model.DeviceMessageOutbox{}, nil
+	}
+
+	rows, err := s.db.Query(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+		FROM device_message_outbox
+		WHERE status = ANY($1)
+		ORDER BY updated_at DESC, created_at DESC, message_id ASC
+		LIMIT $2 OFFSET $3
+	`, outboxStatusesToStrings(statuses), limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	messages := make([]model.DeviceMessageOutbox, 0)
+	for rows.Next() {
+		message, err := scanDeviceMessageOutbox(rows)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func (s *Store) ListInboxMessagesByStatus(ctx context.Context, statuses []model.DeviceMessageInboxStatus, limit, offset int) ([]model.DeviceMessageInbox, error) {
+	if len(statuses) == 0 {
+		return []model.DeviceMessageInbox{}, nil
+	}
+
+	rows, err := s.db.Query(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+		FROM device_message_inbox
+		WHERE status = ANY($1)
+		ORDER BY updated_at DESC, created_at DESC, message_id ASC
+		LIMIT $2 OFFSET $3
+	`, inboxStatusesToStrings(statuses), limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	messages := make([]model.DeviceMessageInbox, 0)
+	for rows.Next() {
+		message, err := scanDeviceMessageInbox(rows)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func (s *Store) GetOutboxMessageDetail(ctx context.Context, messageID string) (OutboxMessageDetail, error) {
+	message, err := s.GetOutboxMessage(ctx, messageID)
+	if err != nil {
+		return OutboxMessageDetail{}, err
+	}
+
+	operation, err := s.getDeviceOperationOptional(ctx, message.OperationID)
+	if err != nil {
+		return OutboxMessageDetail{}, err
+	}
+
+	return OutboxMessageDetail{
+		Message:   message,
+		Operation: operation,
+	}, nil
+}
+
+func (s *Store) GetInboxMessageDetail(ctx context.Context, messageID string) (InboxMessageDetail, error) {
+	message, err := s.GetInboxMessage(ctx, messageID)
+	if err != nil {
+		return InboxMessageDetail{}, err
+	}
+
+	operation, err := s.getDeviceOperationOptional(ctx, message.OperationID)
+	if err != nil {
+		return InboxMessageDetail{}, err
+	}
+
+	return InboxMessageDetail{
+		Message:   message,
+		Operation: operation,
+	}, nil
+}
+
+func (s *Store) RequeueOutboxMessage(ctx context.Context, messageID string, availableAt time.Time) (model.DeviceMessageOutbox, *model.DeviceOperation, bool, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.DeviceMessageOutbox{}, nil, false, err
+	}
+	defer tx.Rollback(ctx)
+
+	message, err := scanDeviceMessageOutbox(tx.QueryRow(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+		FROM device_message_outbox
+		WHERE message_id = $1
+		FOR UPDATE
+	`, messageID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageOutbox{}, nil, false, ErrNotFound
+	}
+	if err != nil {
+		return model.DeviceMessageOutbox{}, nil, false, err
+	}
+
+	operation, err := scanDeviceOperation(tx.QueryRow(ctx, `
+		SELECT id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+		FROM device_operations
+		WHERE operation_id = $1
+		FOR UPDATE
+	`, message.OperationID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageOutbox{}, nil, false, ErrNotFound
+	}
+	if err != nil {
+		return model.DeviceMessageOutbox{}, nil, false, err
+	}
+
+	if isCompletedLifecycleOperationStatus(operation.Status, operation.OperationType) {
+		return model.DeviceMessageOutbox{}, nil, false, ErrConflict
+	}
+
+	switch message.Status {
+	case model.DeviceMessageOutboxStatusPending:
+		if err := tx.Commit(ctx); err != nil {
+			return model.DeviceMessageOutbox{}, nil, false, err
+		}
+		return message, &operation, false, nil
+	case model.DeviceMessageOutboxStatusRetrying, model.DeviceMessageOutboxStatusDeadLettered:
+	default:
+		return model.DeviceMessageOutbox{}, nil, false, ErrConflict
+	}
+
+	availableAt = availableAt.UTC().Truncate(time.Microsecond)
+	message, err = scanDeviceMessageOutbox(tx.QueryRow(ctx, `
+		UPDATE device_message_outbox
+		SET status = 'pending',
+			attempt_count = 0,
+			last_error = NULL,
+			available_at = $2,
+			published_at = NULL
+		WHERE message_id = $1
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, available_at, published_at, created_at, updated_at
+	`, messageID, availableAt))
+	if err != nil {
+		return model.DeviceMessageOutbox{}, nil, false, err
+	}
+
+	operation, err = scanDeviceOperation(tx.QueryRow(ctx, `
+		UPDATE device_operations
+		SET status = 'pending',
+			result_payload = '{}'::jsonb,
+			error_code = NULL,
+			error_message = NULL,
+			retryable = NULL,
+			completed_at = NULL
+		WHERE operation_id = $1
+		RETURNING id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+	`, operation.OperationID))
+	if err != nil {
+		return model.DeviceMessageOutbox{}, nil, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.DeviceMessageOutbox{}, nil, false, err
+	}
+	return message, &operation, true, nil
+}
+
+func (s *Store) RequeueInboxMessage(ctx context.Context, messageID string) (model.DeviceMessageInbox, *model.DeviceOperation, bool, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.DeviceMessageInbox{}, nil, false, err
+	}
+	defer tx.Rollback(ctx)
+
+	message, err := scanDeviceMessageInbox(tx.QueryRow(ctx, `
+		SELECT id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+		FROM device_message_inbox
+		WHERE message_id = $1
+		FOR UPDATE
+	`, messageID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceMessageInbox{}, nil, false, ErrNotFound
+	}
+	if err != nil {
+		return model.DeviceMessageInbox{}, nil, false, err
+	}
+
+	operation, err := getDeviceOperationOptionalTx(ctx, tx, message.OperationID)
+	if err != nil {
+		return model.DeviceMessageInbox{}, nil, false, err
+	}
+
+	switch message.Status {
+	case model.DeviceMessageInboxStatusRetrying:
+		if err := tx.Commit(ctx); err != nil {
+			return model.DeviceMessageInbox{}, nil, false, err
+		}
+		return message, operation, false, nil
+	case model.DeviceMessageInboxStatusDeadLettered:
+	default:
+		return model.DeviceMessageInbox{}, nil, false, ErrConflict
+	}
+
+	message, err = scanDeviceMessageInbox(tx.QueryRow(ctx, `
+		UPDATE device_message_inbox
+		SET status = 'retrying',
+			attempt_count = 0,
+			last_error = NULL,
+			processed_at = NULL
+		WHERE message_id = $1
+		RETURNING id::text, message_id, operation_id, correlation_id, causation_id, stream, message_type, schema_version, partition_key, payload, status, attempt_count, last_error, received_at, processed_at, created_at, updated_at
+	`, messageID))
+	if err != nil {
+		return model.DeviceMessageInbox{}, nil, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.DeviceMessageInbox{}, nil, false, err
+	}
+	return message, operation, true, nil
+}
+
+func (s *Store) getDeviceOperationOptional(ctx context.Context, operationID string) (*model.DeviceOperation, error) {
+	operation, err := s.GetDeviceOperation(ctx, operationID)
+	if errors.Is(err, ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &operation, nil
+}
+
+func getDeviceOperationOptionalTx(ctx context.Context, tx pgx.Tx, operationID string) (*model.DeviceOperation, error) {
+	operation, err := scanDeviceOperation(tx.QueryRow(ctx, `
+		SELECT id::text, operation_id, correlation_id, organization_id::text, device_id::text, operation_type, status, requested_by, request_payload, result_payload, error_code, error_message, retryable, created_at, updated_at, completed_at
+		FROM device_operations
+		WHERE operation_id = $1
+		FOR UPDATE
+	`, operationID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &operation, nil
+}
+
+func outboxStatusesToStrings(statuses []model.DeviceMessageOutboxStatus) []string {
+	values := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		values = append(values, string(status))
+	}
+	return values
+}
+
+func inboxStatusesToStrings(statuses []model.DeviceMessageInboxStatus) []string {
+	values := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		values = append(values, string(status))
+	}
+	return values
+}
+
+func isCompletedLifecycleOperationStatus(status model.DeviceOperationStatus, operationType model.DeviceOperationType) bool {
+	if operationType != model.DeviceOperationTypeProvision && operationType != model.DeviceOperationTypeDeactivate {
+		return false
+	}
+	return status == model.DeviceOperationStatusSucceeded || status == model.DeviceOperationStatusFailed
+}

--- a/internal/store/lifecycle_admin_integration_test.go
+++ b/internal/store/lifecycle_admin_integration_test.go
@@ -1,0 +1,293 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/model"
+)
+
+func TestListOutboxMessagesByStatusFiltersLifecycleRows(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+
+	ctx := context.Background()
+	first := createLifecycleOutboxFixture(t, env, "list-outbox-1", time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC))
+	second := createLifecycleOutboxFixture(t, env, "list-outbox-2", time.Date(2026, 4, 29, 9, 5, 0, 0, time.UTC))
+	third := createLifecycleOutboxFixture(t, env, "list-outbox-3", time.Date(2026, 4, 29, 9, 10, 0, 0, time.UTC))
+
+	if _, err := env.store.UpdateOutboxMessage(ctx, first.Message.MessageID, DeviceMessageOutboxUpdateInput{
+		Status:       model.DeviceMessageOutboxStatusRetrying,
+		AttemptCount: 2,
+		LastError:    stringPtr("retry later"),
+		AvailableAt:  first.Message.AvailableAt.Add(2 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.store.UpdateOutboxMessage(ctx, second.Message.MessageID, DeviceMessageOutboxUpdateInput{
+		Status:       model.DeviceMessageOutboxStatusDeadLettered,
+		AttemptCount: 5,
+		LastError:    stringPtr("permanent failure"),
+		AvailableAt:  second.Message.AvailableAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.store.UpdateOutboxMessage(ctx, third.Message.MessageID, DeviceMessageOutboxUpdateInput{
+		Status:       model.DeviceMessageOutboxStatusPublished,
+		AttemptCount: 1,
+		AvailableAt:  third.Message.AvailableAt,
+		PublishedAt:  timePtr(third.Message.AvailableAt.Add(time.Minute)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	messages, err := env.store.ListOutboxMessagesByStatus(ctx, []model.DeviceMessageOutboxStatus{
+		model.DeviceMessageOutboxStatusRetrying,
+		model.DeviceMessageOutboxStatusDeadLettered,
+	}, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 outbox messages, got %d", len(messages))
+	}
+	if messages[0].MessageID != second.Message.MessageID || messages[1].MessageID != first.Message.MessageID {
+		t.Fatalf("unexpected outbox list order: %+v", messages)
+	}
+}
+
+func TestGetOutboxMessageDetailIncludesOperation(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	fixture := createLifecycleOutboxFixture(t, env, "show-outbox", time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC))
+
+	detail, err := env.store.GetOutboxMessageDetail(context.Background(), fixture.Message.MessageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Message.MessageID != fixture.Message.MessageID {
+		t.Fatalf("unexpected outbox detail message: %+v", detail.Message)
+	}
+	if detail.Operation == nil || detail.Operation.OperationID != fixture.Operation.OperationID {
+		t.Fatalf("expected related operation %q, got %+v", fixture.Operation.OperationID, detail.Operation)
+	}
+}
+
+func TestRequeueOutboxMessageResetsRetryState(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	fixture := createLifecycleOutboxFixture(t, env, "requeue-outbox", time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC))
+
+	completedAt := fixture.Message.AvailableAt.Add(10 * time.Minute)
+	if _, err := env.store.UpdateOutboxMessage(ctx, fixture.Message.MessageID, DeviceMessageOutboxUpdateInput{
+		Status:       model.DeviceMessageOutboxStatusDeadLettered,
+		AttemptCount: 5,
+		LastError:    stringPtr("publish failed"),
+		AvailableAt:  completedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	retryable := false
+	if _, err := env.store.UpdateDeviceOperation(ctx, fixture.Operation.OperationID, DeviceOperationUpdateInput{
+		Status:        model.DeviceOperationStatusDeadLettered,
+		ResultPayload: map[string]any{"phase": "publish"},
+		ErrorCode:     stringPtr("publish_failed"),
+		ErrorMessage:  stringPtr("publish failed"),
+		Retryable:     &retryable,
+		CompletedAt:   &completedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	requeueAt := time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC)
+	message, operation, changed, err := env.store.RequeueOutboxMessage(ctx, fixture.Message.MessageID, requeueAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected dead-lettered outbox row to be requeued")
+	}
+	if message.Status != model.DeviceMessageOutboxStatusPending || message.AttemptCount != 0 {
+		t.Fatalf("unexpected outbox message after requeue: %+v", message)
+	}
+	if message.LastError != nil || message.PublishedAt != nil || !message.AvailableAt.Equal(requeueAt) {
+		t.Fatalf("expected cleared outbox retry fields, got %+v", message)
+	}
+	if operation == nil {
+		t.Fatal("expected related operation in requeue result")
+	}
+	if operation.Status != model.DeviceOperationStatusPending {
+		t.Fatalf("expected pending operation after requeue, got %+v", operation)
+	}
+	if operation.ErrorCode != nil || operation.ErrorMessage != nil || operation.Retryable != nil || operation.CompletedAt != nil {
+		t.Fatalf("expected cleared operation error fields, got %+v", operation)
+	}
+}
+
+func TestRequeueOutboxMessageRejectsCompletedLifecycleOperation(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	fixture := createLifecycleOutboxFixture(t, env, "requeue-outbox-guard", time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC))
+
+	if _, err := env.store.UpdateOutboxMessage(ctx, fixture.Message.MessageID, DeviceMessageOutboxUpdateInput{
+		Status:       model.DeviceMessageOutboxStatusRetrying,
+		AttemptCount: 2,
+		LastError:    stringPtr("stale retry"),
+		AvailableAt:  fixture.Message.AvailableAt.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	completedAt := fixture.Message.AvailableAt.Add(5 * time.Minute)
+	if _, err := env.store.UpdateDeviceOperation(ctx, fixture.Operation.OperationID, DeviceOperationUpdateInput{
+		Status:        model.DeviceOperationStatusSucceeded,
+		ResultPayload: map[string]any{"video_cloud_devid": "video-requeue-outbox-guard"},
+		CompletedAt:   &completedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, err := env.store.RequeueOutboxMessage(ctx, fixture.Message.MessageID, completedAt.Add(time.Minute))
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict when requeue would roll back a completed operation, got %v", err)
+	}
+}
+
+func TestListInboxMessagesByStatusAndShowDetail(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	fixture := createLifecycleOutboxFixture(t, env, "list-inbox", time.Date(2026, 4, 29, 13, 0, 0, 0, time.UTC))
+
+	firstReceivedAt := time.Date(2026, 4, 29, 13, 5, 0, 0, time.UTC)
+	secondReceivedAt := time.Date(2026, 4, 29, 13, 10, 0, 0, time.UTC)
+	if _, _, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-list-inbox-1",
+		OperationID:   fixture.Operation.OperationID,
+		CorrelationID: fixture.Operation.CorrelationID,
+		Stream:        "video.account.events",
+		MessageType:   string(channel.MessageTypeDeviceProvisionFailed),
+		SchemaVersion: "1.0",
+		PartitionKey:  fixture.Operation.DeviceID,
+		Payload:       map[string]any{"error_code": "bad_request"},
+		Status:        model.DeviceMessageInboxStatusRetrying,
+		AttemptCount:  1,
+		ReceivedAt:    firstReceivedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-list-inbox-2",
+		OperationID:   fixture.Operation.OperationID,
+		CorrelationID: fixture.Operation.CorrelationID,
+		Stream:        "video.account.events",
+		MessageType:   string(channel.MessageTypeDeviceProvisionFailed),
+		SchemaVersion: "1.0",
+		PartitionKey:  fixture.Operation.DeviceID,
+		Payload:       map[string]any{"error_code": "fatal"},
+		Status:        model.DeviceMessageInboxStatusDeadLettered,
+		AttemptCount:  5,
+		LastError:     stringPtr("fatal"),
+		ReceivedAt:    secondReceivedAt,
+		ProcessedAt:   timePtr(secondReceivedAt.Add(time.Minute)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	messages, err := env.store.ListInboxMessagesByStatus(ctx, []model.DeviceMessageInboxStatus{
+		model.DeviceMessageInboxStatusRetrying,
+		model.DeviceMessageInboxStatusDeadLettered,
+	}, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 inbox messages, got %d", len(messages))
+	}
+	if messages[0].MessageID != "evt-list-inbox-2" || messages[1].MessageID != "evt-list-inbox-1" {
+		t.Fatalf("unexpected inbox list order: %+v", messages)
+	}
+
+	detail, err := env.store.GetInboxMessageDetail(ctx, "evt-list-inbox-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Operation == nil || detail.Operation.OperationID != fixture.Operation.OperationID {
+		t.Fatalf("expected related operation %q, got %+v", fixture.Operation.OperationID, detail.Operation)
+	}
+}
+
+func TestRequeueInboxMessageReopensDeadLetteredRow(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	fixture := createLifecycleOutboxFixture(t, env, "requeue-inbox", time.Date(2026, 4, 29, 14, 0, 0, 0, time.UTC))
+
+	processedAt := fixture.Message.AvailableAt.Add(15 * time.Minute)
+	if _, _, err := env.store.CreateOrGetInboxMessage(ctx, DeviceMessageInboxCreateInput{
+		MessageID:     "evt-requeue-inbox",
+		OperationID:   fixture.Operation.OperationID,
+		CorrelationID: fixture.Operation.CorrelationID,
+		Stream:        "video.account.events",
+		MessageType:   string(channel.MessageTypeDeviceProvisionFailed),
+		SchemaVersion: "1.0",
+		PartitionKey:  fixture.Operation.DeviceID,
+		Payload:       map[string]any{"error_code": "fatal"},
+		Status:        model.DeviceMessageInboxStatusDeadLettered,
+		AttemptCount:  5,
+		LastError:     stringPtr("fatal"),
+		ReceivedAt:    fixture.Message.AvailableAt,
+		ProcessedAt:   &processedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	message, operation, changed, err := env.store.RequeueInboxMessage(ctx, "evt-requeue-inbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected dead-lettered inbox row to reopen")
+	}
+	if message.Status != model.DeviceMessageInboxStatusRetrying || message.AttemptCount != 0 {
+		t.Fatalf("unexpected inbox message after requeue: %+v", message)
+	}
+	if message.LastError != nil || message.ProcessedAt != nil {
+		t.Fatalf("expected cleared inbox retry fields, got %+v", message)
+	}
+	if operation == nil || operation.OperationID != fixture.Operation.OperationID {
+		t.Fatalf("expected related operation %q, got %+v", fixture.Operation.OperationID, operation)
+	}
+}
+
+func createLifecycleOutboxFixture(t *testing.T, env storeIntegrationEnv, suffix string, now time.Time) DeviceLifecycleOperationResult {
+	t.Helper()
+
+	orgID, userID, deviceID := createDeviceFixtureForEmail(t, env, suffix+"@example.com")
+	result, err := env.store.StartDeviceLifecycleOperation(context.Background(), DeviceLifecycleOperationInput{
+		OperationID:       "op-" + suffix,
+		CorrelationID:     "corr-" + suffix,
+		MessageID:         "msg-" + suffix,
+		OrganizationID:    orgID,
+		DeviceID:          deviceID,
+		OperationType:     model.DeviceOperationTypeProvision,
+		RequestedBy:       &userID,
+		RequestPayload:    map[string]any{"video_cloud_devid": "video-" + suffix},
+		OutboxMessageType: string(channel.MessageTypeDeviceProvisionRequested),
+		OutboxPayload: map[string]any{
+			"org_id":            orgID,
+			"account_device_id": deviceID,
+			"video_cloud_devid": "video-" + suffix,
+			"activity_id":       "activity-" + suffix,
+			"clip_public_key":   "clip-" + suffix,
+			"requested_by":      userID,
+		},
+		Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
+}


### PR DESCRIPTION
## Summary
- add a supported `cmd/lifecycle-admin` maintenance CLI for listing, inspecting, and requeueing lifecycle outbox and inbox rows
- add store-level list/show/requeue helpers that reset publish retry state safely and block outbox requeue from rolling completed lifecycle operations backward
- update the README and provisioning worker runbook to use the maintenance CLI, including the inbox replay caveat for acknowledged broker messages

## Validation
- `git diff --check`
- `go test ./cmd/lifecycle-admin ./internal/store -count=1`
- `go test ./... -count=1`
- `go build ./...`
- `go test ./internal/store -run 'Test(RequeueOutboxMessageResetsRetryState|RequeueOutboxMessageRejectsCompletedLifecycleOperation|RequeueInboxMessageReopensDeadLetteredRow)$' -count=1 -v` (env-gated tests currently skip because `TEST_DATABASE_URL` is unset in this runtime; Docker is installed but the daemon is not running)

Refs #44