### PR TITLE
[Account] Add current-user password change

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -16,6 +16,7 @@ Provisioning and account/video event-channel integration are the v2 surface impl
 - Postgres persistence.
 - SQL migrations for schema management.
 - Email/password authentication.
+- Authenticated current-user password change.
 - JWT-based API authentication.
 - Refresh-token support for longer sessions.
 - Organization-based account model.
@@ -41,6 +42,7 @@ Provisioning and account/video event-channel integration are the v2 surface impl
 - Device command dispatch.
 - Device self-registration or provisioning flows in v1.
 - Device certificate management.
+- OTP/email verification, self-service password recovery/reset, account deletion, and third-party/social login.
 - Custom RBAC permissions.
 - Multi-region deployment concerns.
 
@@ -309,6 +311,9 @@ Constraints:
 - Refresh tokens may be used to issue new access tokens.
 - Refreshing a session rotates the refresh token. The previous refresh token is revoked and must not be accepted again.
 - Logout revokes the active refresh token.
+- `PATCH /v1/me/password` lets the authenticated current user change their password after presenting the current password and a new password of at least 8 characters.
+- Password change revokes all active refresh tokens for the user. Existing access tokens remain valid until their normal expiry.
+- OTP verification, self-service password recovery/reset, account deletion, and third-party/social login are deferred first-phase lifecycle capabilities and must not be presented as available API behavior until implemented.
 - Expired or revoked refresh tokens may be removed by an explicit maintenance command.
 
 ## 6. Authorization
@@ -349,6 +354,7 @@ All endpoints are versioned under `/v1`.
 | `POST` | `/v1/auth/refresh` | No | Exchange refresh token for new access token. |
 | `POST` | `/v1/auth/logout` | Yes | Revoke current refresh token/session. |
 | `GET` | `/v1/me` | Yes | Return current user and memberships. |
+| `PATCH` | `/v1/me/password` | Yes | Change current user password and revoke refresh tokens. |
 
 ### Organizations and Members
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -37,7 +37,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 
 | Behavior group | Evidence |
 | --- | --- |
-| Auth and sessions | Register, login, invalid login, refresh rotation, old refresh rejection, logout revocation, expired token parsing, wrong-secret parsing. |
+| Auth and sessions | Register, login, invalid login, password change with current-password validation, refresh-token revocation after password change, refresh rotation, old refresh rejection, logout revocation, expired token parsing, wrong-secret parsing. |
 | Disabled users | Disabled users cannot use existing access tokens, refresh tokens, or login until re-enabled. |
 | Organization access | Current-user organization listing, organization create/get/update, cross-organization organization access rejection. |
 | Member management | Owner add/update/remove/disable/enable member flows, admin/member forbidden paths, last-owner downgrade/remove/disable protection. |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -39,6 +39,7 @@ func (s *Server) Router() *gin.Engine {
 	protected.Use(s.requireAuth())
 	protected.POST("/auth/logout", s.logout)
 	protected.GET("/me", s.me)
+	protected.PATCH("/me/password", s.changePassword)
 
 	protected.GET("/orgs", s.listOrganizations)
 	protected.POST("/orgs", s.createOrganization)
@@ -221,6 +222,36 @@ func (s *Server) me(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"user": user, "organizations": orgPage.Organizations})
+}
+
+type changePasswordRequest struct {
+	CurrentPassword string `json:"current_password" binding:"required"`
+	NewPassword     string `json:"new_password" binding:"required,min=8"`
+}
+
+func (s *Server) changePassword(c *gin.Context) {
+	var req changePasswordRequest
+	if !bind(c, &req) {
+		return
+	}
+
+	userID := currentUserID(c)
+	_, hash, err := s.store.GetUserPasswordByID(c.Request.Context(), userID)
+	if err != nil || !auth.CheckPassword(hash, req.CurrentPassword) {
+		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid current password")
+		return
+	}
+
+	newHash, err := auth.HashPassword(req.NewPassword)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "password_hash_failed", "Could not hash password")
+		return
+	}
+	if err := s.store.UpdateUserPassword(c.Request.Context(), userID, newHash); err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func (s *Server) listOrganizations(c *gin.Context) {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -129,6 +129,64 @@ func TestIntegrationRegisterLoginRefreshAndLogout(t *testing.T) {
 	}
 }
 
+func TestIntegrationCurrentUserCanChangePassword(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	registered := registerUser(t, env.router, "password-change@example.com", "Password Org")
+
+	wrongCurrentRes := performJSON(env.router, http.MethodPatch, "/v1/me/password", map[string]any{
+		"current_password": "wrong-password",
+		"new_password":     "new-password123",
+	}, registered.Tokens.AccessToken)
+	if wrongCurrentRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected wrong current password 401, got %d", wrongCurrentRes.Code)
+	}
+
+	shortPasswordRes := performJSON(env.router, http.MethodPatch, "/v1/me/password", map[string]any{
+		"current_password": "password123",
+		"new_password":     "short",
+	}, registered.Tokens.AccessToken)
+	if shortPasswordRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected short new password 400, got %d", shortPasswordRes.Code)
+	}
+
+	changeRes := performJSON(env.router, http.MethodPatch, "/v1/me/password", map[string]any{
+		"current_password": "password123",
+		"new_password":     "new-password123",
+	}, registered.Tokens.AccessToken)
+	if changeRes.Code != http.StatusNoContent {
+		t.Fatalf("expected password change 204, got %d: %s", changeRes.Code, changeRes.Body.String())
+	}
+
+	oldPasswordLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "password-change@example.com",
+		"password": "password123",
+	}, "")
+	if oldPasswordLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected old password login 401, got %d", oldPasswordLoginRes.Code)
+	}
+
+	revokedRefreshRes := performJSON(env.router, http.MethodPost, "/v1/auth/refresh", map[string]any{
+		"refresh_token": registered.Tokens.RefreshToken,
+	}, "")
+	if revokedRefreshRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected password change to revoke refresh token, got %d", revokedRefreshRes.Code)
+	}
+
+	meRes := performJSON(env.router, http.MethodGet, "/v1/me", nil, registered.Tokens.AccessToken)
+	if meRes.Code != http.StatusOK {
+		t.Fatalf("expected existing access token to remain valid until expiry, got %d", meRes.Code)
+	}
+
+	newPasswordLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "password-change@example.com",
+		"password": "new-password123",
+	}, "")
+	if newPasswordLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected new password login 200, got %d: %s", newPasswordLoginRes.Code, newPasswordLoginRes.Body.String())
+	}
+}
+
 func TestIntegrationDisabledUserCannotUseExistingTokens(t *testing.T) {
 	env := newIntegrationEnv(t)
 

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -27,6 +27,12 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	}, "")
 	contract.validate(t, http.MethodPost, "/v1/auth/login", registerRes)
 
+	changePasswordRes := performJSON(env.router, http.MethodPatch, "/v1/me/password", map[string]any{
+		"current_password": "password123",
+		"new_password":     "contract-password123",
+	}, registered.Tokens.AccessToken)
+	contract.validate(t, http.MethodPatch, "/v1/me/password", changePasswordRes)
+
 	orgUpdateRes := performJSON(env.router, http.MethodPatch, "/v1/orgs/"+registered.Organization.ID, map[string]any{
 		"name": "Contract Org Updated",
 	}, registered.Tokens.AccessToken)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -117,6 +117,20 @@ func (s *Store) GetUserPassword(ctx context.Context, email string) (model.User, 
 	return user, hash, err
 }
 
+func (s *Store) GetUserPasswordByID(ctx context.Context, userID string) (model.User, string, error) {
+	var user model.User
+	var hash string
+	err := s.db.QueryRow(ctx, `
+		SELECT id::text, email, password_hash, display_name, created_at, updated_at, disabled_at
+		FROM users
+		WHERE id = $1 AND disabled_at IS NULL
+	`, userID).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.User{}, "", ErrNotFound
+	}
+	return user, hash, err
+}
+
 func (s *Store) GetUser(ctx context.Context, userID string) (model.User, error) {
 	var user model.User
 	err := s.db.QueryRow(ctx, `
@@ -128,6 +142,34 @@ func (s *Store) GetUser(ctx context.Context, userID string) (model.User, error) 
 		return model.User{}, ErrNotFound
 	}
 	return user, err
+}
+
+func (s *Store) UpdateUserPassword(ctx context.Context, userID, passwordHash string) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE users
+		SET password_hash = $2
+		WHERE id = $1 AND disabled_at IS NULL
+	`, userID, passwordHash)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE refresh_tokens
+		SET revoked_at = now()
+		WHERE user_id = $1 AND revoked_at IS NULL
+	`, userID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (s *Store) SaveRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -106,6 +106,24 @@ paths:
                 $ref: "#/components/schemas/MeResponse"
         "401":
           $ref: "#/components/responses/Error"
+  /v1/me/password:
+    patch:
+      security:
+        - bearerAuth: []
+      summary: Change the current user's password.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangePasswordRequest"
+      responses:
+        "204":
+          description: Password changed and active refresh tokens revoked.
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
   /v1/orgs:
     get:
       security:
@@ -677,6 +695,16 @@ components:
         refresh_token:
           type: string
           minLength: 1
+    ChangePasswordRequest:
+      type: object
+      required: [current_password, new_password]
+      properties:
+        current_password:
+          type: string
+          description: Current password for the authenticated user.
+        new_password:
+          type: string
+          minLength: 8
     CreateOrganizationRequest:
       type: object
       required: [name]

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -132,7 +132,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 
 | Behavior group | Evidence |
 | --- | --- |
-| Auth and sessions | Register, login, invalid login, refresh rotation, old refresh rejection, logout revocation, expired token parsing, wrong-secret parsing. |
+| Auth and sessions | Register, login, invalid login, password change with current-password validation, refresh-token revocation after password change, refresh rotation, old refresh rejection, logout revocation, expired token parsing, wrong-secret parsing. |
 | Disabled users | Disabled users cannot use existing access tokens, refresh tokens, or login until re-enabled. |
 | Organization access | Current-user organization listing, organization create/get/update, cross-organization organization access rejection. |
 | Member management | Owner add/update/remove/disable/enable member flows, admin/member forbidden paths, last-owner downgrade/remove/disable protection. |


### PR DESCRIPTION
## Summary
- add protected `PATCH /v1/me/password` for authenticated current-user password changes
- verify current password, enforce an 8-character new-password minimum, update the password hash, and revoke active refresh tokens
- document this as the first implemented lifecycle slice while explicitly deferring OTP verification, password recovery/reset, account deletion, and third-party/social login

## Validation
- `go test ./internal/api -run 'TestIntegrationCurrentUserCanChangePassword|TestIntegrationResponsesMatchOpenAPIContract' -count=1`
- `go test ./internal/api ./internal/openapi -count=1`
- `git diff --check`
- `go test ./... -count=1`

Note: `TEST_DATABASE_URL` is unset in this environment, so the existing database-backed integration tests were compiled but skipped by their guard.

Refs #62