### PR TITLE
feat: OTP email verification and self-service password recovery

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"rtk_account_manager/internal/auth"
 	"rtk_account_manager/internal/config"
 	"rtk_account_manager/internal/database"
+	"rtk_account_manager/internal/mailer"
 	"rtk_account_manager/internal/store"
 )
 
@@ -25,7 +26,13 @@ func main() {
 	defer db.Close()
 
 	authService := auth.NewService(cfg.AccessSecret, cfg.RefreshSecret, cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
-	server := api.New(store.New(db), authService)
+	mailerService := mailer.NewLogMailer(nil)
+	server := api.NewWithMailer(store.New(db), authService, mailerService, api.AuthCodeOptions{
+		EmailVerificationTTL: cfg.EmailVerificationTTL,
+		PasswordResetTTL:     cfg.PasswordResetTTL,
+		OTPResendInterval:    cfg.OTPResendInterval,
+		OTPMaxAttempts:       cfg.OTPMaxAttempts,
+	})
 
 	log.Printf("listening on :%s", cfg.Port)
 	if err := server.Router().Run(":" + cfg.Port); err != nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -12,18 +13,51 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"rtk_account_manager/internal/auth"
+	"rtk_account_manager/internal/mailer"
 	"rtk_account_manager/internal/model"
 	"rtk_account_manager/internal/store"
 )
 
+type AuthCodeOptions struct {
+	EmailVerificationTTL time.Duration
+	PasswordResetTTL     time.Duration
+	OTPResendInterval    time.Duration
+	OTPMaxAttempts       int
+}
+
 type Server struct {
-	store *store.Store
-	auth  *auth.Service
+	store           *store.Store
+	auth            *auth.Service
+	mailer          mailer.Mailer
+	authCodeOptions AuthCodeOptions
 }
 
 func New(store *store.Store, authService *auth.Service) *Server {
-	return &Server{store: store, auth: authService}
+	return NewWithMailer(store, authService, nil, AuthCodeOptions{})
 }
+
+func NewWithMailer(store *store.Store, authService *auth.Service, mailerService mailer.Mailer, opts AuthCodeOptions) *Server {
+	if mailerService == nil {
+		mailerService = nopMailer{}
+	}
+	if opts.EmailVerificationTTL <= 0 {
+		opts.EmailVerificationTTL = 30 * time.Minute
+	}
+	if opts.PasswordResetTTL <= 0 {
+		opts.PasswordResetTTL = 30 * time.Minute
+	}
+	if opts.OTPResendInterval < 0 {
+		opts.OTPResendInterval = 0
+	}
+	if opts.OTPMaxAttempts <= 0 {
+		opts.OTPMaxAttempts = 5
+	}
+	return &Server{store: store, auth: authService, mailer: mailerService, authCodeOptions: opts}
+}
+
+type nopMailer struct{}
+
+func (nopMailer) Send(_ context.Context, _ mailer.Message) error { return nil }
 
 func (s *Server) Router() *gin.Engine {
 	r := gin.New()
@@ -36,6 +70,10 @@ func (s *Server) Router() *gin.Engine {
 	v1.POST("/auth/register", s.register)
 	v1.POST("/auth/login", s.login)
 	v1.POST("/auth/refresh", s.refresh)
+	v1.POST("/auth/verify-email", s.verifyEmail)
+	v1.POST("/auth/resend-verification", s.resendVerification)
+	v1.POST("/auth/forgot-password", s.forgotPassword)
+	v1.POST("/auth/reset-password", s.resetPassword)
 
 	protected := v1.Group("")
 	protected.Use(s.requireAuth())
@@ -113,6 +151,10 @@ func (s *Server) register(c *gin.Context) {
 	tokens, err := s.issueTokens(c, result.User.ID)
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
+		return
+	}
+	if err := s.issueEmailVerification(c.Request.Context(), result.User.ID, result.User.Email, 0); err != nil && !errors.Is(err, store.ErrAlreadyVerified) {
+		writeError(c, http.StatusInternalServerError, "verification_send_failed", "Could not send verification email")
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"user": result.User, "organization": result.Organization, "tokens": tokens})

--- a/internal/api/auth_codes.go
+++ b/internal/api/auth_codes.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"rtk_account_manager/internal/auth"
+	"rtk_account_manager/internal/mailer"
+	"rtk_account_manager/internal/store"
+)
+
+const otpDigits = 6
+
+func generateOTP() (string, error) {
+	max := big.NewInt(1)
+	for i := 0; i < otpDigits; i++ {
+		max.Mul(max, big.NewInt(10))
+	}
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%0*d", otpDigits, n.Int64()), nil
+}
+
+func (s *Server) issueEmailVerification(ctx context.Context, userID, email string, minResend time.Duration) error {
+	code, err := generateOTP()
+	if err != nil {
+		return err
+	}
+	err = s.store.StartEmailVerification(ctx, store.EmailVerificationStartInput{
+		UserID:            userID,
+		CodeHash:          auth.HashToken(code),
+		ExpiresAt:         time.Now().UTC().Add(s.authCodeOptions.EmailVerificationTTL),
+		MinResendInterval: minResend,
+	})
+	if err != nil {
+		return err
+	}
+	return s.mailer.Send(ctx, mailer.Message{
+		Kind:      mailer.MessageKindEmailVerification,
+		Recipient: email,
+		Code:      code,
+	})
+}
+
+func (s *Server) issuePasswordReset(ctx context.Context, userID, email string, minResend time.Duration) error {
+	code, err := generateOTP()
+	if err != nil {
+		return err
+	}
+	err = s.store.StartPasswordReset(ctx, store.PasswordResetStartInput{
+		UserID:            userID,
+		CodeHash:          auth.HashToken(code),
+		ExpiresAt:         time.Now().UTC().Add(s.authCodeOptions.PasswordResetTTL),
+		MinResendInterval: minResend,
+	})
+	if err != nil {
+		return err
+	}
+	return s.mailer.Send(ctx, mailer.Message{
+		Kind:      mailer.MessageKindPasswordReset,
+		Recipient: email,
+		Code:      code,
+	})
+}
+
+type verifyEmailRequest struct {
+	Email string `json:"email" binding:"required,email"`
+	Code  string `json:"code" binding:"required"`
+}
+
+func (s *Server) verifyEmail(c *gin.Context) {
+	var req verifyEmailRequest
+	if !bind(c, &req) {
+		return
+	}
+	if !requireNonBlank(c, "code", req.Code) {
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	userID, err := s.store.GetUserIDByEmail(c.Request.Context(), email)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_verification", "Invalid email or code")
+		return
+	}
+	user, err := s.store.ConsumeEmailVerification(c.Request.Context(), userID, auth.HashToken(strings.TrimSpace(req.Code)), s.authCodeOptions.OTPMaxAttempts)
+	if err != nil {
+		writeAuthCodeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"user": user})
+}
+
+type resendVerificationRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+func (s *Server) resendVerification(c *gin.Context) {
+	var req resendVerificationRequest
+	if !bind(c, &req) {
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	userID, err := s.store.GetUserIDByEmail(c.Request.Context(), email)
+	if err != nil {
+		// Do not leak whether the account exists.
+		c.Status(http.StatusAccepted)
+		return
+	}
+	if err := s.issueEmailVerification(c.Request.Context(), userID, email, s.authCodeOptions.OTPResendInterval); err != nil {
+		switch {
+		case errors.Is(err, store.ErrAlreadyVerified):
+			writeError(c, http.StatusConflict, "already_verified", "Email is already verified")
+		case errors.Is(err, store.ErrResendThrottled):
+			writeError(c, http.StatusTooManyRequests, "resend_throttled", "Verification code was recently sent; try again later")
+		default:
+			writeError(c, http.StatusInternalServerError, "verification_send_failed", "Could not send verification email")
+		}
+		return
+	}
+	c.Status(http.StatusAccepted)
+}
+
+type forgotPasswordRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+func (s *Server) forgotPassword(c *gin.Context) {
+	var req forgotPasswordRequest
+	if !bind(c, &req) {
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	userID, err := s.store.GetUserIDByEmail(c.Request.Context(), email)
+	if err != nil {
+		// Do not leak whether the account exists.
+		c.Status(http.StatusAccepted)
+		return
+	}
+	if err := s.issuePasswordReset(c.Request.Context(), userID, email, s.authCodeOptions.OTPResendInterval); err != nil {
+		if errors.Is(err, store.ErrResendThrottled) {
+			// Treat throttle as silent success to avoid leaking timing info.
+			c.Status(http.StatusAccepted)
+			return
+		}
+		writeError(c, http.StatusInternalServerError, "reset_send_failed", "Could not send password reset")
+		return
+	}
+	c.Status(http.StatusAccepted)
+}
+
+type resetPasswordRequest struct {
+	Email       string `json:"email" binding:"required,email"`
+	Code        string `json:"code" binding:"required"`
+	NewPassword string `json:"new_password" binding:"required,min=8"`
+}
+
+func (s *Server) resetPassword(c *gin.Context) {
+	var req resetPasswordRequest
+	if !bind(c, &req) {
+		return
+	}
+	if !requireNonBlank(c, "code", req.Code) {
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	userID, err := s.store.GetUserIDByEmail(c.Request.Context(), email)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_reset", "Invalid email or code")
+		return
+	}
+	hash, err := auth.HashPassword(req.NewPassword)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "password_hash_failed", "Could not hash password")
+		return
+	}
+	if err := s.store.ConsumePasswordReset(c.Request.Context(), userID, auth.HashToken(strings.TrimSpace(req.Code)), hash, s.authCodeOptions.OTPMaxAttempts); err != nil {
+		writeAuthCodeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func writeAuthCodeError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, store.ErrCodeMismatch):
+		writeError(c, http.StatusBadRequest, "invalid_code", "Verification code is incorrect")
+	case errors.Is(err, store.ErrCodeExpired):
+		writeError(c, http.StatusBadRequest, "code_expired", "Verification code has expired")
+	case errors.Is(err, store.ErrTooManyAttempts):
+		writeError(c, http.StatusTooManyRequests, "too_many_attempts", "Too many verification attempts; request a new code")
+	case errors.Is(err, store.ErrNotFound):
+		writeError(c, http.StatusBadRequest, "invalid_code", "Verification code is incorrect")
+	default:
+		writeError(c, http.StatusInternalServerError, "internal_error", "Internal server error")
+	}
+}

--- a/internal/api/auth_codes_test.go
+++ b/internal/api/auth_codes_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestGenerateOTPProduces6DigitStrings(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		code, err := generateOTP()
+		if err != nil {
+			t.Fatalf("generateOTP: %v", err)
+		}
+		if len(code) != 6 {
+			t.Fatalf("expected 6-char code, got %q", code)
+		}
+		n, err := strconv.Atoi(code)
+		if err != nil || n < 0 || n > 999999 {
+			t.Fatalf("expected numeric code in [0,999999], got %q", code)
+		}
+		seen[code] = true
+	}
+	if len(seen) < 10 {
+		t.Fatalf("expected code variety, got only %d distinct codes in 50 samples", len(seen))
+	}
+}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -16,14 +16,16 @@ import (
 	"rtk_account_manager/internal/auth"
 	"rtk_account_manager/internal/channel"
 	"rtk_account_manager/internal/database"
+	"rtk_account_manager/internal/mailer"
 	"rtk_account_manager/internal/model"
 	"rtk_account_manager/internal/store"
 	"rtk_account_manager/internal/testutil"
 )
 
 type integrationEnv struct {
-	router *gin.Engine
-	db     *pgxpool.Pool
+	router  *gin.Engine
+	db      *pgxpool.Pool
+	mailer  *mailer.RecordingMailer
 }
 
 func newIntegrationEnv(t *testing.T) integrationEnv {
@@ -55,7 +57,14 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 
 	gin.SetMode(gin.TestMode)
 	authService := auth.NewService("test-access-secret", "test-refresh-secret", time.Minute, time.Hour)
-	return integrationEnv{router: New(store.New(db), authService).Router(), db: db}
+	rec := &mailer.RecordingMailer{}
+	router := NewWithMailer(store.New(db), authService, rec, AuthCodeOptions{
+		EmailVerificationTTL: 5 * time.Minute,
+		PasswordResetTTL:     5 * time.Minute,
+		OTPResendInterval:    0,
+		OTPMaxAttempts:       5,
+	}).Router()
+	return integrationEnv{router: router, db: db, mailer: rec}
 }
 
 func TestIntegrationRegisterLoginRefreshAndLogout(t *testing.T) {
@@ -1802,4 +1811,255 @@ func validateAccountCommandEnvelope(t *testing.T, message model.DeviceMessageOut
 		t.Fatalf("validate outbox envelope: %v", err)
 	}
 	return decoded
+}
+
+type verifyEmailBody struct {
+	User struct {
+		ID              string     `json:"id"`
+		Email           string     `json:"email"`
+		EmailVerifiedAt *time.Time `json:"email_verified_at"`
+	} `json:"user"`
+}
+
+func TestIntegrationEmailVerificationFlow(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	owner := registerUser(t, env.router, "verify@example.com", "Verify Org")
+
+	// register should have queued a verification email
+	if len(env.mailer.Sent) != 1 {
+		t.Fatalf("expected 1 verification email after register, got %d", len(env.mailer.Sent))
+	}
+	sentCode := env.mailer.Sent[0].Code
+	if len(sentCode) != 6 {
+		t.Fatalf("expected 6-digit OTP, got %q", sentCode)
+	}
+
+	// wrong code → 400
+	wrongRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"email": "verify@example.com",
+		"code":  "000000",
+	}, "")
+	if wrongRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected wrong-code 400, got %d: %s", wrongRes.Code, wrongRes.Body.String())
+	}
+
+	// correct code → 200 with email_verified_at set
+	okRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"email": "verify@example.com",
+		"code":  sentCode,
+	}, "")
+	if okRes.Code != http.StatusOK {
+		t.Fatalf("expected verify 200, got %d: %s", okRes.Code, okRes.Body.String())
+	}
+	body := decodeBody[verifyEmailBody](t, okRes)
+	if body.User.EmailVerifiedAt == nil {
+		t.Fatalf("expected email_verified_at to be set, got nil")
+	}
+	if body.User.ID != owner.User.ID {
+		t.Fatalf("expected same user, got %s", body.User.ID)
+	}
+
+	// reusing the same code → 400 (row deleted)
+	replayRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"email": "verify@example.com",
+		"code":  sentCode,
+	}, "")
+	if replayRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected replay 400, got %d", replayRes.Code)
+	}
+
+	// resend on already-verified → 409
+	resendRes := performJSON(env.router, http.MethodPost, "/v1/auth/resend-verification", map[string]any{
+		"email": "verify@example.com",
+	}, "")
+	if resendRes.Code != http.StatusConflict {
+		t.Fatalf("expected resend-on-verified 409, got %d: %s", resendRes.Code, resendRes.Body.String())
+	}
+
+	// GET /me should show email_verified_at
+	meRes := performJSON(env.router, http.MethodGet, "/v1/me", nil, owner.Tokens.AccessToken)
+	if meRes.Code != http.StatusOK {
+		t.Fatalf("expected me 200, got %d", meRes.Code)
+	}
+	var meOut struct {
+		User struct {
+			EmailVerifiedAt *time.Time `json:"email_verified_at"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(meRes.Body.Bytes(), &meOut); err != nil {
+		t.Fatalf("decode me: %v", err)
+	}
+	if meOut.User.EmailVerifiedAt == nil {
+		t.Fatalf("expected email_verified_at in /me response")
+	}
+}
+
+func TestIntegrationResendVerificationFlow(t *testing.T) {
+	env := newIntegrationEnv(t)
+	registerUser(t, env.router, "resend@example.com", "Resend Org")
+
+	firstCode := env.mailer.Sent[0].Code
+
+	// resend (interval = 0 in test env → always allowed)
+	resendRes := performJSON(env.router, http.MethodPost, "/v1/auth/resend-verification", map[string]any{
+		"email": "resend@example.com",
+	}, "")
+	if resendRes.Code != http.StatusAccepted {
+		t.Fatalf("expected resend 202, got %d: %s", resendRes.Code, resendRes.Body.String())
+	}
+	if len(env.mailer.Sent) != 2 {
+		t.Fatalf("expected 2 sent emails, got %d", len(env.mailer.Sent))
+	}
+	newCode := env.mailer.Sent[1].Code
+
+	// old code no longer valid after resend
+	oldRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"email": "resend@example.com",
+		"code":  firstCode,
+	}, "")
+	if oldRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected old-code 400, got %d", oldRes.Code)
+	}
+
+	// new code works
+	newRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"email": "resend@example.com",
+		"code":  newCode,
+	}, "")
+	if newRes.Code != http.StatusOK {
+		t.Fatalf("expected new-code 200, got %d: %s", newRes.Code, newRes.Body.String())
+	}
+
+	// unknown email → 202 (no leakage)
+	unknownRes := performJSON(env.router, http.MethodPost, "/v1/auth/resend-verification", map[string]any{
+		"email": "nobody@example.com",
+	}, "")
+	if unknownRes.Code != http.StatusAccepted {
+		t.Fatalf("expected unknown-email resend 202, got %d", unknownRes.Code)
+	}
+}
+
+func TestIntegrationPasswordResetFlow(t *testing.T) {
+	env := newIntegrationEnv(t)
+	registerUser(t, env.router, "reset@example.com", "Reset Org")
+
+	// forgot-password for unknown email → 202 (no leakage)
+	unknownRes := performJSON(env.router, http.MethodPost, "/v1/auth/forgot-password", map[string]any{
+		"email": "nobody@example.com",
+	}, "")
+	if unknownRes.Code != http.StatusAccepted {
+		t.Fatalf("expected unknown forgot 202, got %d", unknownRes.Code)
+	}
+
+	forgotRes := performJSON(env.router, http.MethodPost, "/v1/auth/forgot-password", map[string]any{
+		"email": "reset@example.com",
+	}, "")
+	if forgotRes.Code != http.StatusAccepted {
+		t.Fatalf("expected forgot 202, got %d: %s", forgotRes.Code, forgotRes.Body.String())
+	}
+
+	var resetCode string
+	for _, m := range env.mailer.Sent {
+		if m.Kind == "password_reset" {
+			resetCode = m.Code
+		}
+	}
+	if resetCode == "" {
+		t.Fatal("expected password_reset email")
+	}
+
+	// wrong code → 400
+	wrongRes := performJSON(env.router, http.MethodPost, "/v1/auth/reset-password", map[string]any{
+		"email":        "reset@example.com",
+		"code":         "000000",
+		"new_password": "newpassword99",
+	}, "")
+	if wrongRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected wrong-code 400, got %d", wrongRes.Code)
+	}
+
+	// correct code → 204
+	resetRes := performJSON(env.router, http.MethodPost, "/v1/auth/reset-password", map[string]any{
+		"email":        "reset@example.com",
+		"code":         resetCode,
+		"new_password": "newpassword99",
+	}, "")
+	if resetRes.Code != http.StatusNoContent {
+		t.Fatalf("expected reset 204, got %d: %s", resetRes.Code, resetRes.Body.String())
+	}
+
+	// old password no longer works
+	oldLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "reset@example.com",
+		"password": "password123",
+	}, "")
+	if oldLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected old-password 401, got %d", oldLoginRes.Code)
+	}
+
+	// new password works
+	newLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "reset@example.com",
+		"password": "newpassword99",
+	}, "")
+	if newLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected new-password login 200, got %d: %s", newLoginRes.Code, newLoginRes.Body.String())
+	}
+
+	// reset code reuse → 400
+	replayRes := performJSON(env.router, http.MethodPost, "/v1/auth/reset-password", map[string]any{
+		"email":        "reset@example.com",
+		"code":         resetCode,
+		"new_password": "anotherpass99",
+	}, "")
+	if replayRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected replay-code 400, got %d", replayRes.Code)
+	}
+}
+
+func TestIntegrationOTPMaxAttemptsExhausted(t *testing.T) {
+	env := newIntegrationEnv(t)
+	registerUser(t, env.router, "exhaust@example.com", "Exhaust Org")
+	_ = env.mailer.Sent[0].Code // register code — ignore
+
+	// request a password reset
+	performJSON(env.router, http.MethodPost, "/v1/auth/forgot-password", map[string]any{
+		"email": "exhaust@example.com",
+	}, "")
+	var resetCode string
+	for _, m := range env.mailer.Sent {
+		if m.Kind == "password_reset" {
+			resetCode = m.Code
+			break
+		}
+	}
+	if resetCode == "" {
+		t.Fatal("expected password_reset email")
+	}
+
+	// exhaust 5 attempts with wrong code
+	for i := 0; i < 5; i++ {
+		res := performJSON(env.router, http.MethodPost, "/v1/auth/reset-password", map[string]any{
+			"email":        "exhaust@example.com",
+			"code":         "000000",
+			"new_password": "newpassword99",
+		}, "")
+		if i < 4 && res.Code != http.StatusBadRequest {
+			t.Fatalf("attempt %d: expected 400, got %d", i+1, res.Code)
+		}
+		if i == 4 && res.Code != http.StatusTooManyRequests {
+			t.Fatalf("5th attempt: expected 429, got %d: %s", res.Code, res.Body.String())
+		}
+	}
+
+	// correct code no longer works — row deleted
+	expiredRes := performJSON(env.router, http.MethodPost, "/v1/auth/reset-password", map[string]any{
+		"email":        "exhaust@example.com",
+		"code":         resetCode,
+		"new_password": "newpassword99",
+	}, "")
+	if expiredRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected deleted-row 400, got %d", expiredRes.Code)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	CrossServiceConsumerGroup     string
 	CrossServiceMaxAttempts       int
 	CrossServicePollInterval      time.Duration
+	EmailVerificationTTL          time.Duration
+	PasswordResetTTL              time.Duration
+	OTPResendInterval             time.Duration
+	OTPMaxAttempts                int
 }
 
 func Load() (Config, error) {
@@ -63,6 +67,10 @@ func load() (Config, error) {
 		CrossServiceConsumerGroup:     getenv("CROSS_SERVICE_CONSUMER_GROUP", "rtk_account_manager"),
 		CrossServiceMaxAttempts:       intValue("CROSS_SERVICE_MAX_ATTEMPTS", 5),
 		CrossServicePollInterval:      duration("CROSS_SERVICE_POLL_INTERVAL", 5*time.Second),
+		EmailVerificationTTL:          duration("EMAIL_VERIFICATION_TTL", 30*time.Minute),
+		PasswordResetTTL:              duration("PASSWORD_RESET_TTL", 30*time.Minute),
+		OTPResendInterval:             duration("OTP_RESEND_INTERVAL", 60*time.Second),
+		OTPMaxAttempts:                intValue("OTP_MAX_ATTEMPTS", 5),
 	}
 	return cfg, nil
 }

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -1,0 +1,48 @@
+package mailer
+
+import (
+	"context"
+	"log"
+)
+
+type MessageKind string
+
+const (
+	MessageKindEmailVerification MessageKind = "email_verification"
+	MessageKindPasswordReset     MessageKind = "password_reset"
+)
+
+type Message struct {
+	Kind      MessageKind
+	Recipient string
+	Code      string
+}
+
+type Mailer interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+type LogMailer struct {
+	logger *log.Logger
+}
+
+func NewLogMailer(logger *log.Logger) *LogMailer {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &LogMailer{logger: logger}
+}
+
+func (m *LogMailer) Send(_ context.Context, msg Message) error {
+	m.logger.Printf("mailer: sent kind=%s recipient=%s code=%s", msg.Kind, msg.Recipient, msg.Code)
+	return nil
+}
+
+type RecordingMailer struct {
+	Sent []Message
+}
+
+func (m *RecordingMailer) Send(_ context.Context, msg Message) error {
+	m.Sent = append(m.Sent, msg)
+	return nil
+}

--- a/internal/mailer/mailer_test.go
+++ b/internal/mailer/mailer_test.go
@@ -1,0 +1,39 @@
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestLogMailerWritesStructuredEntry(t *testing.T) {
+	var buf bytes.Buffer
+	m := NewLogMailer(log.New(&buf, "", 0))
+
+	if err := m.Send(context.Background(), Message{
+		Kind:      MessageKindEmailVerification,
+		Recipient: "user@example.com",
+		Code:      "123456",
+	}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	got := buf.String()
+	for _, want := range []string{"email_verification", "user@example.com", "123456"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected log to contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestRecordingMailerCapturesMessages(t *testing.T) {
+	m := &RecordingMailer{}
+	if err := m.Send(context.Background(), Message{Kind: MessageKindPasswordReset, Recipient: "a@b", Code: "999"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Sent) != 1 || m.Sent[0].Code != "999" {
+		t.Fatalf("expected one recorded message, got %+v", m.Sent)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -95,12 +95,13 @@ const (
 )
 
 type User struct {
-	ID          string     `json:"id"`
-	Email       string     `json:"email"`
-	DisplayName *string    `json:"display_name,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
-	UpdatedAt   time.Time  `json:"updated_at"`
-	DisabledAt  *time.Time `json:"disabled_at,omitempty"`
+	ID              string     `json:"id"`
+	Email           string     `json:"email"`
+	DisplayName     *string    `json:"display_name,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	DisabledAt      *time.Time `json:"disabled_at,omitempty"`
+	EmailVerifiedAt *time.Time `json:"email_verified_at,omitempty"`
 }
 
 type Organization struct {

--- a/internal/store/auth_codes.go
+++ b/internal/store/auth_codes.go
@@ -1,0 +1,297 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+var (
+	ErrCodeMismatch = errors.New("verification code does not match")
+	ErrCodeExpired  = errors.New("verification code expired")
+	ErrTooManyAttempts = errors.New("too many verification attempts")
+	ErrAlreadyVerified = errors.New("email already verified")
+	ErrResendThrottled = errors.New("verification code recently sent")
+)
+
+type EmailVerificationStartInput struct {
+	UserID            string
+	CodeHash          string
+	ExpiresAt         time.Time
+	MinResendInterval time.Duration
+}
+
+func (s *Store) StartEmailVerification(ctx context.Context, in EmailVerificationStartInput) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var verifiedAt *time.Time
+	err = tx.QueryRow(ctx, `
+		SELECT email_verified_at FROM users WHERE id = $1 AND disabled_at IS NULL FOR UPDATE
+	`, in.UserID).Scan(&verifiedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if verifiedAt != nil {
+		return ErrAlreadyVerified
+	}
+
+	if in.MinResendInterval > 0 {
+		var existingCreatedAt *time.Time
+		err = tx.QueryRow(ctx, `
+			SELECT created_at FROM email_verifications WHERE user_id = $1 FOR UPDATE
+		`, in.UserID).Scan(&existingCreatedAt)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		if existingCreatedAt != nil && time.Since(*existingCreatedAt) < in.MinResendInterval {
+			return ErrResendThrottled
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO email_verifications (user_id, code_hash, expires_at, attempts, created_at)
+		VALUES ($1, $2, $3, 0, now())
+		ON CONFLICT (user_id) DO UPDATE
+		SET code_hash = EXCLUDED.code_hash,
+		    expires_at = EXCLUDED.expires_at,
+		    attempts = 0,
+		    created_at = now()
+	`, in.UserID, in.CodeHash, in.ExpiresAt); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (s *Store) ConsumeEmailVerification(ctx context.Context, userID, codeHash string, maxAttempts int) (model.User, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.User{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var storedHash string
+	var expiresAt time.Time
+	var attempts int
+	err = tx.QueryRow(ctx, `
+		SELECT code_hash, expires_at, attempts
+		FROM email_verifications
+		WHERE user_id = $1
+		FOR UPDATE
+	`, userID).Scan(&storedHash, &expiresAt, &attempts)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.User{}, ErrNotFound
+	}
+	if err != nil {
+		return model.User{}, err
+	}
+
+	if time.Now().UTC().After(expiresAt) {
+		if _, err := tx.Exec(ctx, `DELETE FROM email_verifications WHERE user_id = $1`, userID); err != nil {
+			return model.User{}, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return model.User{}, err
+		}
+		return model.User{}, ErrCodeExpired
+	}
+
+	if storedHash != codeHash {
+		newAttempts := attempts + 1
+		if maxAttempts > 0 && newAttempts >= maxAttempts {
+			if _, err := tx.Exec(ctx, `DELETE FROM email_verifications WHERE user_id = $1`, userID); err != nil {
+				return model.User{}, err
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return model.User{}, err
+			}
+			return model.User{}, ErrTooManyAttempts
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE email_verifications SET attempts = attempts + 1 WHERE user_id = $1
+		`, userID); err != nil {
+			return model.User{}, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return model.User{}, err
+		}
+		return model.User{}, ErrCodeMismatch
+	}
+
+	var user model.User
+	err = tx.QueryRow(ctx, `
+		UPDATE users
+		SET email_verified_at = now()
+		WHERE id = $1 AND disabled_at IS NULL
+		RETURNING id::text, email, display_name, created_at, updated_at, disabled_at, email_verified_at
+	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt, &user.EmailVerifiedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.User{}, ErrNotFound
+	}
+	if err != nil {
+		return model.User{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM email_verifications WHERE user_id = $1`, userID); err != nil {
+		return model.User{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.User{}, err
+	}
+	return user, nil
+}
+
+type PasswordResetStartInput struct {
+	UserID            string
+	CodeHash          string
+	ExpiresAt         time.Time
+	MinResendInterval time.Duration
+}
+
+func (s *Store) StartPasswordReset(ctx context.Context, in PasswordResetStartInput) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var existing string
+	err = tx.QueryRow(ctx, `
+		SELECT id::text FROM users WHERE id = $1 AND disabled_at IS NULL FOR UPDATE
+	`, in.UserID).Scan(&existing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+
+	if in.MinResendInterval > 0 {
+		var existingCreatedAt *time.Time
+		err = tx.QueryRow(ctx, `
+			SELECT created_at FROM password_resets WHERE user_id = $1 FOR UPDATE
+		`, in.UserID).Scan(&existingCreatedAt)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		if existingCreatedAt != nil && time.Since(*existingCreatedAt) < in.MinResendInterval {
+			return ErrResendThrottled
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO password_resets (user_id, code_hash, expires_at, attempts, created_at)
+		VALUES ($1, $2, $3, 0, now())
+		ON CONFLICT (user_id) DO UPDATE
+		SET code_hash = EXCLUDED.code_hash,
+		    expires_at = EXCLUDED.expires_at,
+		    attempts = 0,
+		    created_at = now()
+	`, in.UserID, in.CodeHash, in.ExpiresAt); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (s *Store) ConsumePasswordReset(ctx context.Context, userID, codeHash, newPasswordHash string, maxAttempts int) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var storedHash string
+	var expiresAt time.Time
+	var attempts int
+	err = tx.QueryRow(ctx, `
+		SELECT code_hash, expires_at, attempts
+		FROM password_resets
+		WHERE user_id = $1
+		FOR UPDATE
+	`, userID).Scan(&storedHash, &expiresAt, &attempts)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+
+	if time.Now().UTC().After(expiresAt) {
+		if _, err := tx.Exec(ctx, `DELETE FROM password_resets WHERE user_id = $1`, userID); err != nil {
+			return err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return err
+		}
+		return ErrCodeExpired
+	}
+
+	if storedHash != codeHash {
+		newAttempts := attempts + 1
+		if maxAttempts > 0 && newAttempts >= maxAttempts {
+			if _, err := tx.Exec(ctx, `DELETE FROM password_resets WHERE user_id = $1`, userID); err != nil {
+				return err
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return err
+			}
+			return ErrTooManyAttempts
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE password_resets SET attempts = attempts + 1 WHERE user_id = $1
+		`, userID); err != nil {
+			return err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return err
+		}
+		return ErrCodeMismatch
+	}
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE users
+		SET password_hash = $2
+		WHERE id = $1 AND disabled_at IS NULL
+	`, userID, newPasswordHash)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM password_resets WHERE user_id = $1`, userID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE refresh_tokens SET revoked_at = now() WHERE user_id = $1 AND revoked_at IS NULL
+	`, userID); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (s *Store) GetUserIDByEmail(ctx context.Context, email string) (string, error) {
+	var userID string
+	err := s.db.QueryRow(ctx, `
+		SELECT id::text FROM users WHERE email = $1 AND disabled_at IS NULL
+	`, email).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	return userID, err
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,8 +82,8 @@ func (s *Store) Register(ctx context.Context, in RegisterInput) (RegisterResult,
 	err = tx.QueryRow(ctx, `
 		INSERT INTO users (email, password_hash, display_name)
 		VALUES ($1, $2, $3)
-		RETURNING id::text, email, display_name, created_at, updated_at, disabled_at
-	`, in.Email, in.PasswordHash, in.DisplayName).Scan(&user.ID, &user.Email, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+		RETURNING id::text, email, display_name, created_at, updated_at, disabled_at, email_verified_at
+	`, in.Email, in.PasswordHash, in.DisplayName).Scan(&user.ID, &user.Email, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt, &user.EmailVerifiedAt)
 	if err != nil {
 		return RegisterResult{}, err
 	}
@@ -117,10 +117,10 @@ func (s *Store) GetUserPassword(ctx context.Context, email string) (model.User, 
 	var user model.User
 	var hash string
 	err := s.db.QueryRow(ctx, `
-		SELECT id::text, email, password_hash, display_name, created_at, updated_at, disabled_at
+		SELECT id::text, email, password_hash, display_name, created_at, updated_at, disabled_at, email_verified_at
 		FROM users
 		WHERE email = $1 AND disabled_at IS NULL
-	`, email).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	`, email).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt, &user.EmailVerifiedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, "", ErrNotFound
 	}
@@ -131,10 +131,10 @@ func (s *Store) GetUserPasswordByID(ctx context.Context, userID string) (model.U
 	var user model.User
 	var hash string
 	err := s.db.QueryRow(ctx, `
-		SELECT id::text, email, password_hash, display_name, created_at, updated_at, disabled_at
+		SELECT id::text, email, password_hash, display_name, created_at, updated_at, disabled_at, email_verified_at
 		FROM users
 		WHERE id = $1 AND disabled_at IS NULL
-	`, userID).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	`, userID).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt, &user.EmailVerifiedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, "", ErrNotFound
 	}
@@ -144,10 +144,10 @@ func (s *Store) GetUserPasswordByID(ctx context.Context, userID string) (model.U
 func (s *Store) GetUser(ctx context.Context, userID string) (model.User, error) {
 	var user model.User
 	err := s.db.QueryRow(ctx, `
-		SELECT id::text, email, display_name, created_at, updated_at, disabled_at
+		SELECT id::text, email, display_name, created_at, updated_at, disabled_at, email_verified_at
 		FROM users
 		WHERE id = $1 AND disabled_at IS NULL
-	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt, &user.EmailVerifiedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, ErrNotFound
 	}

--- a/migrations/009_email_verification_password_reset.sql
+++ b/migrations/009_email_verification_password_reset.sql
@@ -1,0 +1,24 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS email_verifications (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    code_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS email_verifications_expires_at_idx
+    ON email_verifications (expires_at);
+
+CREATE TABLE IF NOT EXISTS password_resets (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    code_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS password_resets_expires_at_idx
+    ON password_resets (expires_at);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -92,6 +92,74 @@ paths:
           $ref: "#/components/responses/Error"
         "401":
           $ref: "#/components/responses/Error"
+  /v1/auth/verify-email:
+    post:
+      summary: Verify email address with a one-time code.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VerifyEmailRequest"
+      responses:
+        "200":
+          description: Email verified.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerifyEmailResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "429":
+          $ref: "#/components/responses/Error"
+  /v1/auth/resend-verification:
+    post:
+      summary: Resend email verification code.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResendVerificationRequest"
+      responses:
+        "202":
+          description: Verification email queued (or address not found — response is intentionally ambiguous).
+        "400":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+        "429":
+          $ref: "#/components/responses/Error"
+  /v1/auth/forgot-password:
+    post:
+      summary: Request a password reset code by email.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ForgotPasswordRequest"
+      responses:
+        "202":
+          description: Reset email queued (or address not found — response is intentionally ambiguous).
+        "400":
+          $ref: "#/components/responses/Error"
+  /v1/auth/reset-password:
+    post:
+      summary: Reset password using a one-time code.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResetPasswordRequest"
+      responses:
+        "204":
+          description: Password reset.
+        "400":
+          $ref: "#/components/responses/Error"
+        "429":
+          $ref: "#/components/responses/Error"
   /v1/me:
     get:
       security:
@@ -967,6 +1035,51 @@ components:
         refresh_token:
           type: string
           minLength: 1
+    VerifyEmailRequest:
+      type: object
+      required: [email, code]
+      properties:
+        email:
+          type: string
+          format: email
+        code:
+          type: string
+          minLength: 6
+          maxLength: 6
+    VerifyEmailResponse:
+      type: object
+      required: [user]
+      properties:
+        user:
+          $ref: "#/components/schemas/User"
+    ResendVerificationRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+    ForgotPasswordRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+    ResetPasswordRequest:
+      type: object
+      required: [email, code, new_password]
+      properties:
+        email:
+          type: string
+          format: email
+        code:
+          type: string
+          minLength: 6
+          maxLength: 6
+        new_password:
+          type: string
+          minLength: 8
     ChangePasswordRequest:
       type: object
       required: [current_password, new_password]
@@ -1251,6 +1364,9 @@ components:
           type: string
           format: date-time
         disabled_at:
+          type: string
+          format: date-time
+        email_verified_at:
           type: string
           format: date-time
     Organization:


### PR DESCRIPTION
Closes #73

## Summary

- **Migration 009** adds `users.email_verified_at`, `email_verifications` table, and `password_resets` table (code_hash + expires_at + attempts per user)
- **`internal/mailer`** new package: `Mailer` interface, `LogMailer` (log-based adapter, mirrors broker `log` pattern), `RecordingMailer` for tests
- **`store/auth_codes.go`** transactional OTP helpers: start / consume for both email verification and password reset; DB-side resend throttling; attempt counter; lockout on the N-th wrong attempt (row deleted, further requests rejected)
- **`api/auth_codes.go`** four new public endpoints; `register` now issues a verification OTP on success
- **Config** reads `EMAIL_VERIFICATION_TTL`, `PASSWORD_RESET_TTL`, `OTP_RESEND_INTERVAL`, `OTP_MAX_ATTEMPTS` with safe defaults (30 min TTL, 60 s resend interval, 5 max attempts)
- **`model.User`** gains `email_verified_at`; all existing user SELECTs updated
- **OpenAPI** documents all 4 new paths and the new `email_verified_at` field on `User`

## New endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/v1/auth/verify-email` | public | Submit 6-digit OTP to mark email verified |
| POST | `/v1/auth/resend-verification` | public | Re-issue verification OTP (throttled) |
| POST | `/v1/auth/forgot-password` | public | Request password reset OTP (always 202) |
| POST | `/v1/auth/reset-password` | public | Submit OTP + new password |

## Security notes

- `forgot-password` and `resend-verification` for unknown emails return the same 202 to avoid user enumeration
- OTP stored as SHA-256 hash; plaintext never persisted
- Consuming a code (correct or max-attempts) deletes the row immediately
- Password reset revokes all active refresh tokens

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `TestLogMailerWritesStructuredEntry`, `TestRecordingMailerCapturesMessages`
- [x] `TestGenerateOTPProduces6DigitStrings`
- [x] `TestIntegrationEmailVerificationFlow` — register triggers OTP, wrong code 400, correct code 200 with `email_verified_at`, replay 400, resend-on-verified 409, `/me` reflects verified status
- [x] `TestIntegrationResendVerificationFlow` — resend invalidates old code, new code works, unknown email 202
- [x] `TestIntegrationPasswordResetFlow` — unknown email 202, wrong code 400, correct code 204, old password rejected, new password accepted, replay 400
- [x] `TestIntegrationOTPMaxAttemptsExhausted` — 5th wrong attempt returns 429, correct code rejected after lockout
- [x] Full `make integration-test` suite passes (all 11 packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)