### PR TITLE
[Account] Add current-user self disable

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -17,6 +17,7 @@ Provisioning and account/video event-channel integration are the v2 surface impl
 - SQL migrations for schema management.
 - Email/password authentication.
 - Authenticated current-user password change.
+- Authenticated current-user account disable/delete.
 - JWT-based API authentication.
 - Refresh-token support for longer sessions.
 - Organization-based account model.
@@ -43,7 +44,7 @@ Provisioning and account/video event-channel integration are the v2 surface impl
 - Device command dispatch.
 - Device self-registration or provisioning flows in v1.
 - Device certificate management.
-- OTP/email verification, self-service password recovery/reset, account deletion, and third-party/social login.
+- OTP/email verification, self-service password recovery/reset, and third-party/social login.
 - Executable batch operations, OTA campaign execution, and firmware rollout policy.
 - Custom RBAC permissions.
 - Multi-region deployment concerns.
@@ -165,6 +166,7 @@ Constraints:
 
 - `email` must be stored lowercase and trimmed.
 - Disabled users must not authenticate, refresh tokens, or access protected organization/device APIs with existing access tokens.
+- Self-service account deletion is implemented as account-manager user soft-disable by setting `disabled_at`; it does not remove organizations, memberships, devices, or product-level device state.
 
 ### `organization_members`
 
@@ -372,7 +374,9 @@ Constraints:
 - Logout revokes the active refresh token.
 - `PATCH /v1/me/password` lets the authenticated current user change their password after presenting the current password and a new password of at least 8 characters.
 - Password change revokes all active refresh tokens for the user. Existing access tokens remain valid until their normal expiry.
-- OTP verification, self-service password recovery/reset, account deletion, and third-party/social login are deferred first-phase lifecycle capabilities and must not be presented as available API behavior until implemented.
+- `DELETE /v1/me` lets the authenticated current user disable their own account. The operation revokes active refresh tokens and refuses to disable the user while they are the last active owner of any organization.
+- Self-service account deletion is account-manager user lifecycle only. It preserves organization memberships and registry/device records, and it does not imply product-level device deletion or deactivation.
+- OTP verification, self-service password recovery/reset, and third-party/social login are deferred first-phase lifecycle capabilities and must not be presented as available API behavior until implemented.
 - Expired or revoked refresh tokens may be removed by an explicit maintenance command.
 
 ## 6. Authorization
@@ -415,6 +419,7 @@ All endpoints are versioned under `/v1`.
 | `POST` | `/v1/auth/refresh` | No | Exchange refresh token for new access token. |
 | `POST` | `/v1/auth/logout` | Yes | Revoke current refresh token/session. |
 | `GET` | `/v1/me` | Yes | Return current user and memberships. |
+| `DELETE` | `/v1/me` | Yes | Disable current user account and revoke refresh tokens. |
 | `PATCH` | `/v1/me/password` | Yes | Change current user password and revoke refresh tokens. |
 
 ### Organizations and Members
@@ -778,6 +783,7 @@ Tests should cover:
 - Device status can be updated by `owner` or `admin`.
 - Last organization `owner` cannot be removed or downgraded.
 - Last organization `owner` cannot be disabled.
+- Self-service account deletion is refused while the current user is the last active `owner` of any organization.
 - Owner can disable and enable member users.
 - Admin and member cannot disable or enable users.
 - Refresh token rotation rejects previously used refresh tokens.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -41,6 +41,7 @@ func (s *Server) Router() *gin.Engine {
 	protected.Use(s.requireAuth())
 	protected.POST("/auth/logout", s.logout)
 	protected.GET("/me", s.me)
+	protected.DELETE("/me", s.deleteCurrentUser)
 	protected.PATCH("/me/password", s.changePassword)
 
 	protected.GET("/orgs", s.listOrganizations)
@@ -236,6 +237,14 @@ func (s *Server) me(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"user": user, "organizations": orgPage.Organizations})
+}
+
+func (s *Server) deleteCurrentUser(c *gin.Context) {
+	if err := s.store.DisableCurrentUser(c.Request.Context(), currentUserID(c)); err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 type changePasswordRequest struct {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -187,6 +187,66 @@ func TestIntegrationCurrentUserCanChangePassword(t *testing.T) {
 	}
 }
 
+func TestIntegrationCurrentUserCanDisableSelfWithOwnerSafety(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	lastOwner := registerUser(t, env.router, "last-owner@example.com", "Last Owner Org")
+	lastOwnerDeleteRes := performJSON(env.router, http.MethodDelete, "/v1/me", nil, lastOwner.Tokens.AccessToken)
+	if lastOwnerDeleteRes.Code != http.StatusConflict {
+		t.Fatalf("expected last owner self-delete 409, got %d: %s", lastOwnerDeleteRes.Code, lastOwnerDeleteRes.Body.String())
+	}
+
+	owner := registerUser(t, env.router, "self-delete@example.com", "Self Delete Org")
+	backupOwner := registerUser(t, env.router, "backup-owner@example.com", "Backup Owner Org")
+
+	addBackupOwnerRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/members", map[string]any{
+		"email": "backup-owner@example.com",
+		"role":  "owner",
+	}, owner.Tokens.AccessToken)
+	if addBackupOwnerRes.Code != http.StatusCreated {
+		t.Fatalf("expected add backup owner 201, got %d: %s", addBackupOwnerRes.Code, addBackupOwnerRes.Body.String())
+	}
+
+	deleteRes := performJSON(env.router, http.MethodDelete, "/v1/me", nil, owner.Tokens.AccessToken)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("expected self-delete 204, got %d: %s", deleteRes.Code, deleteRes.Body.String())
+	}
+
+	meRes := performJSON(env.router, http.MethodGet, "/v1/me", nil, owner.Tokens.AccessToken)
+	if meRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected disabled self access token 401, got %d", meRes.Code)
+	}
+	refreshRes := performJSON(env.router, http.MethodPost, "/v1/auth/refresh", map[string]any{
+		"refresh_token": owner.Tokens.RefreshToken,
+	}, "")
+	if refreshRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected disabled self refresh token 401, got %d", refreshRes.Code)
+	}
+	loginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "self-delete@example.com",
+		"password": "password123",
+	}, "")
+	if loginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected disabled self login 401, got %d", loginRes.Code)
+	}
+
+	membersRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/members", nil, backupOwner.Tokens.AccessToken)
+	if membersRes.Code != http.StatusOK {
+		t.Fatalf("expected backup owner member list 200, got %d: %s", membersRes.Code, membersRes.Body.String())
+	}
+	members := decodeBody[membersBody](t, membersRes)
+	foundDisabledOwner := false
+	for _, member := range members.Members {
+		if member.UserID == owner.User.ID {
+			foundDisabledOwner = member.DisabledAt != nil
+			break
+		}
+	}
+	if !foundDisabledOwner {
+		t.Fatal("expected disabled current user to remain listed as a disabled member")
+	}
+}
+
 func TestIntegrationDisabledUserCannotUseExistingTokens(t *testing.T) {
 	env := newIntegrationEnv(t)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -182,6 +182,72 @@ func (s *Store) UpdateUserPassword(ctx context.Context, userID, passwordHash str
 	return tx.Commit(ctx)
 }
 
+func (s *Store) DisableCurrentUser(ctx context.Context, userID string) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var activeUserID string
+	err = tx.QueryRow(ctx, `
+		SELECT id::text
+		FROM users
+		WHERE id = $1 AND disabled_at IS NULL
+		FOR UPDATE
+	`, userID).Scan(&activeUserID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+
+	rows, err := tx.Query(ctx, `
+		SELECT organization_id::text
+		FROM organization_members
+		WHERE user_id = $1 AND role = 'owner'
+		FOR UPDATE
+	`, userID)
+	if err != nil {
+		return err
+	}
+	ownerOrgIDs := []string{}
+	for rows.Next() {
+		var orgID string
+		if err := rows.Scan(&orgID); err != nil {
+			rows.Close()
+			return err
+		}
+		ownerOrgIDs = append(ownerOrgIDs, orgID)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	for _, orgID := range ownerOrgIDs {
+		if err := ensureNotLastActiveOwnerTx(ctx, tx, orgID, userID); err != nil {
+			return err
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE users SET disabled_at = now() WHERE id = $1
+	`, userID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE refresh_tokens
+		SET revoked_at = now()
+		WHERE user_id = $1 AND revoked_at IS NULL
+	`, userID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 func (s *Store) SaveRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {
 	_, err := s.db.Exec(ctx, `
 		INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
@@ -507,7 +573,7 @@ func (s *Store) DisableMemberUser(ctx context.Context, orgID, userID string) (mo
 	}
 	defer tx.Rollback(ctx)
 
-	if err := ensureNotLastOwnerTx(ctx, tx, orgID, userID); err != nil {
+	if err := ensureNotLastActiveOwnerTx(ctx, tx, orgID, userID); err != nil {
 		return model.Member{}, err
 	}
 	if _, err := tx.Exec(ctx, `
@@ -577,6 +643,57 @@ func (s *Store) RemoveMember(ctx context.Context, orgID, userID string) error {
 		return ErrNotFound
 	}
 	return tx.Commit(ctx)
+}
+
+func ensureNotLastActiveOwnerTx(ctx context.Context, tx pgx.Tx, orgID, userID string) error {
+	var role model.Role
+	err := tx.QueryRow(ctx, `
+		SELECT role
+		FROM organization_members
+		WHERE organization_id = $1 AND user_id = $2
+		FOR UPDATE
+	`, orgID, userID).Scan(&role)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if role != model.RoleOwner {
+		return nil
+	}
+
+	rows, err := tx.Query(ctx, `
+		SELECT m.user_id::text, u.disabled_at
+		FROM organization_members m
+		JOIN users u ON u.id = m.user_id
+		WHERE m.organization_id = $1 AND m.role = 'owner'
+		FOR UPDATE OF m, u
+	`, orgID)
+	if err != nil {
+		return err
+	}
+	activeOtherOwners := 0
+	for rows.Next() {
+		var ownerID string
+		var disabledAt *time.Time
+		if err := rows.Scan(&ownerID, &disabledAt); err != nil {
+			rows.Close()
+			return err
+		}
+		if ownerID != userID && disabledAt == nil {
+			activeOtherOwners++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	if activeOtherOwners == 0 {
+		return ErrLastOwner
+	}
+	return nil
 }
 
 func ensureNotLastOwnerTx(ctx context.Context, tx pgx.Tx, orgID, userID string) error {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -106,6 +106,18 @@ paths:
                 $ref: "#/components/schemas/MeResponse"
         "401":
           $ref: "#/components/responses/Error"
+    delete:
+      security:
+        - bearerAuth: []
+      summary: Disable the current user account.
+      description: Soft-disables the authenticated user, revokes active refresh tokens, and refuses to disable the user while they are the last active owner of any organization. This does not delete organizations, memberships, devices, or product-level device state.
+      responses:
+        "204":
+          description: Current user disabled and active refresh tokens revoked.
+        "401":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
   /v1/me/password:
     patch:
       security:


### PR DESCRIPTION
## Summary
- add protected `DELETE /v1/me` to soft-disable the current user and revoke active refresh tokens
- enforce owner safety by rejecting self-disable when the user is the last active owner of any organization
- update docs/OpenAPI for account-manager-only delete semantics and keep OTP, password recovery, and social login deferred

## Validation
- `go test ./internal/api -run 'TestIntegrationCurrentUserCanDisableSelfWithOwnerSafety|TestIntegrationLastOwnerCannotBeRemovedOrDowngraded|TestIntegrationCurrentUserCanChangePassword|TestIntegrationResponsesMatchOpenAPIContract' -count=1`
- `go test ./internal/openapi -count=1`
- `git diff --check`
- `go test ./... -count=1`

Note: `TEST_DATABASE_URL` is unset locally, so database-backed integration tests compiled but skipped by their existing guard. CI should run them with Postgres.

Refs #62