### PR TITLE
[Docs] Finalize delete versus product deactivation policy

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -29,7 +29,7 @@ Residual contract follow-up gaps for this milestone snapshot:
 - Define and hand off the video-side lifecycle integration worker that consumes `account.video.commands`, calls Realtek video server APIs, and publishes `video.account.events`.
 - Decide whether provisioning should persist the pending `video_cloud_devid` mapping to device metadata before video-side success/failure projection.
 - Add an operational surface for inspecting and requeueing retry/dead-letter lifecycle messages without direct SQL.
-- Keep `DELETE /devices/:deviceId` registry soft-delete explicitly separate from product-level `POST /deactivate`, unless product policy later requires delete to enqueue deactivation.
+- Final policy: keep `DELETE /devices/:deviceId` as a registry-only soft-disable and require explicit `POST /deactivate` for product-level video teardown.
 - Decide whether account manager should expose a product-level readiness view, or whether readiness remains owned by an integration service.
 
 ## Milestone And Issue Map
@@ -59,7 +59,7 @@ These issues are follow-ups to the merged account-manager v2 implementation. The
 | `[Integration] Implement video-side account/video lifecycle worker` | P1 | `integration`, `worker`, `v2` | Likely `video_cloud` or a dedicated integration repo | Worker consumes `DeviceProvisionRequested` / `DeviceDeactivateRequested`, calls Realtek video server `POST /activate_camera` / `POST /deactivate_camera`, and publishes success/failure events. |
 | `[API] Persist pending video_cloud_devid mapping on provisioning request` | P2 | `api`, `backend`, `v2` | `rtk_account_manager` | Provisioning request records the requested mapping in account-manager metadata before the video-side result arrives, without treating activation as complete. |
 | `[Ops] Add lifecycle dead-letter and retry management commands` | P2 | `ops`, `worker`, `backend`, `v2` | `rtk_account_manager` | Admin CLI or maintenance commands list failed lifecycle messages, inspect payload/error context, and safely requeue eligible rows. |
-| `[Docs] Finalize delete versus product deactivation policy` | P2 | `docs`, `api`, `v2` | `rtk_account_manager` plus product owner | Document whether registry delete stays soft-delete only or also enqueues `DeviceDeactivateRequested`; update API behavior only if product policy changes. |
+| `[Docs] Finalize delete versus product deactivation policy` | P2 | `docs`, `api`, `v2` | `rtk_account_manager` | Document the final policy that registry delete stays soft-delete only while explicit `POST /deactivate` owns product teardown. |
 | `[Integration] Define product-level provisioning readiness contract` | P3 | `integration`, `docs`, `v2` | Integration service or cross-repo contracts | Define the aggregate readiness signal spanning account record, video activation, subject-bound tokens, device info/config, and transport online state. |
 
 Status values:
@@ -414,14 +414,12 @@ Do not reuse Realtek video server `POST /setup_eventhub` configuration for this 
 
 ## Phase 9: Deactivation And Delete Semantics
 
-Keep account registry deletion and product-level deactivation distinct.
+Final policy: keep account-registry deletion and product-level deactivation distinct.
 
-Recommended behavior:
-
-- `POST /deactivate` starts product-level deactivation.
-- `DELETE /devices/:deviceId` remains account-registry soft-disable.
-- If product policy requires delete to trigger deactivation, delete should enqueue `DeviceDeactivateRequested` and mark metadata as `video_cloud_activation_status=deactivation_pending`.
-- A failed deactivation must be visible in metadata and operation state.
+- `POST /deactivate` is the only account-manager API that starts product-level video teardown.
+- `DELETE /devices/:deviceId` remains an account-registry soft-disable and does not enqueue `DeviceDeactivateRequested`.
+- If the product-side device must be torn down, call `POST /deactivate`, wait for the corresponding terminal video-side result event, then optionally soft-delete the registry record.
+- A failed deactivation must remain visible in metadata and operation state; registry delete alone must not be presented as completed product disablement.
 
 ## Phase 10: Testing And Reporting
 

--- a/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
+++ b/docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md
@@ -264,7 +264,7 @@ The local `log` publisher itself is deterministic and does not manufacture trans
 - `POST /v1/orgs/:orgId/devices/:deviceId/deactivate` is the product-side teardown path. It creates a lifecycle operation and emits `DeviceDeactivateRequested` for the downstream video service.
 - `DELETE /v1/orgs/:orgId/devices/:deviceId` is the account-manager registry delete path. It disables the account-side device record; it does not send a cross-service deactivation command by itself.
 
-If the product-side device should be torn down, run deactivation first and confirm the matching video-side result event. Use the registry delete endpoint only for account-manager record lifecycle.
+If the product-side device should be torn down, run deactivation first and confirm the matching video-side result event before treating the device as fully disabled at product level. Use the registry delete endpoint only for account-manager record lifecycle.
 
 ## Shutdown
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -454,7 +454,7 @@ Provisioning rules:
 - Disabled devices cannot be provisioned.
 - The API must not directly call Realtek video server.
 - Product-level deactivation and account registry soft-delete are distinct operations.
-- `DELETE /devices/:deviceId` remains account-registry soft-disable unless product policy explicitly changes it later.
+- `DELETE /devices/:deviceId` remains an account-registry soft-disable and does not enqueue `DeviceDeactivateRequested`.
 - Omitting the deactivation `reason` defaults the outbox payload to `account_device_disabled`.
 - Reusing an explicit `operation_id` returns the existing operation when the normalized request matches and returns `409 Conflict` when it does not.
 - Operation responses may also include `error_code`, `error_message`, `retryable`, and `completed_at` once the inbox projection records a terminal result.
@@ -612,5 +612,5 @@ Known follow-up items:
 - A video-side lifecycle integration worker must consume `account.video.commands`, call Realtek video server `POST /activate_camera` and `POST /deactivate_camera`, then publish `video.account.events`.
 - Provisioning may need to persist the requested `video_cloud_devid` mapping to device metadata immediately when a provisioning request is accepted, while still leaving activation status pending until video-side projection.
 - Retry and dead-letter rows are inspectable in Postgres today, but an admin maintenance command should expose list, inspect, and safe requeue workflows for operators.
-- Account registry soft-delete and product-level video deactivation remain separate. If product policy changes so delete also requires video deactivation, `DELETE /devices/:deviceId` must enqueue `DeviceDeactivateRequested` before claiming product-level disablement.
+- Account registry soft-delete and product-level video deactivation remain separate. Product teardown requires explicit `POST /deactivate`; `DELETE /devices/:deviceId` only disables the account-side registry record.
 - Product-level readiness is not an account-manager-only state. A complete readiness contract should define how account record, video activation, subject-bound token issuance, device info/config, and transport ownership are aggregated.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -439,6 +439,7 @@ paths:
       security:
         - bearerAuth: []
       summary: Delete device.
+      description: Soft-disable the account-manager registry device record only. This route does not start product-level video deactivation.
       parameters:
         - $ref: "#/components/parameters/OrgId"
         - $ref: "#/components/parameters/DeviceId"
@@ -514,6 +515,7 @@ paths:
       security:
         - bearerAuth: []
       summary: Create or reuse a deactivation operation.
+      description: Start product-level video teardown by enqueuing `DeviceDeactivateRequested`. This route is distinct from registry soft-delete.
       parameters:
         - $ref: "#/components/parameters/OrgId"
         - $ref: "#/components/parameters/DeviceId"


### PR DESCRIPTION
## Summary
- finalize the contract that registry delete stays account-manager-only while explicit `POST /deactivate` owns product-level video teardown
- remove hedge language from the spec, rollout plan, and runbook so delete is not mistaken for completed product disablement
- clarify the same separation in OpenAPI route descriptions for delete and deactivate

## Validation
- `git diff --check`
- `go test ./internal/api -run TestOpenAPIContract -count=1`

Refs #45