### PR TITLE
Persist video_cloud_clip_public_key in provisioning pending metadata

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -275,7 +275,7 @@ Rules:
 - `member` may read provisioning state but may not initiate lifecycle commands.
 - Device must exist in the organization.
 - Disabled devices cannot be provisioned.
-- Accepting provisioning immediately exposes pending `video_cloud_devid`, `video_cloud_activity_id`, and `video_cloud_activation_status=pending` in projected device metadata.
+- Accepting provisioning immediately exposes pending `video_cloud_devid`, `video_cloud_activity_id`, `video_cloud_clip_public_key`, and `video_cloud_activation_status=pending` in projected device metadata.
 - Duplicate `operation_id` with the same payload returns the existing operation.
 - Duplicate `operation_id` with a conflicting payload returns `409 Conflict`.
 - The API must not directly call Realtek video server.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -650,7 +650,8 @@ Provisioning-state response body for `GET .../provisioning`:
 Provisioning rules:
 
 - The API writes the operation row and outbox row transactionally.
-- Accepting a provisioning request immediately merges pending `video_cloud_devid`, `video_cloud_activity_id`, and `video_cloud_activation_status=pending` into device metadata without implying activation success.
+- Accepting a provisioning request immediately merges pending `video_cloud_devid`, `video_cloud_activity_id`,
+  `video_cloud_clip_public_key`, and `video_cloud_activation_status=pending` into device metadata without implying activation success.
 - Disabled devices cannot be provisioned.
 - The API must not directly call Realtek video server.
 - Product-level deactivation and account registry soft-delete are distinct operations.

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1360,6 +1360,9 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudActivityID]; got != "activity-1" {
 		t.Fatalf("expected pending activity id in provisioning state, got %+v", got)
 	}
+	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudClipPublicKey]; got != "clip-key-1" {
+		t.Fatalf("expected pending clip public key in provisioning state, got %+v", got)
+	}
 	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusPending) {
 		t.Fatalf("expected pending activation status in provisioning state, got %+v", got)
 	}

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -148,7 +148,7 @@ func (s *Server) provisionDevice(c *gin.Context) {
 			"clip_public_key":   clipPublicKey,
 			"requested_by":      currentUserID(c),
 		},
-		MetadataPatch: store.PendingProvisionMetadata(videoCloudDevid, activityID),
+		MetadataPatch: store.PendingProvisionMetadata(videoCloudDevid, activityID, clipPublicKey),
 		Now:           time.Now().UTC().Truncate(time.Microsecond),
 	})
 	if err != nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -55,6 +55,7 @@ const (
 	DeviceMetadataVideoCloudActivityID       = "video_cloud_activity_id"
 	DeviceMetadataVideoCloudActivatedAt      = "video_cloud_activated_at"
 	DeviceMetadataVideoCloudDeactivatedAt    = "video_cloud_deactivated_at"
+	DeviceMetadataVideoCloudClipPublicKey    = "video_cloud_clip_public_key"
 	DeviceMetadataVideoCloudLastError        = "video_cloud_last_error"
 )
 

--- a/internal/store/device_lifecycle_integration_test.go
+++ b/internal/store/device_lifecycle_integration_test.go
@@ -47,7 +47,7 @@ func TestStartDeviceLifecycleOperationPersistsPendingProvisionMetadata(t *testin
 			"clip_public_key":   "clip-key-1",
 			"requested_by":      userID,
 		},
-		MetadataPatch: PendingProvisionMetadata("video-device-1", "activity-1"),
+		MetadataPatch: PendingProvisionMetadata("video-device-1", "activity-1", "clip-key-1"),
 		Now:           time.Now().UTC().Truncate(time.Microsecond),
 	})
 	if err != nil {
@@ -64,6 +64,9 @@ func TestStartDeviceLifecycleOperationPersistsPendingProvisionMetadata(t *testin
 	}
 	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudActivityID]; got != "activity-1" {
 		t.Fatalf("expected pending metadata to expose requested activity id, got %+v", got)
+	}
+	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudClipPublicKey]; got != "clip-key-1" {
+		t.Fatalf("expected pending metadata to expose requested clip public key, got %+v", got)
 	}
 	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusPending) {
 		t.Fatalf("expected pending activation status, got %+v", got)

--- a/internal/store/device_projection.go
+++ b/internal/store/device_projection.go
@@ -15,10 +15,11 @@ import (
 
 const projectionMetadataPrefix = "video_cloud_"
 
-func PendingProvisionMetadata(videoCloudDevid, activityID string) map[string]any {
+func PendingProvisionMetadata(videoCloudDevid, activityID, clipPublicKey string) map[string]any {
 	return map[string]any{
 		model.DeviceMetadataVideoCloudDevid:            videoCloudDevid,
 		model.DeviceMetadataVideoCloudActivityID:       activityID,
+		model.DeviceMetadataVideoCloudClipPublicKey:    clipPublicKey,
 		model.DeviceMetadataVideoCloudActivationStatus: model.VideoCloudActivationStatusPending,
 		model.DeviceMetadataVideoCloudActivatedAt:      nil,
 		model.DeviceMetadataVideoCloudDeactivatedAt:    nil,


### PR DESCRIPTION
## Summary

Store the provisioning lifecycle pending metadata using `video_cloud_clip_public_key` in both lifecycle patching and video metadata for provisioning flow.

Refs #43

## Changes

- Add metadata constant for clip public key
- Persist clip public key into `PendingProvisionMetadata` when provisioning starts
- Add integration test coverage for projection and API
- Update provisioning and event channel docs

## Validation

- `go test ./internal/store ./internal/api -count=1`
- GitHub CI `test` succeeded on head `00bc33db8c30a04e38b0aabdb4a6be312f4cbfde`
