### PR TITLE
[Account] Guard active owner invariant

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -394,7 +394,7 @@ Rules:
 - Only `owner` may invite/add members, remove members, or change member roles.
 - Only `owner` may disable or enable member user accounts.
 - Only `owner` may remove another `owner`.
-- The last `owner` in an organization must not be removed, downgraded, or disabled.
+- The last active `owner` in an organization must not be removed, downgraded, or disabled; disabled owner memberships do not satisfy this invariant.
 - Disabling a member user sets `users.disabled_at`, revokes that user's active refresh tokens, and prevents login, refresh, and protected API access.
 - Enabling a member user clears `users.disabled_at`.
 - `owner` and `admin` may create, update, disable, delete, and update status for devices.
@@ -781,8 +781,7 @@ Tests should cover:
 - Duplicate device `serial_number` in the same organization is rejected.
 - Same `serial_number` may be used in different organizations.
 - Device status can be updated by `owner` or `admin`.
-- Last organization `owner` cannot be removed or downgraded.
-- Last organization `owner` cannot be disabled.
+- Last active organization `owner` cannot be removed, downgraded, or disabled.
 - Self-service account deletion is refused while the current user is the last active `owner` of any organization.
 - Owner can disable and enable member users.
 - Admin and member cannot disable or enable users.

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -245,6 +245,18 @@ func TestIntegrationCurrentUserCanDisableSelfWithOwnerSafety(t *testing.T) {
 	if !foundDisabledOwner {
 		t.Fatal("expected disabled current user to remain listed as a disabled member")
 	}
+
+	backupDowngradeRes := performJSON(env.router, http.MethodPatch, "/v1/orgs/"+owner.Organization.ID+"/members/"+backupOwner.User.ID, map[string]any{
+		"role": "admin",
+	}, backupOwner.Tokens.AccessToken)
+	if backupDowngradeRes.Code != http.StatusConflict {
+		t.Fatalf("expected only active owner downgrade 409, got %d", backupDowngradeRes.Code)
+	}
+
+	backupRemoveRes := performJSON(env.router, http.MethodDelete, "/v1/orgs/"+owner.Organization.ID+"/members/"+backupOwner.User.ID, nil, backupOwner.Tokens.AccessToken)
+	if backupRemoveRes.Code != http.StatusConflict {
+		t.Fatalf("expected only active owner remove 409, got %d", backupRemoveRes.Code)
+	}
 }
 
 func TestIntegrationDisabledUserCannotUseExistingTokens(t *testing.T) {
@@ -1085,6 +1097,36 @@ func TestIntegrationLastOwnerCannotBeRemovedOrDowngraded(t *testing.T) {
 	`, owner.Organization.ID, owner.User.ID)
 	if err == nil {
 		t.Fatal("expected direct SQL deletion of last owner to fail")
+	}
+
+	disabledOwner := registerUser(t, env.router, "disabled-owner@example.com", "Disabled Owner Org")
+	activeOwner := registerUser(t, env.router, "active-owner@example.com", "Active Owner Org")
+	addActiveOwnerRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+disabledOwner.Organization.ID+"/members", map[string]any{
+		"email": "active-owner@example.com",
+		"role":  "owner",
+	}, disabledOwner.Tokens.AccessToken)
+	if addActiveOwnerRes.Code != http.StatusCreated {
+		t.Fatalf("expected add active owner 201, got %d: %s", addActiveOwnerRes.Code, addActiveOwnerRes.Body.String())
+	}
+	deleteDisabledOwnerRes := performJSON(env.router, http.MethodDelete, "/v1/me", nil, disabledOwner.Tokens.AccessToken)
+	if deleteDisabledOwnerRes.Code != http.StatusNoContent {
+		t.Fatalf("expected disable original owner 204, got %d: %s", deleteDisabledOwnerRes.Code, deleteDisabledOwnerRes.Body.String())
+	}
+
+	_, err = env.db.Exec(context.Background(), `
+		UPDATE organization_members SET role = 'admin'
+		WHERE organization_id = $1 AND user_id = $2
+	`, disabledOwner.Organization.ID, activeOwner.User.ID)
+	if err == nil {
+		t.Fatal("expected direct SQL downgrade of only active owner to fail")
+	}
+
+	_, err = env.db.Exec(context.Background(), `
+		DELETE FROM organization_members
+		WHERE organization_id = $1 AND user_id = $2
+	`, disabledOwner.Organization.ID, activeOwner.User.ID)
+	if err == nil {
+		t.Fatal("expected direct SQL deletion of only active owner to fail")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -533,7 +533,7 @@ func (s *Store) UpdateMemberRole(ctx context.Context, orgID, userID string, role
 	defer tx.Rollback(ctx)
 
 	if role != model.RoleOwner {
-		if err := ensureNotLastOwnerTx(ctx, tx, orgID, userID); err != nil {
+		if err := ensureNotLastActiveOwnerTx(ctx, tx, orgID, userID); err != nil {
 			return model.Member{}, err
 		}
 	}
@@ -630,7 +630,7 @@ func (s *Store) RemoveMember(ctx context.Context, orgID, userID string) error {
 	}
 	defer tx.Rollback(ctx)
 
-	if err := ensureNotLastOwnerTx(ctx, tx, orgID, userID); err != nil {
+	if err := ensureNotLastActiveOwnerTx(ctx, tx, orgID, userID); err != nil {
 		return err
 	}
 	tag, err := tx.Exec(ctx, `
@@ -691,44 +691,6 @@ func ensureNotLastActiveOwnerTx(ctx context.Context, tx pgx.Tx, orgID, userID st
 	}
 	rows.Close()
 	if activeOtherOwners == 0 {
-		return ErrLastOwner
-	}
-	return nil
-}
-
-func ensureNotLastOwnerTx(ctx context.Context, tx pgx.Tx, orgID, userID string) error {
-	ownerRows, err := tx.Query(ctx, `
-		SELECT user_id FROM organization_members
-		WHERE organization_id = $1 AND role = 'owner'
-		FOR UPDATE
-	`, orgID)
-	if err != nil {
-		return err
-	}
-	ownerCount := 0
-	for ownerRows.Next() {
-		ownerCount++
-	}
-	if err := ownerRows.Err(); err != nil {
-		ownerRows.Close()
-		return err
-	}
-	ownerRows.Close()
-
-	var role model.Role
-	err = tx.QueryRow(ctx, `
-		SELECT role
-		FROM organization_members
-		WHERE organization_id = $1 AND user_id = $2
-		FOR UPDATE
-	`, orgID, userID).Scan(&role)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ErrNotFound
-	}
-	if err != nil {
-		return err
-	}
-	if role == model.RoleOwner && ownerCount <= 1 {
 		return ErrLastOwner
 	}
 	return nil

--- a/migrations/008_active_owner_guard.sql
+++ b/migrations/008_active_owner_guard.sql
@@ -25,17 +25,3 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS organization_members_prevent_last_owner_delete
-    ON organization_members;
-CREATE TRIGGER organization_members_prevent_last_owner_delete
-    BEFORE DELETE ON organization_members
-    FOR EACH ROW
-    EXECUTE FUNCTION prevent_last_owner_removal();
-
-DROP TRIGGER IF EXISTS organization_members_prevent_last_owner_update
-    ON organization_members;
-CREATE TRIGGER organization_members_prevent_last_owner_update
-    BEFORE UPDATE OF role ON organization_members
-    FOR EACH ROW
-    EXECUTE FUNCTION prevent_last_owner_removal();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -275,6 +275,7 @@ paths:
       security:
         - bearerAuth: []
       summary: Update member role.
+      description: Refuses to downgrade the last active organization owner. Disabled owner memberships do not satisfy the active-owner invariant.
       parameters:
         - $ref: "#/components/parameters/OrgId"
         - $ref: "#/components/parameters/UserId"
@@ -305,6 +306,7 @@ paths:
       security:
         - bearerAuth: []
       summary: Remove member from organization.
+      description: Refuses to remove the last active organization owner. Disabled owner memberships do not satisfy the active-owner invariant.
       parameters:
         - $ref: "#/components/parameters/OrgId"
         - $ref: "#/components/parameters/UserId"


### PR DESCRIPTION
## Summary
- make owner downgrade/removal use the same active-owner invariant as account self-disable
- update the last-owner database trigger for fresh databases and add a forward migration for existing databases
- cover self-disable plus backup-owner downgrade/remove regressions and direct SQL trigger paths

## Validation
- `go test ./internal/api -run 'TestIntegrationCurrentUserCanDisableSelfWithOwnerSafety|TestIntegrationLastOwnerCannotBeRemovedOrDowngraded|TestIntegrationResponsesMatchOpenAPIContract' -count=1`
- `go test ./internal/openapi -count=1`
- `go test ./internal/api ./internal/openapi ./internal/store ./internal/auth ./internal/model -count=1`
- `go test ./... -count=1`
- `git diff --check`

Refs #62