### PR TITLE
Add product readiness vocabulary projection

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -454,6 +454,13 @@ Account-side readiness states:
 - `deactivated`
 - `disabled`
 
+`GET /provisioning` also exposes `readiness.product_state` with the shared
+product-readiness vocabulary (`registered`, `cloud_activation_pending`,
+`activated`, `online`, `failed`, `deactivation_pending`, `deactivated`) derived
+from the same account-side source facts. `claim_pending` and
+`local_onboarding_pending` are intentionally not emitted until account manager
+owns durable facts for those phases.
+
 Failure handling:
 
 - Activation failure must stay visible through operation error fields and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -631,6 +631,7 @@ Provisioning-state response body for `GET .../provisioning`:
   },
   "readiness": {
     "state": "transport_pending",
+    "product_state": "activated",
     "sources": {
       "device_enabled": true,
       "device_status": "offline",
@@ -674,6 +675,13 @@ it owns locally, while the integrating client or service remains responsible
 for adding video-side token and bootstrap inputs that do not live in this
 repository.
 
+The response keeps the legacy account-side `readiness.state` for existing
+clients and also exposes `readiness.product_state` using the shared
+product-readiness vocabulary. The product vocabulary field is still derived
+only from account-manager-owned durable source facts; it does not accept direct
+writes and it does not imply account manager owns SDK/local onboarding,
+credential issuance, or video bootstrap facts.
+
 Current readiness inputs:
 
 | Input | Source of truth | Meaning |
@@ -700,6 +708,23 @@ Account-side readiness projection rules:
   latest deactivation operation status, and projected video last-error data.
 - Compose the final readiness view from this account-manager projection plus
   the required video-side credential and bootstrap signals.
+
+`readiness.product_state` maps account-side facts into the cross-service
+vocabulary as follows:
+
+| Product state | Account-manager projection rule |
+| --- | --- |
+| `registered` | The account registry record exists but account-manager facts do not show active provisioning, or the registry record is soft-disabled without a terminal product deactivation fact. |
+| `cloud_activation_pending` | Provisioning is accepted or not terminal, or activation metadata has not yet projected a terminal result. |
+| `activated` | Provisioning succeeded and activation metadata is `activated`, but owner transport is not currently `online`. |
+| `online` | Provisioning succeeded, activation metadata is `activated`, and account-manager transport status is `online`. |
+| `failed` | Provisioning, deactivation, projected activation metadata, or projected `video_cloud_last_error` records a failure. |
+| `deactivation_pending` | Latest deactivation operation is pending, published, or retrying. |
+| `deactivated` | Latest deactivation operation succeeded or projected activation status is `deactivated`. |
+
+The shared states `claim_pending` and `local_onboarding_pending` remain outside
+the current account-manager projection until this repository owns durable
+source facts for those phases.
 
 Account-side readiness states:
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -347,6 +347,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 		provisioningStatus model.DeviceOperationStatus
 		deactivationStatus *model.DeviceOperationStatus
 		want               model.DeviceReadinessState
+		wantProduct        model.ProductReadinessState
 	}{
 		{
 			name: "accepted provisioning waits for activation",
@@ -355,6 +356,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			}),
 			provisioningStatus: model.DeviceOperationStatusPending,
 			want:               model.DeviceReadinessStateActivationPending,
+			wantProduct:        model.ProductReadinessStateCloudActivationPending,
 		},
 		{
 			name: "activation failure stays visible",
@@ -366,6 +368,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			}),
 			provisioningStatus: model.DeviceOperationStatusFailed,
 			want:               model.DeviceReadinessStateActivationFailed,
+			wantProduct:        model.ProductReadinessStateFailed,
 		},
 		{
 			name: "activation succeeded but offline waits for transport",
@@ -374,6 +377,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			}),
 			provisioningStatus: model.DeviceOperationStatusSucceeded,
 			want:               model.DeviceReadinessStateTransportPending,
+			wantProduct:        model.ProductReadinessStateActivated,
 		},
 		{
 			name: "activation succeeded and online is ready",
@@ -382,6 +386,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			}),
 			provisioningStatus: model.DeviceOperationStatusSucceeded,
 			want:               model.DeviceReadinessStateReady,
+			wantProduct:        model.ProductReadinessStateOnline,
 		},
 		{
 			name: "deactivation pending takes precedence",
@@ -391,6 +396,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			provisioningStatus: model.DeviceOperationStatusSucceeded,
 			deactivationStatus: operationStatusPtr(model.DeviceOperationStatusPublished),
 			want:               model.DeviceReadinessStateDeactivationPending,
+			wantProduct:        model.ProductReadinessStateDeactivationPending,
 		},
 		{
 			name: "deactivation success is deactivated",
@@ -400,6 +406,14 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			provisioningStatus: model.DeviceOperationStatusSucceeded,
 			deactivationStatus: operationStatusPtr(model.DeviceOperationStatusSucceeded),
 			want:               model.DeviceReadinessStateDeactivated,
+			wantProduct:        model.ProductReadinessStateDeactivated,
+		},
+		{
+			name:               "registry disabled stays account-side only",
+			device:             readinessDisabledDevice(model.DeviceStatusDisabled, nil),
+			provisioningStatus: model.DeviceOperationStatusSucceeded,
+			want:               model.DeviceReadinessStateDisabled,
+			wantProduct:        model.ProductReadinessStateRegistered,
 		},
 	}
 
@@ -421,6 +435,9 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			if got.State != tt.want {
 				t.Fatalf("expected readiness %s, got %+v", tt.want, got)
 			}
+			if got.ProductState != tt.wantProduct {
+				t.Fatalf("expected product readiness %s, got %+v", tt.wantProduct, got)
+			}
 			if got.Sources.DeviceStatus != tt.device.Status || got.Sources.ProvisioningOperationStatus != tt.provisioningStatus {
 				t.Fatalf("expected source facts to reflect device and operation, got %+v", got.Sources)
 			}
@@ -436,6 +453,13 @@ func readinessDevice(status model.DeviceStatus, metadata map[string]any) model.D
 		Status:   status,
 		Metadata: metadata,
 	}
+}
+
+func readinessDisabledDevice(status model.DeviceStatus, metadata map[string]any) model.Device {
+	now := time.Now().UTC()
+	device := readinessDevice(status, metadata)
+	device.DisabledAt = &now
+	return device
 }
 
 func operationStatusPtr(status model.DeviceOperationStatus) *model.DeviceOperationStatus {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1369,6 +1369,9 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 	if memberState.Readiness.State != model.DeviceReadinessStateActivationPending {
 		t.Fatalf("expected pending readiness state, got %+v", memberState.Readiness)
 	}
+	if memberState.Readiness.ProductState != model.ProductReadinessStateCloudActivationPending {
+		t.Fatalf("expected pending product readiness state, got %+v", memberState.Readiness)
+	}
 	if memberState.Readiness.Sources.DeviceStatus != model.DeviceStatusUnknown ||
 		memberState.Readiness.Sources.ProvisioningOperationStatus != model.DeviceOperationStatusPending ||
 		memberState.Readiness.Sources.VideoCloudActivationStatus == nil ||

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -65,8 +65,9 @@ type operationResponse struct {
 }
 
 type readinessResponse struct {
-	State   model.DeviceReadinessState `json:"state"`
-	Sources readinessSourcesResponse   `json:"sources"`
+	State        model.DeviceReadinessState  `json:"state"`
+	ProductState model.ProductReadinessState `json:"product_state"`
+	Sources      readinessSourcesResponse    `json:"sources"`
 }
 
 type readinessSourcesResponse struct {
@@ -406,8 +407,9 @@ func readinessFromProjection(device model.Device, provisioningOperation model.De
 	}
 
 	return readinessResponse{
-		State:   readinessStateFromSources(sources),
-		Sources: sources,
+		State:        readinessStateFromSources(sources),
+		ProductState: productReadinessStateFromSources(sources),
+		Sources:      sources,
 	}
 }
 
@@ -448,6 +450,45 @@ func readinessStateFromSources(sources readinessSourcesResponse) model.DeviceRea
 	}
 
 	return model.DeviceReadinessStateActivationPending
+}
+
+func productReadinessStateFromSources(sources readinessSourcesResponse) model.ProductReadinessState {
+	if sources.DeactivationOperationStatus != nil {
+		switch *sources.DeactivationOperationStatus {
+		case model.DeviceOperationStatusPending, model.DeviceOperationStatusPublished, model.DeviceOperationStatusRetrying:
+			return model.ProductReadinessStateDeactivationPending
+		case model.DeviceOperationStatusFailed, model.DeviceOperationStatusDeadLettered:
+			return model.ProductReadinessStateFailed
+		case model.DeviceOperationStatusSucceeded:
+			return model.ProductReadinessStateDeactivated
+		}
+	}
+
+	if sources.VideoCloudActivationStatus != nil && *sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusDeactivated) {
+		return model.ProductReadinessStateDeactivated
+	}
+
+	if !sources.DeviceEnabled || sources.DeviceStatus == model.DeviceStatusDisabled {
+		return model.ProductReadinessStateRegistered
+	}
+
+	if sources.ProvisioningOperationStatus == model.DeviceOperationStatusFailed ||
+		sources.ProvisioningOperationStatus == model.DeviceOperationStatusDeadLettered ||
+		(sources.VideoCloudActivationStatus != nil && *sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusFailed)) ||
+		sources.VideoCloudLastError != nil {
+		return model.ProductReadinessStateFailed
+	}
+
+	if sources.ProvisioningOperationStatus == model.DeviceOperationStatusSucceeded &&
+		sources.VideoCloudActivationStatus != nil &&
+		*sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusActivated) {
+		if sources.DeviceStatus == model.DeviceStatusOnline {
+			return model.ProductReadinessStateOnline
+		}
+		return model.ProductReadinessStateActivated
+	}
+
+	return model.ProductReadinessStateCloudActivationPending
 }
 
 func metadataString(metadata map[string]any, key string) (string, bool) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -49,6 +49,20 @@ const (
 	DeviceReadinessStateDisabled            DeviceReadinessState = "disabled"
 )
 
+type ProductReadinessState string
+
+const (
+	ProductReadinessStateRegistered             ProductReadinessState = "registered"
+	ProductReadinessStateClaimPending           ProductReadinessState = "claim_pending"
+	ProductReadinessStateLocalOnboardingPending ProductReadinessState = "local_onboarding_pending"
+	ProductReadinessStateCloudActivationPending ProductReadinessState = "cloud_activation_pending"
+	ProductReadinessStateActivated              ProductReadinessState = "activated"
+	ProductReadinessStateOnline                 ProductReadinessState = "online"
+	ProductReadinessStateFailed                 ProductReadinessState = "failed"
+	ProductReadinessStateDeactivationPending    ProductReadinessState = "deactivation_pending"
+	ProductReadinessStateDeactivated            ProductReadinessState = "deactivated"
+)
+
 const (
 	DeviceMetadataVideoCloudDevid            = "video_cloud_devid"
 	DeviceMetadataVideoCloudActivationStatus = "video_cloud_activation_status"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1210,10 +1210,12 @@ components:
           additionalProperties: true
     DeviceReadinessProjection:
       type: object
-      required: [state, sources]
+      required: [state, product_state, sources]
       properties:
         state:
           $ref: "#/components/schemas/DeviceReadinessState"
+        product_state:
+          $ref: "#/components/schemas/ProductReadinessState"
         sources:
           type: object
           required: [device_enabled, device_status, provisioning_operation_status]
@@ -1455,6 +1457,9 @@ components:
     DeviceReadinessState:
       type: string
       enum: [activation_pending, activation_failed, transport_pending, ready, deactivation_pending, deactivation_failed, deactivated, disabled]
+    ProductReadinessState:
+      type: string
+      enum: [registered, claim_pending, local_onboarding_pending, cloud_activation_pending, activated, online, failed, deactivation_pending, deactivated]
     ErrorResponse:
       type: object
       required: [error]


### PR DESCRIPTION
## Summary

- expose `readiness.product_state` on `GET /v1/orgs/{orgId}/devices/{deviceId}/provisioning` using the shared product-readiness vocabulary
- keep legacy account-side `readiness.state` intact while deriving the product vocabulary from the same durable source facts
- update OpenAPI, SPEC/runbook docs, and readiness tests for the new response field

Refs #72

## Validation

- `go test ./internal/api ./internal/model ./internal/store -count=1`
- `go test ./... -count=1`