### PR TITLE
[Provisioning] Enforce strict provision request fields

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -518,6 +520,24 @@ func currentUserID(c *gin.Context) string {
 func bind(c *gin.Context, dst any) bool {
 	if err := c.ShouldBindJSON(dst); err != nil {
 		writeError(c, http.StatusBadRequest, "invalid_request", err.Error())
+		return false
+	}
+	return true
+}
+
+func bindStrict(c *gin.Context, dst any) bool {
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_request", err.Error())
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			writeError(c, http.StatusBadRequest, "invalid_request", "request body must contain a single JSON value")
+		} else {
+			writeError(c, http.StatusBadRequest, "invalid_request", err.Error())
+		}
 		return false
 	}
 	return true

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,6 +144,47 @@ func TestValidationHelpersWriteErrors(t *testing.T) {
 	}
 	if inconsistentBody.Error.Code != "operation_state_inconsistent" {
 		t.Fatalf("expected operation_state_inconsistent error code, got %+v", inconsistentBody)
+	}
+}
+
+func TestBindStrictRejectsUnknownFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	type strictRequest struct {
+		Name string `json:"name"`
+	}
+
+	rejectRecorder := httptest.NewRecorder()
+	rejectContext, _ := gin.CreateTestContext(rejectRecorder)
+	rejectContext.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"camera","claim_material":{"serial_number":"CAM-001"}}`))
+	if bindStrict(rejectContext, &strictRequest{}) {
+		t.Fatal("expected unknown field to be rejected")
+	}
+	if rejectRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected unknown field 400, got %d", rejectRecorder.Code)
+	}
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rejectRecorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON error body, got %v", err)
+	}
+	if body.Error.Code != "invalid_request" || !strings.Contains(body.Error.Message, `unknown field "claim_material"`) {
+		t.Fatalf("expected unknown field invalid_request, got %+v", body)
+	}
+
+	acceptRecorder := httptest.NewRecorder()
+	acceptContext, _ := gin.CreateTestContext(acceptRecorder)
+	acceptContext.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"camera"}`))
+	var accepted strictRequest
+	if !bindStrict(acceptContext, &accepted) {
+		t.Fatalf("expected strict request to be accepted: %s", acceptRecorder.Body.String())
+	}
+	if accepted.Name != "camera" {
+		t.Fatalf("expected decoded name, got %+v", accepted)
 	}
 }
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -896,6 +896,16 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 		t.Fatalf("expected raw claim material 400, got %d: %s", rawClaimRes.Code, rawClaimRes.Body.String())
 	}
 
+	unknownFieldRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provision", map[string]any{
+		"video_cloud_devid": "video-device-1",
+		"activity_id":       "activity-1",
+		"clip_public_key":   "clip-key-1",
+		"future_claim_key":  "PROVISION-001",
+	}, owner.Tokens.AccessToken)
+	if unknownFieldRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected unknown provision field 400, got %d: %s", unknownFieldRes.Code, unknownFieldRes.Body.String())
+	}
+
 	provisionRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provision", map[string]any{
 		"video_cloud_devid": "video-device-1",
 		"activity_id":       "activity-1",

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -80,7 +80,7 @@ type readinessSourcesResponse struct {
 
 func (s *Server) provisionDevice(c *gin.Context) {
 	var req provisionRequest
-	if !bind(c, &req) {
+	if !bindStrict(c, &req) {
 		return
 	}
 	if !rejectUnsupportedClaimMaterial(c, req) {


### PR DESCRIPTION
## Summary
- enforce the `ProvisionDeviceRequest` `additionalProperties: false` contract at runtime for `POST /provision`
- reject unknown provisioning request keys with `invalid_request` instead of silently ignoring them
- add unit and integration coverage for unknown-field rejection alongside the existing raw claim-material rejection cases

## Validation
- `go test ./internal/api -run 'TestBindStrictRejectsUnknownFields|TestRejectUnsupportedClaimMaterial|TestIntegrationProvisioningEndpoints' -count=1`
- `go test ./internal/api ./internal/openapi -count=1`
- `git diff --check origin/main...HEAD`
- `go test ./... -count=1`

Follow-up to PR #64 reviewer finding.
Refs #60