### PR TITLE
[Integration] Define product-level provisioning readiness contract

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -11,7 +11,7 @@ This plan is derived from:
 - `contracts/CONTRACT_OVERVIEW.md`
 - `docs/SPEC.md`
 
-As of April 29, 2026, `origin/main` already includes the merged persistence, API, worker, broker, test-report, and runbook slices for this milestone. The remaining account-manager work is contract follow-up hardening around cross-repository integration boundaries and operational maintenance surfaces.
+As of April 30, 2026, `origin/main` already includes the merged persistence, API, worker, broker, test-report, and runbook slices for this milestone. The remaining account-manager work is contract and operations follow-up around cross-repository integration boundaries, lifecycle maintenance tooling, and delete semantics.
 
 ## Current Implementation Snapshot
 
@@ -27,10 +27,8 @@ The current account manager now implements:
 Residual contract follow-up gaps for this milestone snapshot:
 
 - Define and hand off the video-side lifecycle integration worker that consumes `account.video.commands`, calls Realtek video server APIs, and publishes `video.account.events`.
-- Decide whether provisioning should persist the pending `video_cloud_devid` mapping to device metadata before video-side success/failure projection.
 - Add an operational surface for inspecting and requeueing retry/dead-letter lifecycle messages without direct SQL.
 - Keep `DELETE /devices/:deviceId` registry soft-delete explicitly separate from product-level `POST /deactivate`, unless product policy later requires delete to enqueue deactivation.
-- Decide whether account manager should expose a product-level readiness view, or whether readiness remains owned by an integration service.
 
 ## Milestone And Issue Map
 
@@ -422,6 +420,44 @@ Recommended behavior:
 - `DELETE /devices/:deviceId` remains account-registry soft-disable.
 - If product policy requires delete to trigger deactivation, delete should enqueue `DeviceDeactivateRequested` and mark metadata as `video_cloud_activation_status=deactivation_pending`.
 - A failed deactivation must be visible in metadata and operation state.
+
+## Phase 9.1: Product Readiness Contract
+
+Product-level readiness is a composed multi-service state, not an
+account-manager-owned boolean.
+
+Contract rules:
+
+- `rtk_account_manager` owns registry state, provisioning operation state,
+  projected `video_cloud_*` metadata, and projected account-side
+  `online|offline` status.
+- Realtek video server or the video-side integration layer owns token issuance,
+  video-side bootstrap prerequisites, and transport/session readiness inputs
+  that do not live in account-manager state.
+- `GET /provisioning` is the account-side lifecycle projection surface; it is
+  not a unified product-readiness endpoint.
+- Clients or an integrating service must compose readiness from both account
+  and video-side signals until a future dedicated readiness API is explicitly
+  designed and implemented.
+
+Recommended composed readiness states:
+
+- `registry_only`
+- `activation_pending`
+- `activation_failed`
+- `activation_succeeded`
+- `credentials_pending`
+- `transport_pending`
+- `ready`
+- `degraded`
+
+Failure handling:
+
+- Activation failure must stay visible through operation error fields and
+  projected metadata.
+- Missing token/bootstrap prerequisites after activation must surface as
+  post-activation readiness gaps, not as fake activation success.
+- `status=online` alone does not prove full provisioning readiness.
 
 ## Phase 10: Testing And Reporting
 

--- a/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
+++ b/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
@@ -201,6 +201,29 @@ EOF
 
 Re-run the device query above and confirm `status=online`.
 
+## Readiness Interpretation
+
+This repository does not expose one aggregate "device ready" endpoint.
+
+- `GET /provisioning` tells you whether account side accepted the lifecycle
+  request and what activation metadata has been projected back so far.
+- `DeviceProvisionSucceeded` means the mapped video-side activation succeeded;
+  it does not prove token issuance, device bootstrap, or owner transport
+  connectivity are complete.
+- `status=online` means the device projected an owner transport connection; it
+  does not prove provisioning or token issuance completed successfully.
+
+Treat local product readiness as a composed check:
+
+1. Account-manager device record exists and is enabled.
+2. Provisioning operation succeeded and the expected `video_cloud_*` metadata is present.
+3. Any required video-side token/bootstrap step is complete.
+4. The device projects `status=online` through `DeviceOnlineChanged`.
+
+If activation fails, or if the device never comes online after activation,
+surface that as a readiness gap instead of treating the device as fully
+provisioned.
+
 ## Run A Deactivation Flow
 
 1. Create the deactivation operation:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -461,6 +461,63 @@ Provisioning rules:
 - `DeviceProvisionSucceeded` replaces the pending activation metadata with the terminal activation result but does not set account-manager `status=online`.
 - `DeviceOnlineChanged` is the only video-side event that may project account-manager `status=online|offline`.
 
+### Product Readiness Contract
+
+`rtk_account_manager` does not currently own one aggregate "product readiness"
+boolean or API. Product readiness crosses multiple service boundaries, so the
+current owner of readiness aggregation is the integrating client or service
+that can read both account-manager projections and the remaining video-side
+bootstrap inputs.
+
+Current readiness inputs:
+
+| Input | Source of truth | Meaning |
+| --- | --- | --- |
+| Account registry record exists and is enabled | `rtk_account_manager` device APIs | The organization-scoped device record exists and is not soft-disabled. |
+| Provisioning operation accepted | `POST /provision`, `GET /provisioning` | Account side persisted the lifecycle operation and outbox command. |
+| Video activation result projected | `GET /provisioning`, device `video_cloud_*` metadata | Realtek video activation succeeded or failed for the mapped device identity. |
+| Subject-bound token issuance completed | Video-side or integration-service auth surface | The device or app has the credentials required for product use. |
+| Video-side bootstrap prerequisites completed when required | Video-side APIs | Device info/config setup or equivalent downstream bootstrap state is available. |
+| Owner transport connected | Account-manager device `status`, projected from `DeviceOnlineChanged` | The device has actually come online through its supported owner transport. |
+
+Client consumption rules:
+
+- Treat `GET /v1/orgs/:orgId/devices/:deviceId/provisioning` as the
+  account-side lifecycle projection, not as a full readiness endpoint.
+- Do not treat `DeviceProvisionSucceeded` by itself as product-ready; it only
+  proves activation metadata was projected.
+- Do not treat account-manager `status=online` by itself as product-ready; it
+  does not prove activation or token issuance completed.
+- Compose the final readiness view from account-manager lifecycle state plus
+  the required video-side credential and bootstrap signals.
+
+Recommended composed readiness states:
+
+| State | Required signals | Meaning |
+| --- | --- | --- |
+| `registry_only` | Device record exists, no accepted provisioning operation | The device exists only as an account-side registry record. |
+| `activation_pending` | Provisioning operation is `pending`, `published`, or `retrying` | Account side accepted provisioning, but no terminal activation result is projected yet. |
+| `activation_failed` | Provisioning operation is `failed` or `dead_lettered`, or projected metadata records `video_cloud_last_error` | Activation did not complete; clients must surface the failure instead of claiming readiness. |
+| `activation_succeeded` | Provisioning operation is `succeeded` and activation metadata is present | Video activation completed, but downstream readiness steps may still be missing. |
+| `credentials_pending` | Activation succeeded, but required token issuance is not confirmed | The device is activated but not yet ready to authenticate for product use. |
+| `transport_pending` | Activation and credentials are ready, but the device is not yet projected `online` | Bootstrap is almost complete, but the device has not connected through owner transport yet. |
+| `ready` | Activation succeeded, credentials/bootstrap are ready, and the device is projected `online` | The product can treat the device as provisioned and currently connected. |
+| `degraded` | The device was previously `ready` but later projects `offline` or another required dependency regresses | Product readiness was reached earlier, but current usability degraded. |
+
+Failure handling rules:
+
+- If activation fails, surface the provisioning operation error fields and
+  projected `video_cloud_last_error`; do not silently collapse back to
+  `registry_only`.
+- If token issuance or other video-side bootstrap fails after activation,
+  surface that as a post-activation readiness failure rather than rewriting the
+  account-manager provisioning result.
+- If the device never projects `online`, keep the readiness view in
+  `transport_pending` or a more specific post-activation state instead of
+  claiming full success.
+- A future unified readiness endpoint would require a separate API/OpenAPI/test
+  change set; this repository does not currently expose one.
+
 ## 8. API Conventions
 
 - Request and response bodies use JSON.


### PR DESCRIPTION
## Summary
- define product-level provisioning readiness as a composed multi-service state instead of an account-manager-owned boolean or endpoint
- document the required readiness inputs, recommended composed states, and failure handling in the main spec and rollout plan
- update the local provisioning runbook so activation success and `status=online` are not mistaken for full product readiness

## Validation
- `git diff --check`
- docs-only change; no code or test behavior changed

Refs #46