### PR TITLE
[Eval Tier] Self-service signup API, email verification, org quota field, quota-raise workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Testing policy and report maintenance are documented in `docs/TESTING.md`.
 The current v2 provisioning and account/video event-channel surface is documented in `docs/SPEC.md`; rollout tracking and dependency history live in `docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md`.
 The implementation stays aligned with the `contracts/` submodule for provisioning and cross-service channel boundaries.
 The local provisioning and worker flow, including the `log` broker adapter runbook, is documented in `docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md`.
-The local auth verification and password reset delivery adapter is `AUTH_TOKEN_DELIVERY=log`; generated one-time tokens are written to the API server log for dev/test use until a production mail or SMS adapter replaces it. Quota-raise approval and decline notifications are logged through the same local server process until a real mail adapter is configured.
+The local auth verification and password reset delivery adapter is `AUTH_TOKEN_DELIVERY=log`; generated one-time tokens are written to the API server log for dev/test use until a production mail or SMS adapter replaces it. Quota-raise approval and decline notifications use the SMTP mail path when `SMTP_HOST` and `SMTP_FROM` are configured, and otherwise fall back to the local log adapter for dev/test.
 Set `CROSS_SERVICE_BROKER=azure_eventhubs` plus `AZURE_EVENTHUB_CONNECTION_STRING` to run the workers against Azure Event Hubs instead of the local `log` adapter. The inbox worker persists Azure consumer checkpoints at `.state/azure_eventhubs/<stream>__<consumer-group>.json` by default; set `AZURE_EVENTHUB_CHECKPOINT_FILE` to override that path.
 
 ## Smoke Test

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Testing policy and report maintenance are documented in `docs/TESTING.md`.
 The current v2 provisioning and account/video event-channel surface is documented in `docs/SPEC.md`; rollout tracking and dependency history live in `docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md`.
 The implementation stays aligned with the `contracts/` submodule for provisioning and cross-service channel boundaries.
 The local provisioning and worker flow, including the `log` broker adapter runbook, is documented in `docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md`.
-The local auth verification and password reset delivery adapter is `AUTH_TOKEN_DELIVERY=log`; generated one-time tokens are written to the API server log for dev/test use until a production mail or SMS adapter replaces it.
+The local auth verification and password reset delivery adapter is `AUTH_TOKEN_DELIVERY=log`; generated one-time tokens are written to the API server log for dev/test use until a production mail or SMS adapter replaces it. Quota-raise approval and decline notifications are logged through the same local server process until a real mail adapter is configured.
 Set `CROSS_SERVICE_BROKER=azure_eventhubs` plus `AZURE_EVENTHUB_CONNECTION_STRING` to run the workers against Azure Event Hubs instead of the local `log` adapter. The inbox worker persists Azure consumer checkpoints at `.state/azure_eventhubs/<stream>__<consumer-group>.json` by default; set `AZURE_EVENTHUB_CHECKPOINT_FILE` to override that path.
 
 ## Smoke Test

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,8 @@ func main() {
 	default:
 		log.Fatalf("unsupported AUTH_TOKEN_DELIVERY %q", cfg.AuthTokenDelivery)
 	}
-	server := api.NewWithAuthTokenSink(store.New(db), authService, authTokenSink)
+	notificationSink := api.NewLogQuotaRaiseNotificationSink(log.Default())
+	server := api.NewWithAuthTokenAndNotificationSink(store.New(db), authService, authTokenSink, notificationSink)
 
 	log.Printf("listening on :%s", cfg.Port)
 	if err := server.Router().Run(":" + cfg.Port); err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log"
+	"net/smtp"
+	"strings"
 
 	"rtk_account_manager/internal/api"
 	"rtk_account_manager/internal/auth"
@@ -32,11 +34,30 @@ func main() {
 	default:
 		log.Fatalf("unsupported AUTH_TOKEN_DELIVERY %q", cfg.AuthTokenDelivery)
 	}
-	notificationSink := api.NewLogQuotaRaiseNotificationSink(log.Default())
+	notificationSink := quotaRaiseNotificationSink(cfg)
 	server := api.NewWithAuthTokenAndNotificationSink(store.New(db), authService, authTokenSink, notificationSink)
 
 	log.Printf("listening on :%s", cfg.Port)
 	if err := server.Router().Run(":" + cfg.Port); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func quotaRaiseNotificationSink(cfg config.Config) api.QuotaRaiseNotificationSink {
+	if cfg.SMTPHost != "" && cfg.SMTPFrom != "" {
+		addr := cfg.SMTPHost
+		if cfg.SMTPPort != "" && !strings.Contains(addr, ":") {
+			addr = addr + ":" + cfg.SMTPPort
+		}
+		var auth smtp.Auth
+		if cfg.SMTPUsername != "" || cfg.SMTPPassword != "" {
+			host := cfg.SMTPHost
+			if i := strings.Index(host, ":"); i >= 0 {
+				host = host[:i]
+			}
+			auth = smtp.PlainAuth("", cfg.SMTPUsername, cfg.SMTPPassword, host)
+		}
+		return api.NewSMTPQuotaRaiseNotificationSink(addr, cfg.SMTPFrom, auth)
+	}
+	return api.NewLogQuotaRaiseNotificationSink(log.Default())
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -421,6 +421,10 @@ evaluation tier:
   raise request with requested quota, use case, and contact info. Platform
   admin approval or decline updates the request status and applies approved
   quotas up to the 200-device ceiling.
+- The evaluation-tier lifecycle emits audit events for signup, email
+  verification, and quota-raise submission/decision, and the admin metrics
+  snapshot surfaces signup counts, verification completion, quota-raise
+  status counts, and live quota utilization for evaluation organizations.
 
 The implementation in this repository should stay aligned with the paired
 wire-contract updates in `rtk_cloud_contracts_doc` before the issue is closed.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -393,6 +393,11 @@ Constraints:
   production server entrypoint wires `AUTH_TOKEN_DELIVERY=log` as the local
   dev/test adapter so one-time verification and reset tokens are emitted to the
   server log until a real mail or SMS adapter is configured.
+- Quota-raise decision delivery is also an explicit adapter boundary. The API
+  process accepts a `QuotaRaiseNotificationSink` for approval/decline
+  notifications, and the production server entrypoint wires the local log
+  adapter so quota decisions are observable in dev/test until a real mail
+  adapter is configured.
 - Third-party/social login is a deferred first-phase lifecycle capability and
   must not be presented as available API behavior until implemented.
 - Expired or revoked refresh tokens may be removed by an explicit maintenance command.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -397,7 +397,7 @@ Constraints:
   must not be presented as available API behavior until implemented.
 - Expired or revoked refresh tokens may be removed by an explicit maintenance command.
 
-### Self-Service Evaluation Tier (Deferred Capability)
+### Self-Service Evaluation Tier
 
 `rtk_cloud_workspace/docs/business-model.md` defines a public evaluation tier
 (default 5 devices, ceiling 200 on request, non-commercial use) and a private
@@ -405,27 +405,25 @@ commercial tier (no minimum scale, one-time license + annual maintenance).
 Account manager is the planned owner of the API surface that supports the
 evaluation tier:
 
-- A self-service signup endpoint that creates a user and initial organization
-  in an unverified state, paired with an email verification token issuance and
-  consumption flow. The existing `POST /v1/auth/register` endpoint is internal-
-  use today; the self-service variant requires email verification before the
-  account becomes active for login or device registration.
-- An organization-level evaluation device quota field, sourced from
-  `business-model.md` (default `5`, maximum `200`). Device registration must
-  reject organizations whose quota is exceeded with a typed error rather than
-  falling through silently.
-- A quota-raise request workflow: the user-facing UI lives in
-  `rtk_cloud_admin`, but the persisted request, audit, and approval state
-  belong here. Approvals raise `evaluation_device_quota` up to the 200 ceiling.
-- Tier metadata on the organization record (`tier ∈ {evaluation, commercial}`)
-  so tier-aware behavior can be enforced consistently across this service and
-  downstream services that look up organization facts.
+- `POST /v1/auth/signup` creates an evaluation-tier user and initial
+  organization in a signup-pending state, issues an email verification token,
+  and returns `202 Accepted` without login tokens.
+- `POST /v1/auth/verify-email` consumes the verification token and clears the
+  signup-pending state so the account can log in.
+- The existing `POST /v1/auth/register` endpoint remains the internal-use path
+  for account creation that is not part of the public signup flow.
+- Organizations carry tier metadata (`tier ∈ {evaluation, commercial}`) and an
+  evaluation device quota (`evaluation_device_quota`, default `5`, maximum
+  `200`). Device registration rejects evaluation-tier organizations whose
+  active device count would exceed the quota with typed error
+  `EVALUATION_QUOTA_EXCEEDED`; commercial-tier organizations ignore the quota.
+- `POST /v1/orgs/{org_id}/quota-raise-requests` stores a user-submitted quota
+  raise request with requested quota, use case, and contact info. Platform
+  admin approval or decline updates the request status and applies approved
+  quotas up to the 200-device ceiling.
 
-This is a **deferred capability**: it is not yet part of the implemented API
-surface. The implementation work will be tracked through a separate issue
-opened against this repository once the cross-repo doc baseline is approved.
-Until that issue lands, do not present signup, email verification, or
-evaluation-quota behavior as available.
+The implementation in this repository should stay aligned with the paired
+wire-contract updates in `rtk_cloud_contracts_doc` before the issue is closed.
 
 ## 6. Authorization
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -395,9 +395,10 @@ Constraints:
   server log until a real mail or SMS adapter is configured.
 - Quota-raise decision delivery is also an explicit adapter boundary. The API
   process accepts a `QuotaRaiseNotificationSink` for approval/decline
-  notifications, and the production server entrypoint wires the local log
-  adapter so quota decisions are observable in dev/test until a real mail
-  adapter is configured.
+  notifications. The production server entrypoint wires SMTP delivery when
+  `SMTP_HOST` and `SMTP_FROM` are configured, and otherwise falls back to the
+  local log adapter so quota decisions are observable in dev/test until a real
+  mail adapter is configured.
 - Third-party/social login is a deferred first-phase lifecycle capability and
   must not be presented as available API behavior until implemented.
 - Expired or revoked refresh tokens may be removed by an explicit maintenance command.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,11 +19,12 @@ import (
 )
 
 type Server struct {
-	store         *store.Store
-	auth          *auth.Service
-	authTokenSink AuthTokenSink
-	signupLimiter *signupLimiter
-	signupPolicy  signupPolicy
+	store                      *store.Store
+	auth                       *auth.Service
+	authTokenSink              AuthTokenSink
+	quotaRaiseNotificationSink QuotaRaiseNotificationSink
+	signupLimiter              *signupLimiter
+	signupPolicy               signupPolicy
 }
 
 var ErrAuthTokenSinkUnavailable = errors.New("auth token sink unavailable")
@@ -78,6 +79,52 @@ func (s LogAuthTokenSink) DeliverAuthToken(_ context.Context, delivery AuthToken
 
 func NewWithAuthTokenSink(store *store.Store, authService *auth.Service, sink AuthTokenSink) *Server {
 	return newServer(store, authService, sink)
+}
+
+type QuotaRaiseNotificationDelivery struct {
+	RecipientEmail   string
+	RecipientName    *string
+	OrganizationID   string
+	OrganizationName string
+	RequestedQuota   int
+	ApprovedQuota    *int
+	DecisionReason   *string
+	Decision         string
+}
+
+type QuotaRaiseNotificationSink interface {
+	DeliverQuotaRaiseNotification(context.Context, QuotaRaiseNotificationDelivery) error
+}
+
+type LogQuotaRaiseNotificationSink struct {
+	logger *log.Logger
+}
+
+func NewLogQuotaRaiseNotificationSink(logger *log.Logger) LogQuotaRaiseNotificationSink {
+	return LogQuotaRaiseNotificationSink{logger: logger}
+}
+
+func (s LogQuotaRaiseNotificationSink) DeliverQuotaRaiseNotification(_ context.Context, delivery QuotaRaiseNotificationDelivery) error {
+	logger := s.logger
+	if logger == nil {
+		logger = log.Default()
+	}
+	logger.Printf(
+		"quota raise notification decision=%s email=%s org_id=%s org_name=%s requested_quota=%d approved_quota=%v",
+		delivery.Decision,
+		delivery.RecipientEmail,
+		delivery.OrganizationID,
+		delivery.OrganizationName,
+		delivery.RequestedQuota,
+		delivery.ApprovedQuota,
+	)
+	return nil
+}
+
+func NewWithAuthTokenAndNotificationSink(store *store.Store, authService *auth.Service, authSink AuthTokenSink, notificationSink QuotaRaiseNotificationSink) *Server {
+	server := newServer(store, authService, authSink)
+	server.quotaRaiseNotificationSink = notificationSink
+	return server
 }
 
 func (s *Server) Router() *gin.Engine {
@@ -925,6 +972,13 @@ func bind(c *gin.Context, dst any) bool {
 		return false
 	}
 	return true
+}
+
+func bindOptional(c *gin.Context, dst any) bool {
+	if c.Request.ContentLength == 0 {
+		return true
+	}
+	return bind(c, dst)
 }
 
 func bindStrict(c *gin.Context, dst any) bool {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -140,6 +140,7 @@ func (s *Server) Router() *gin.Engine {
 
 	protected.POST("/admin/quota-raise-requests/:requestId/approve", s.requirePlatformAdmin(), s.approveQuotaRaiseRequest)
 	protected.POST("/admin/quota-raise-requests/:requestId/decline", s.requirePlatformAdmin(), s.declineQuotaRaiseRequest)
+	protected.GET("/admin/metrics", s.requirePlatformAdmin(), s.adminMetrics)
 
 	return r
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/smtp"
 	"strconv"
 	"strings"
 	"time"
@@ -119,6 +122,63 @@ func (s LogQuotaRaiseNotificationSink) DeliverQuotaRaiseNotification(_ context.C
 		delivery.ApprovedQuota,
 	)
 	return nil
+}
+
+type SMTPQuotaRaiseNotificationSink struct {
+	host     string
+	from     string
+	auth     smtp.Auth
+	sendMail func(string, smtp.Auth, string, []string, []byte) error
+}
+
+func NewSMTPQuotaRaiseNotificationSink(host, from string, auth smtp.Auth) SMTPQuotaRaiseNotificationSink {
+	return SMTPQuotaRaiseNotificationSink{
+		host:     host,
+		from:     from,
+		auth:     auth,
+		sendMail: smtp.SendMail,
+	}
+}
+
+func (s SMTPQuotaRaiseNotificationSink) DeliverQuotaRaiseNotification(_ context.Context, delivery QuotaRaiseNotificationDelivery) error {
+	if s.sendMail == nil {
+		return errors.New("smtp quota raise notification sink unavailable")
+	}
+	subject := fmt.Sprintf("Quota raise %s", delivery.Decision)
+	body := buildQuotaRaiseNotificationBody(delivery)
+	msg := buildSMTPMessage(s.from, delivery.RecipientEmail, subject, body)
+	return s.sendMail(s.host, s.auth, s.from, []string{delivery.RecipientEmail}, msg)
+}
+
+func buildQuotaRaiseNotificationBody(delivery QuotaRaiseNotificationDelivery) string {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "Quota raise decision: %s\r\n", delivery.Decision)
+	fmt.Fprintf(&b, "Organization: %s (%s)\r\n", delivery.OrganizationName, delivery.OrganizationID)
+	if delivery.RecipientName != nil && strings.TrimSpace(*delivery.RecipientName) != "" {
+		fmt.Fprintf(&b, "Requester: %s <%s>\r\n", strings.TrimSpace(*delivery.RecipientName), delivery.RecipientEmail)
+	} else {
+		fmt.Fprintf(&b, "Requester: <%s>\r\n", delivery.RecipientEmail)
+	}
+	fmt.Fprintf(&b, "Requested quota: %d\r\n", delivery.RequestedQuota)
+	if delivery.ApprovedQuota != nil {
+		fmt.Fprintf(&b, "Approved quota: %d\r\n", *delivery.ApprovedQuota)
+	}
+	if delivery.DecisionReason != nil && strings.TrimSpace(*delivery.DecisionReason) != "" {
+		fmt.Fprintf(&b, "Decision reason: %s\r\n", strings.TrimSpace(*delivery.DecisionReason))
+	}
+	return b.String()
+}
+
+func buildSMTPMessage(from, to, subject, body string) []byte {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "To: %s\r\n", to)
+	fmt.Fprintf(&b, "From: %s\r\n", from)
+	fmt.Fprintf(&b, "Subject: %s\r\n", subject)
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=utf-8\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(body)
+	return b.Bytes()
 }
 
 func NewWithAuthTokenAndNotificationSink(store *store.Store, authService *auth.Service, authSink AuthTokenSink, notificationSink QuotaRaiseNotificationSink) *Server {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -22,12 +22,24 @@ type Server struct {
 	store         *store.Store
 	auth          *auth.Service
 	authTokenSink AuthTokenSink
+	signupLimiter *signupLimiter
+	signupPolicy  signupPolicy
 }
 
 var ErrAuthTokenSinkUnavailable = errors.New("auth token sink unavailable")
 
+func newServer(store *store.Store, authService *auth.Service, sink AuthTokenSink) *Server {
+	return &Server{
+		store:         store,
+		auth:          authService,
+		authTokenSink: sink,
+		signupLimiter: newSignupLimiter(5, time.Hour),
+		signupPolicy:  loadSignupPolicy(),
+	}
+}
+
 func New(store *store.Store, authService *auth.Service) *Server {
-	return &Server{store: store, auth: authService}
+	return newServer(store, authService, nil)
 }
 
 type AuthTokenDelivery struct {
@@ -65,7 +77,7 @@ func (s LogAuthTokenSink) DeliverAuthToken(_ context.Context, delivery AuthToken
 }
 
 func NewWithAuthTokenSink(store *store.Store, authService *auth.Service, sink AuthTokenSink) *Server {
-	return &Server{store: store, auth: authService, authTokenSink: sink}
+	return newServer(store, authService, sink)
 }
 
 func (s *Server) Router() *gin.Engine {
@@ -77,6 +89,7 @@ func (s *Server) Router() *gin.Engine {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 	v1.POST("/auth/register", s.register)
+	v1.POST("/auth/signup", s.signup)
 	v1.POST("/auth/login", s.login)
 	v1.POST("/auth/refresh", s.refresh)
 	v1.POST("/auth/verify-email", s.verifyEmail)
@@ -95,6 +108,7 @@ func (s *Server) Router() *gin.Engine {
 	protected.POST("/orgs", s.createOrganization)
 	protected.GET("/orgs/:orgId", s.getOrganization)
 	protected.PATCH("/orgs/:orgId", s.requireOrgRole(model.RoleOwner), s.updateOrganization)
+	protected.POST("/orgs/:orgId/quota-raise-requests", s.requireOrgRole(model.RoleOwner, model.RoleAdmin, model.RoleMember), s.createQuotaRaiseRequest)
 	protected.GET("/orgs/:orgId/members", s.requireOrgRole(model.RoleOwner, model.RoleAdmin, model.RoleMember), s.listMembers)
 	protected.POST("/orgs/:orgId/members", s.requireOrgRole(model.RoleOwner), s.addMember)
 	protected.PATCH("/orgs/:orgId/members/:userId", s.requireOrgRole(model.RoleOwner), s.updateMemberRole)
@@ -124,6 +138,9 @@ func (s *Server) Router() *gin.Engine {
 	protected.DELETE("/orgs/:orgId/devices/:deviceId", s.requireOrgRole(model.RoleOwner, model.RoleAdmin), s.deleteDevice)
 	protected.PATCH("/orgs/:orgId/devices/:deviceId/status", s.requireOrgRole(model.RoleOwner, model.RoleAdmin), s.updateDeviceStatus)
 
+	protected.POST("/admin/quota-raise-requests/:requestId/approve", s.requirePlatformAdmin(), s.approveQuotaRaiseRequest)
+	protected.POST("/admin/quota-raise-requests/:requestId/decline", s.requirePlatformAdmin(), s.declineQuotaRaiseRequest)
+
 	return r
 }
 
@@ -148,10 +165,13 @@ func (s *Server) register(c *gin.Context) {
 		return
 	}
 	result, err := s.store.Register(c.Request.Context(), store.RegisterInput{
-		Email:            strings.ToLower(strings.TrimSpace(req.Email)),
-		PasswordHash:     hash,
-		DisplayName:      req.DisplayName,
-		OrganizationName: strings.TrimSpace(req.OrganizationName),
+		Email:                     strings.ToLower(strings.TrimSpace(req.Email)),
+		PasswordHash:              hash,
+		DisplayName:               req.DisplayName,
+		OrganizationName:          strings.TrimSpace(req.OrganizationName),
+		OrganizationTier:          model.OrganizationTierCommercial,
+		EvaluationDeviceQuota:     5,
+		SignupPendingVerification: false,
 	})
 	if err != nil {
 		writeStoreError(c, err)
@@ -186,6 +206,10 @@ func (s *Server) login(c *gin.Context) {
 	}
 	user, hash, err := s.store.GetUserPassword(c.Request.Context(), strings.ToLower(strings.TrimSpace(req.Email)))
 	if err != nil || !auth.CheckPassword(hash, req.Password) {
+		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
+		return
+	}
+	if user.SignupPendingVerification {
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
 		return
 	}
@@ -1000,6 +1024,8 @@ func writeStoreError(c *gin.Context, err error) {
 		writeError(c, http.StatusConflict, "conflict", "Resource already exists with conflicting data")
 	case errors.Is(err, store.ErrRateLimited):
 		writeError(c, http.StatusTooManyRequests, "rate_limited", "Too many token requests")
+	case errors.Is(err, store.ErrEvaluationQuotaExceeded):
+		writeError(c, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", "Evaluation device quota exceeded")
 	case errors.Is(err, errOperationStateInconsistent):
 		writeError(c, http.StatusInternalServerError, "operation_state_inconsistent", err.Error())
 	case strings.Contains(err.Error(), "duplicate key"):

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/smtp"
 	"strings"
 	"testing"
 	"time"
@@ -136,6 +137,60 @@ func TestLogQuotaRaiseNotificationSinkWritesDelivery(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected log output to contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestSMTPQuotaRaiseNotificationSinkWritesDelivery(t *testing.T) {
+	sink := NewSMTPQuotaRaiseNotificationSink("smtp.example:587", "no-reply@example.com", nil)
+	var gotAddr string
+	var gotFrom string
+	var gotTo []string
+	var gotMsg []byte
+	sink.sendMail = func(addr string, _ smtp.Auth, from string, to []string, msg []byte) error {
+		gotAddr = addr
+		gotFrom = from
+		gotTo = append([]string(nil), to...)
+		gotMsg = append([]byte(nil), msg...)
+		return nil
+	}
+
+	approvedQuota := 12
+	decisionReason := "approved for pilot"
+	recipientName := "Owner"
+	err := sink.DeliverQuotaRaiseNotification(context.Background(), QuotaRaiseNotificationDelivery{
+		RecipientEmail:   "owner@example.com",
+		RecipientName:    &recipientName,
+		OrganizationID:   "org-1",
+		OrganizationName: "Owner Org",
+		RequestedQuota:   8,
+		ApprovedQuota:    &approvedQuota,
+		DecisionReason:   &decisionReason,
+		Decision:         "approved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotAddr != "smtp.example:587" || gotFrom != "no-reply@example.com" {
+		t.Fatalf("unexpected SMTP envelope: addr=%q from=%q", gotAddr, gotFrom)
+	}
+	if len(gotTo) != 1 || gotTo[0] != "owner@example.com" {
+		t.Fatalf("unexpected recipients: %+v", gotTo)
+	}
+	for _, want := range []string{
+		"To: owner@example.com",
+		"From: no-reply@example.com",
+		"Subject: Quota raise approved",
+		"Quota raise decision: approved",
+		"Organization: Owner Org (org-1)",
+		"Requester: Owner <owner@example.com>",
+		"Requested quota: 8",
+		"Approved quota: 12",
+		"Decision reason: approved for pilot",
+	} {
+		if !strings.Contains(string(gotMsg), want) {
+			t.Fatalf("expected SMTP message to contain %q, got %q", want, string(gotMsg))
 		}
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -104,6 +104,42 @@ func TestLogAuthTokenSinkWritesDelivery(t *testing.T) {
 	}
 }
 
+func TestLogQuotaRaiseNotificationSinkWritesDelivery(t *testing.T) {
+	var buf bytes.Buffer
+	sink := NewLogQuotaRaiseNotificationSink(log.New(&buf, "", 0))
+
+	approvedQuota := 12
+	decisionReason := "approved for pilot"
+	recipientName := "Owner"
+	err := sink.DeliverQuotaRaiseNotification(context.Background(), QuotaRaiseNotificationDelivery{
+		RecipientEmail:   "owner@example.com",
+		RecipientName:    &recipientName,
+		OrganizationID:   "org-1",
+		OrganizationName: "Owner Org",
+		RequestedQuota:   8,
+		ApprovedQuota:    &approvedQuota,
+		DecisionReason:   &decisionReason,
+		Decision:         "approved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	for _, want := range []string{
+		"decision=approved",
+		"email=owner@example.com",
+		"org_id=org-1",
+		"org_name=Owner Org",
+		"requested_quota=8",
+		"approved_quota=",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected log output to contain %q, got %q", want, got)
+		}
+	}
+}
+
 func TestRequireAuthRejectsInvalidToken(t *testing.T) {
 	server := New(nil, auth.NewService("access-secret", "refresh-secret", time.Minute, time.Hour))
 	router := server.Router()

--- a/internal/api/eval_tier.go
+++ b/internal/api/eval_tier.go
@@ -201,7 +201,7 @@ func (s *Server) declineQuotaRaiseRequest(c *gin.Context) {
 
 func (s *Server) decideQuotaRaiseRequest(c *gin.Context, approved bool) {
 	var req quotaRaiseDecisionRequest
-	if !bind(c, &req) {
+	if !bindOptional(c, &req) {
 		return
 	}
 	requestID := c.Param("requestId")
@@ -216,12 +216,35 @@ func (s *Server) decideQuotaRaiseRequest(c *gin.Context, approved bool) {
 			decision.ApprovedQuota = *req.ApprovedQuota
 		}
 	}
-	request, org, err := s.store.DecideQuotaRaiseRequest(c.Request.Context(), decision)
+	request, org, requester, err := s.store.DecideQuotaRaiseRequest(c.Request.Context(), decision)
 	if err != nil {
 		writeStoreError(c, err)
 		return
 	}
+	if s.quotaRaiseNotificationSink != nil {
+		if err := s.quotaRaiseNotificationSink.DeliverQuotaRaiseNotification(c.Request.Context(), QuotaRaiseNotificationDelivery{
+			RecipientEmail:   requester.Email,
+			RecipientName:    requester.DisplayName,
+			OrganizationID:   org.ID,
+			OrganizationName: org.Name,
+			RequestedQuota:   request.RequestedQuota,
+			ApprovedQuota:    approvedQuotaForNotification(org, approved),
+			DecisionReason:   request.DecisionReason,
+			Decision:         string(request.Status),
+		}); err != nil {
+			writeError(c, http.StatusInternalServerError, "notification_delivery_failed", "Could not deliver quota-raise decision notification")
+			return
+		}
+	}
 	c.JSON(http.StatusOK, quotaRaiseDecisionResponse{QuotaRaiseRequest: request, Organization: org})
+}
+
+func approvedQuotaForNotification(org model.Organization, approved bool) *int {
+	if !approved {
+		return nil
+	}
+	quota := org.EvaluationDeviceQuota
+	return &quota
 }
 
 func (s *Server) requirePlatformAdmin() gin.HandlerFunc {

--- a/internal/api/eval_tier.go
+++ b/internal/api/eval_tier.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"net/http"
+	"net/mail"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"rtk_account_manager/internal/auth"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type signupRequest struct {
+	Email            string  `json:"email" binding:"required,email"`
+	Password         string  `json:"password" binding:"required,min=8"`
+	DisplayName      *string `json:"display_name"`
+	OrganizationName string  `json:"organization_name" binding:"required"`
+	CaptchaToken     *string `json:"captcha_token"`
+}
+
+type signupResponse struct {
+	User         model.User         `json:"user"`
+	Organization model.Organization `json:"organization"`
+}
+
+type quotaRaiseRequestRequest struct {
+	RequestedQuota int            `json:"requested_quota" binding:"required"`
+	UseCase        string         `json:"use_case" binding:"required"`
+	ContactInfo    map[string]any `json:"contact_info" binding:"required"`
+}
+
+type quotaRaiseRequestResponse struct {
+	QuotaRaiseRequest model.QuotaRaiseRequest `json:"quota_raise_request"`
+}
+
+type quotaRaiseDecisionRequest struct {
+	ApprovedQuota  *int    `json:"approved_quota"`
+	DecisionReason *string `json:"decision_reason"`
+}
+
+type quotaRaiseDecisionResponse struct {
+	QuotaRaiseRequest model.QuotaRaiseRequest `json:"quota_raise_request"`
+	Organization      model.Organization      `json:"organization"`
+}
+
+type signupPolicy struct {
+	captchaRequired   bool
+	disposableDomains map[string]struct{}
+}
+
+func loadSignupPolicy() signupPolicy {
+	policy := signupPolicy{
+		captchaRequired: parseBoolEnv("SIGNUP_CAPTCHA_REQUIRED"),
+		disposableDomains: map[string]struct{}{
+			"mailinator.com":    {},
+			"10minutemail.com":  {},
+			"guerrillamail.com": {},
+			"tempmail.com":      {},
+			"yopmail.com":       {},
+		},
+	}
+	if env := strings.TrimSpace(os.Getenv("SIGNUP_DISPOSABLE_DOMAINS")); env != "" {
+		policy.disposableDomains = map[string]struct{}{}
+		for _, domain := range strings.Split(env, ",") {
+			domain = strings.ToLower(strings.TrimSpace(domain))
+			if domain != "" {
+				policy.disposableDomains[domain] = struct{}{}
+			}
+		}
+	}
+	return policy
+}
+
+func parseBoolEnv(key string) bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	return value == "1" || value == "true" || value == "yes" || value == "on"
+}
+
+type signupLimiter struct {
+	mu       sync.Mutex
+	limit    int
+	window   time.Duration
+	counters map[string]signupLimitState
+}
+
+type signupLimitState struct {
+	windowStart time.Time
+	count       int
+}
+
+func newSignupLimiter(limit int, window time.Duration) *signupLimiter {
+	return &signupLimiter{
+		limit:    limit,
+		window:   window,
+		counters: map[string]signupLimitState{},
+	}
+}
+
+func (l *signupLimiter) allow(key string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	state := l.counters[key]
+	if state.windowStart.IsZero() || now.Sub(state.windowStart) >= l.window {
+		state.windowStart = now
+		state.count = 0
+	}
+	state.count++
+	l.counters[key] = state
+	return state.count <= l.limit
+}
+
+func (s *Server) signup(c *gin.Context) {
+	var req signupRequest
+	if !bind(c, &req) {
+		return
+	}
+	if !requireNonBlank(c, "organization_name", req.OrganizationName) {
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	if !s.allowSignup(c, email, req.CaptchaToken) {
+		return
+	}
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "password_hash_failed", "Could not hash password")
+		return
+	}
+	result, err := s.store.Register(c.Request.Context(), store.RegisterInput{
+		Email:                     email,
+		PasswordHash:              hash,
+		DisplayName:               req.DisplayName,
+		OrganizationName:          strings.TrimSpace(req.OrganizationName),
+		OrganizationTier:          model.OrganizationTierEvaluation,
+		EvaluationDeviceQuota:     5,
+		SignupPendingVerification: true,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	token, expiresAt, err := s.createAuthToken(c, result.User.ID, "email_verification")
+	if err != nil {
+		writeAuthTokenStoreError(c, err, "Could not issue verification token")
+		return
+	}
+	if err := s.deliverAuthToken(c, result.User.Email, "email_verification", token, expiresAt); err != nil {
+		writeError(c, http.StatusInternalServerError, "token_delivery_failed", "Could not deliver verification token")
+		return
+	}
+	c.JSON(http.StatusAccepted, signupResponse{User: result.User, Organization: result.Organization})
+}
+
+func (s *Server) createQuotaRaiseRequest(c *gin.Context) {
+	var req quotaRaiseRequestRequest
+	if !bind(c, &req) {
+		return
+	}
+	if req.RequestedQuota <= 0 {
+		writeError(c, http.StatusBadRequest, "invalid_request", "requested_quota must be positive")
+		return
+	}
+	if req.RequestedQuota > 200 {
+		writeError(c, http.StatusBadRequest, "invalid_request", "requested_quota must not exceed 200")
+		return
+	}
+	if !requireNonBlank(c, "use_case", req.UseCase) {
+		return
+	}
+	if len(req.ContactInfo) == 0 {
+		writeError(c, http.StatusBadRequest, "invalid_request", "contact_info must not be empty")
+		return
+	}
+	request, err := s.store.CreateQuotaRaiseRequest(c.Request.Context(), store.QuotaRaiseRequestInput{
+		OrganizationID: c.Param("orgId"),
+		RequestedBy:    currentUserID(c),
+		RequestedQuota: req.RequestedQuota,
+		UseCase:        strings.TrimSpace(req.UseCase),
+		ContactInfo:    req.ContactInfo,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, quotaRaiseRequestResponse{QuotaRaiseRequest: request})
+}
+
+func (s *Server) approveQuotaRaiseRequest(c *gin.Context) {
+	s.decideQuotaRaiseRequest(c, true)
+}
+
+func (s *Server) declineQuotaRaiseRequest(c *gin.Context) {
+	s.decideQuotaRaiseRequest(c, false)
+}
+
+func (s *Server) decideQuotaRaiseRequest(c *gin.Context, approved bool) {
+	var req quotaRaiseDecisionRequest
+	if !bind(c, &req) {
+		return
+	}
+	requestID := c.Param("requestId")
+	decision := store.QuotaRaiseDecisionInput{
+		RequestID:      requestID,
+		DecidedBy:      currentUserID(c),
+		DecisionReason: req.DecisionReason,
+		Approved:       approved,
+	}
+	if approved {
+		if req.ApprovedQuota != nil {
+			decision.ApprovedQuota = *req.ApprovedQuota
+		}
+	}
+	request, org, err := s.store.DecideQuotaRaiseRequest(c.Request.Context(), decision)
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, quotaRaiseDecisionResponse{QuotaRaiseRequest: request, Organization: org})
+}
+
+func (s *Server) requirePlatformAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		isAdmin, err := s.store.IsPlatformAdmin(c.Request.Context(), currentUserID(c))
+		if err != nil {
+			writeError(c, http.StatusForbidden, "forbidden", "Insufficient permissions")
+			c.Abort()
+			return
+		}
+		if !isAdmin {
+			writeError(c, http.StatusForbidden, "forbidden", "Insufficient permissions")
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+func (s *Server) allowSignup(c *gin.Context, email string, captchaToken *string) bool {
+	if s.signupLimiter != nil {
+		ip := c.ClientIP()
+		if ip == "" {
+			ip = c.Request.RemoteAddr
+		}
+		if !s.signupLimiter.allow(ip, time.Now().UTC()) {
+			writeError(c, http.StatusTooManyRequests, "rate_limited", "Too many signup attempts")
+			return false
+		}
+	}
+	if s.signupPolicy.captchaRequired && (captchaToken == nil || strings.TrimSpace(*captchaToken) == "") {
+		writeError(c, http.StatusBadRequest, "captcha_required", "captcha_token must be provided")
+		return false
+	}
+	if isDisposableSignupEmail(email, s.signupPolicy.disposableDomains) {
+		writeError(c, http.StatusBadRequest, "disposable_email", "Disposable email addresses are not allowed")
+		return false
+	}
+	return true
+}
+
+func isDisposableSignupEmail(email string, disposableDomains map[string]struct{}) bool {
+	parsed, err := mail.ParseAddress(email)
+	if err == nil {
+		email = parsed.Address
+	}
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(email)), "@")
+	if len(parts) != 2 {
+		return false
+	}
+	_, ok := disposableDomains[parts[1]]
+	return ok
+}

--- a/internal/api/eval_tier_test.go
+++ b/internal/api/eval_tier_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestLoadSignupPolicyHonorsEnvironmentOverrides(t *testing.T) {
+	t.Setenv("SIGNUP_CAPTCHA_REQUIRED", "yes")
+	t.Setenv("SIGNUP_DISPOSABLE_DOMAINS", "example.com, test.invalid ")
+
+	policy := loadSignupPolicy()
+	if !policy.captchaRequired {
+		t.Fatal("expected captcha requirement to be enabled from env")
+	}
+	if _, ok := policy.disposableDomains["example.com"]; !ok {
+		t.Fatalf("expected custom disposable domain to be loaded, got %+v", policy.disposableDomains)
+	}
+	if _, ok := policy.disposableDomains["test.invalid"]; !ok {
+		t.Fatalf("expected trimmed disposable domain to be loaded, got %+v", policy.disposableDomains)
+	}
+	if _, ok := policy.disposableDomains["mailinator.com"]; ok {
+		t.Fatalf("expected default disposable domain set to be replaced, got %+v", policy.disposableDomains)
+	}
+}
+
+func TestIsDisposableSignupEmail(t *testing.T) {
+	domains := map[string]struct{}{
+		"mailinator.com": {},
+	}
+
+	if !isDisposableSignupEmail("Display Name <user@mailinator.com>", domains) {
+		t.Fatal("expected parsed disposable email to be rejected")
+	}
+	if isDisposableSignupEmail("user@example.com", domains) {
+		t.Fatal("expected non-disposable email to be accepted")
+	}
+	if isDisposableSignupEmail("not-an-email", domains) {
+		t.Fatal("expected invalid email syntax to be treated as non-disposable")
+	}
+}
+
+func TestAllowSignupEnforcesCaptchaDisposableAndRateLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	captchaRecorder := httptest.NewRecorder()
+	captchaContext, _ := gin.CreateTestContext(captchaRecorder)
+	captchaContext.Request = httptest.NewRequest(http.MethodPost, "/v1/auth/signup", nil)
+	captchaContext.Request.RemoteAddr = "203.0.113.10:1234"
+	captchaServer := &Server{
+		signupLimiter: newSignupLimiter(5, time.Hour),
+		signupPolicy: signupPolicy{
+			captchaRequired:   true,
+			disposableDomains: map[string]struct{}{"mailinator.com": {}},
+		},
+	}
+	if captchaServer.allowSignup(captchaContext, "user@example.com", nil) {
+		t.Fatal("expected missing captcha token to block signup")
+	}
+	if captchaRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected captcha failure 400, got %d", captchaRecorder.Code)
+	}
+
+	disposableRecorder := httptest.NewRecorder()
+	disposableContext, _ := gin.CreateTestContext(disposableRecorder)
+	disposableContext.Request = httptest.NewRequest(http.MethodPost, "/v1/auth/signup", nil)
+	disposableContext.Request.RemoteAddr = "203.0.113.11:1234"
+	disposableServer := &Server{
+		signupLimiter: newSignupLimiter(5, time.Hour),
+		signupPolicy: signupPolicy{
+			disposableDomains: map[string]struct{}{"mailinator.com": {}},
+		},
+	}
+	if disposableServer.allowSignup(disposableContext, "Display Name <user@mailinator.com>", nil) {
+		t.Fatal("expected disposable email to block signup")
+	}
+	if disposableRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected disposable email failure 400, got %d", disposableRecorder.Code)
+	}
+
+	limitedRecorder := httptest.NewRecorder()
+	limitedContext, _ := gin.CreateTestContext(limitedRecorder)
+	limitedContext.Request = httptest.NewRequest(http.MethodPost, "/v1/auth/signup", nil)
+	limitedContext.Request.RemoteAddr = "203.0.113.12:1234"
+	limitedServer := &Server{
+		signupLimiter: newSignupLimiter(1, time.Hour),
+		signupPolicy:  signupPolicy{},
+	}
+	if !limitedServer.allowSignup(limitedContext, "user@example.com", nil) {
+		t.Fatal("expected first signup attempt to pass")
+	}
+	if limitedServer.allowSignup(limitedContext, "user@example.com", nil) {
+		t.Fatal("expected second signup attempt in the same window to be rate limited")
+	}
+	if limitedRecorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected rate limit failure 429, got %d", limitedRecorder.Code)
+	}
+}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -556,6 +556,98 @@ func TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow(t *testing.T) {
 	}
 }
 
+func TestIntegrationAdminMetricsReportsEmptySnapshot(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	admin := registerUser(t, env.router, "metrics-admin@example.com", "Metrics Admin Org")
+	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	metricsRes := performJSON(env.router, http.MethodGet, "/v1/admin/metrics", nil, admin.Tokens.AccessToken)
+	if metricsRes.Code != http.StatusOK {
+		t.Fatalf("expected empty admin metrics 200, got %d: %s", metricsRes.Code, metricsRes.Body.String())
+	}
+	metricsBody := decodeBody[evalTierMetricsBody](t, metricsRes)
+	if metricsBody.Signups.EvaluationCreated != 0 || metricsBody.Signups.VerificationCompleted != 0 || metricsBody.Signups.VerificationCompletionRate != 0 {
+		t.Fatalf("expected empty signup metrics, got %+v", metricsBody.Signups)
+	}
+	if metricsBody.QuotaRaiseRequests.Pending != 0 || metricsBody.QuotaRaiseRequests.Approved != 0 || metricsBody.QuotaRaiseRequests.Declined != 0 {
+		t.Fatalf("expected empty quota-raise metrics, got %+v", metricsBody.QuotaRaiseRequests)
+	}
+	if len(metricsBody.EvaluationQuotaUsage) != 0 {
+		t.Fatalf("expected no evaluation quota usage rows, got %+v", metricsBody.EvaluationQuotaUsage)
+	}
+}
+
+func TestIntegrationQuotaRaiseValidationAndDefaultApproval(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	signupRes := performJSON(env.router, http.MethodPost, "/v1/auth/signup", map[string]any{
+		"email":             "validate-quota@example.com",
+		"password":          "password123",
+		"display_name":      "Validate Quota",
+		"organization_name": "Validate Quota Org",
+	}, "")
+	if signupRes.Code != http.StatusAccepted {
+		t.Fatalf("expected signup 202, got %d: %s", signupRes.Code, signupRes.Body.String())
+	}
+	signupBody := decodeBody[signupBody](t, signupRes)
+	verifyToken := latestAuthToken(t, env.tokenSink, "validate-quota@example.com", "email_verification")
+	verifyRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"token": verifyToken,
+	}, "")
+	if verifyRes.Code != http.StatusOK {
+		t.Fatalf("expected verify 200, got %d: %s", verifyRes.Code, verifyRes.Body.String())
+	}
+	loginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "validate-quota@example.com",
+		"password": "password123",
+	}, "")
+	if loginRes.Code != http.StatusOK {
+		t.Fatalf("expected login 200, got %d: %s", loginRes.Code, loginRes.Body.String())
+	}
+	loginBody := decodeBody[tokenBody](t, loginRes)
+
+	invalidRequests := []map[string]any{
+		{"requested_quota": 0, "use_case": "pilot", "contact_info": map[string]any{"email": "buyer@example.com"}},
+		{"requested_quota": 201, "use_case": "pilot", "contact_info": map[string]any{"email": "buyer@example.com"}},
+		{"requested_quota": 8, "use_case": "   ", "contact_info": map[string]any{"email": "buyer@example.com"}},
+		{"requested_quota": 8, "use_case": "pilot", "contact_info": map[string]any{}},
+	}
+	for i, body := range invalidRequests {
+		res := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", body, loginBody.Tokens.AccessToken)
+		if res.Code != http.StatusBadRequest {
+			t.Fatalf("expected invalid quota raise request %d to fail 400, got %d: %s", i, res.Code, res.Body.String())
+		}
+	}
+
+	raiseReqRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", map[string]any{
+		"requested_quota": 8,
+		"use_case":        "pilot expansion",
+		"contact_info": map[string]any{
+			"email": "buyer@example.com",
+		},
+	}, loginBody.Tokens.AccessToken)
+	if raiseReqRes.Code != http.StatusCreated {
+		t.Fatalf("expected quota raise request 201, got %d: %s", raiseReqRes.Code, raiseReqRes.Body.String())
+	}
+	raiseReqBody := decodeBody[quotaRaiseRequestBody](t, raiseReqRes)
+
+	admin := registerUser(t, env.router, "validate-quota-admin@example.com", "Validate Quota Admin Org")
+	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{}, admin.Tokens.AccessToken)
+	if approveRes.Code != http.StatusOK {
+		t.Fatalf("expected quota approval 200, got %d: %s", approveRes.Code, approveRes.Body.String())
+	}
+	approvedBody := decodeBody[quotaRaiseDecisionBody](t, approveRes)
+	if approvedBody.Organization.EvaluationDeviceQuota != 8 {
+		t.Fatalf("expected default approval quota to use requested amount, got %+v", approvedBody.Organization)
+	}
+}
+
 func TestIntegrationCurrentUserCanChangePassword(t *testing.T) {
 	env := newIntegrationEnv(t)
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -479,19 +479,75 @@ func TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow(t *testing.T) {
 		t.Fatalf("expected pending quota raise request, got %+v", raiseReqBody.QuotaRaiseRequest)
 	}
 
+	nonAdminApproveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{
+		"approved_quota": 500,
+	}, loginBody.Tokens.AccessToken)
+	if nonAdminApproveRes.Code != http.StatusForbidden {
+		t.Fatalf("expected non-admin approval attempt 403, got %d: %s", nonAdminApproveRes.Code, nonAdminApproveRes.Body.String())
+	}
+
 	admin := registerUser(t, env.router, "platform-admin@example.com", "Admin Org")
 	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
 		t.Fatal(err)
 	}
 	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{
-		"approved_quota": 8,
+		"approved_quota": 500,
 	}, admin.Tokens.AccessToken)
 	if approveRes.Code != http.StatusOK {
 		t.Fatalf("expected quota approval 200, got %d: %s", approveRes.Code, approveRes.Body.String())
 	}
 	approvedBody := decodeBody[quotaRaiseDecisionBody](t, approveRes)
-	if approvedBody.Organization.EvaluationDeviceQuota != 8 {
-		t.Fatalf("expected approved quota 8, got %+v", approvedBody.Organization)
+	if approvedBody.Organization.EvaluationDeviceQuota != 200 {
+		t.Fatalf("expected approved quota to cap at 200, got %+v", approvedBody.Organization)
+	}
+
+	declineReqRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", map[string]any{
+		"requested_quota": 12,
+		"use_case":        "contract exit",
+		"contact_info": map[string]any{
+			"email": "buyer@example.com",
+		},
+	}, loginBody.Tokens.AccessToken)
+	if declineReqRes.Code != http.StatusCreated {
+		t.Fatalf("expected second quota raise request 201, got %d: %s", declineReqRes.Code, declineReqRes.Body.String())
+	}
+	declineReqBody := decodeBody[quotaRaiseRequestBody](t, declineReqRes)
+	declineRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+declineReqBody.QuotaRaiseRequest.ID+"/decline", map[string]any{
+		"decision_reason": "not enough supporting detail",
+	}, admin.Tokens.AccessToken)
+	if declineRes.Code != http.StatusOK {
+		t.Fatalf("expected quota decline 200, got %d: %s", declineRes.Code, declineRes.Body.String())
+	}
+	declinedBody := decodeBody[quotaRaiseDecisionBody](t, declineRes)
+	if declinedBody.QuotaRaiseRequest.Status != string(model.QuotaRaiseRequestStatusDeclined) {
+		t.Fatalf("expected declined quota raise request, got %+v", declinedBody.QuotaRaiseRequest)
+	}
+	if declinedBody.Organization.EvaluationDeviceQuota != 200 {
+		t.Fatalf("expected decline to keep capped quota at 200, got %+v", declinedBody.Organization)
+	}
+
+	metricsRes := performJSON(env.router, http.MethodGet, "/v1/admin/metrics", nil, admin.Tokens.AccessToken)
+	if metricsRes.Code != http.StatusOK {
+		t.Fatalf("expected admin metrics 200, got %d: %s", metricsRes.Code, metricsRes.Body.String())
+	}
+	metricsBody := decodeBody[evalTierMetricsBody](t, metricsRes)
+	if metricsBody.Signups.EvaluationCreated != 1 {
+		t.Fatalf("expected one evaluation signup, got %+v", metricsBody.Signups)
+	}
+	if metricsBody.Signups.VerificationCompleted != 1 {
+		t.Fatalf("expected one signup verification completion, got %+v", metricsBody.Signups)
+	}
+	if metricsBody.Signups.VerificationCompletionRate != 1 {
+		t.Fatalf("expected 100%% verification completion, got %+v", metricsBody.Signups)
+	}
+	if metricsBody.QuotaRaiseRequests.Pending != 0 || metricsBody.QuotaRaiseRequests.Approved != 1 || metricsBody.QuotaRaiseRequests.Declined != 1 {
+		t.Fatalf("expected quota raise status counts to reflect one approve and one decline, got %+v", metricsBody.QuotaRaiseRequests)
+	}
+	if len(metricsBody.EvaluationQuotaUsage) != 1 {
+		t.Fatalf("expected one evaluation org usage entry, got %+v", metricsBody.EvaluationQuotaUsage)
+	}
+	if metricsBody.EvaluationQuotaUsage[0].ActiveDevices != 5 || metricsBody.EvaluationQuotaUsage[0].EvaluationDeviceQuota != 200 {
+		t.Fatalf("expected live quota usage to reflect approved quota and existing devices, got %+v", metricsBody.EvaluationQuotaUsage[0])
 	}
 
 	postApprovalRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/devices", devicePayload("eval-device-5", "EVAL-5"), loginBody.Tokens.AccessToken)
@@ -2126,6 +2182,27 @@ type quotaRaiseDecisionBody struct {
 		Tier                  string `json:"tier"`
 		EvaluationDeviceQuota int    `json:"evaluation_device_quota"`
 	} `json:"organization"`
+}
+
+type evalTierMetricsBody struct {
+	Signups struct {
+		EvaluationCreated          int64   `json:"evaluation_created"`
+		CommercialCreated          int64   `json:"commercial_created"`
+		VerificationCompleted      int64   `json:"verification_completed"`
+		VerificationCompletionRate float64 `json:"verification_completion_rate"`
+	} `json:"signups"`
+	QuotaRaiseRequests struct {
+		Pending  int64 `json:"pending"`
+		Approved int64 `json:"approved"`
+		Declined int64 `json:"declined"`
+	} `json:"quota_raise_requests"`
+	EvaluationQuotaUsage []struct {
+		OrganizationID        string  `json:"organization_id"`
+		OrganizationName      string  `json:"organization_name"`
+		ActiveDevices         int     `json:"active_devices"`
+		EvaluationDeviceQuota int     `json:"evaluation_device_quota"`
+		Utilization           float64 `json:"utilization"`
+	} `json:"evaluation_quota_usage"`
 }
 
 type membersBody struct {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -24,9 +24,10 @@ import (
 )
 
 type integrationEnv struct {
-	router    *gin.Engine
-	db        *pgxpool.Pool
-	tokenSink *recordingAuthTokenSink
+	router           *gin.Engine
+	db               *pgxpool.Pool
+	tokenSink        *recordingAuthTokenSink
+	notificationSink *recordingQuotaRaiseNotificationSink
 }
 
 type recordingAuthTokenSink struct {
@@ -34,6 +35,15 @@ type recordingAuthTokenSink struct {
 }
 
 func (s *recordingAuthTokenSink) DeliverAuthToken(_ context.Context, delivery AuthTokenDelivery) error {
+	s.deliveries = append(s.deliveries, delivery)
+	return nil
+}
+
+type recordingQuotaRaiseNotificationSink struct {
+	deliveries []QuotaRaiseNotificationDelivery
+}
+
+func (s *recordingQuotaRaiseNotificationSink) DeliverQuotaRaiseNotification(_ context.Context, delivery QuotaRaiseNotificationDelivery) error {
 	s.deliveries = append(s.deliveries, delivery)
 	return nil
 }
@@ -68,10 +78,12 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 	gin.SetMode(gin.TestMode)
 	authService := auth.NewService("test-access-secret", "test-refresh-secret", time.Minute, time.Hour)
 	tokenSink := &recordingAuthTokenSink{}
+	notificationSink := &recordingQuotaRaiseNotificationSink{}
 	return integrationEnv{
-		router:    NewWithAuthTokenSink(store.New(db), authService, tokenSink).Router(),
-		db:        db,
-		tokenSink: tokenSink,
+		router:           NewWithAuthTokenAndNotificationSink(store.New(db), authService, tokenSink, notificationSink).Router(),
+		db:               db,
+		tokenSink:        tokenSink,
+		notificationSink: notificationSink,
 	}
 }
 
@@ -638,13 +650,41 @@ func TestIntegrationQuotaRaiseValidationAndDefaultApproval(t *testing.T) {
 	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
 		t.Fatal(err)
 	}
-	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{}, admin.Tokens.AccessToken)
+	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", nil, admin.Tokens.AccessToken)
 	if approveRes.Code != http.StatusOK {
 		t.Fatalf("expected quota approval 200, got %d: %s", approveRes.Code, approveRes.Body.String())
 	}
 	approvedBody := decodeBody[quotaRaiseDecisionBody](t, approveRes)
 	if approvedBody.Organization.EvaluationDeviceQuota != 8 {
 		t.Fatalf("expected default approval quota to use requested amount, got %+v", approvedBody.Organization)
+	}
+	declineReqRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", map[string]any{
+		"requested_quota": 12,
+		"use_case":        "contract exit",
+		"contact_info": map[string]any{
+			"email": "buyer@example.com",
+		},
+	}, loginBody.Tokens.AccessToken)
+	if declineReqRes.Code != http.StatusCreated {
+		t.Fatalf("expected decline quota raise request 201, got %d: %s", declineReqRes.Code, declineReqRes.Body.String())
+	}
+	declineReqBody := decodeBody[quotaRaiseRequestBody](t, declineReqRes)
+	declineRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+declineReqBody.QuotaRaiseRequest.ID+"/decline", nil, admin.Tokens.AccessToken)
+	if declineRes.Code != http.StatusOK {
+		t.Fatalf("expected quota decline 200, got %d: %s", declineRes.Code, declineRes.Body.String())
+	}
+	declinedBody := decodeBody[quotaRaiseDecisionBody](t, declineRes)
+	if declinedBody.QuotaRaiseRequest.Status != string(model.QuotaRaiseRequestStatusDeclined) {
+		t.Fatalf("expected declined quota raise request, got %+v", declinedBody.QuotaRaiseRequest)
+	}
+	if len(env.notificationSink.deliveries) != 2 {
+		t.Fatalf("expected approval and decline notifications, got %+v", env.notificationSink.deliveries)
+	}
+	if env.notificationSink.deliveries[0].Decision != string(model.QuotaRaiseRequestStatusApproved) || env.notificationSink.deliveries[0].RecipientEmail != "validate-quota@example.com" {
+		t.Fatalf("expected approval notification for requester, got %+v", env.notificationSink.deliveries[0])
+	}
+	if env.notificationSink.deliveries[1].Decision != string(model.QuotaRaiseRequestStatusDeclined) || env.notificationSink.deliveries[1].RecipientEmail != "validate-quota@example.com" {
+		t.Fatalf("expected decline notification for requester, got %+v", env.notificationSink.deliveries[1])
 	}
 }
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -59,7 +59,7 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-		TRUNCATE auth_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
+		TRUNCATE auth_tokens, quota_raise_requests, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
 		RESTART IDENTITY CASCADE
 	`); err != nil {
 		t.Fatal(err)
@@ -390,6 +390,113 @@ func TestIntegrationEmailVerificationAndPasswordRecovery(t *testing.T) {
 	}, "")
 	if disabledResendRes.Code != http.StatusAccepted {
 		t.Fatalf("expected disabled resend-verification to remain enumeration-safe 202, got %d", disabledResendRes.Code)
+	}
+}
+
+func TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	signupRes := performJSON(env.router, http.MethodPost, "/v1/auth/signup", map[string]any{
+		"email":             "eval@example.com",
+		"password":          "password123",
+		"display_name":      "Eval User",
+		"organization_name": "Eval Org",
+	}, "")
+	if signupRes.Code != http.StatusAccepted {
+		t.Fatalf("expected signup 202, got %d: %s", signupRes.Code, signupRes.Body.String())
+	}
+	signupBody := decodeBody[signupBody](t, signupRes)
+	if !signupBody.User.SignupPendingVerification || signupBody.User.EmailVerified {
+		t.Fatalf("expected signup-pending user, got %+v", signupBody.User)
+	}
+	if signupBody.Organization.Tier != string(model.OrganizationTierEvaluation) || signupBody.Organization.EvaluationDeviceQuota != 5 {
+		t.Fatalf("expected evaluation org quota defaults, got %+v", signupBody.Organization)
+	}
+
+	unauthorizedLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "eval@example.com",
+		"password": "password123",
+	}, "")
+	if unauthorizedLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected pending signup login to fail, got %d", unauthorizedLoginRes.Code)
+	}
+
+	verifyToken := latestAuthToken(t, env.tokenSink, "eval@example.com", "email_verification")
+	verifyRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"token": verifyToken,
+	}, "")
+	if verifyRes.Code != http.StatusOK {
+		t.Fatalf("expected signup verification 200, got %d: %s", verifyRes.Code, verifyRes.Body.String())
+	}
+	verifiedBody := decodeBody[userBody](t, verifyRes)
+	if !verifiedBody.User.EmailVerified || verifiedBody.User.SignupPendingVerification {
+		t.Fatalf("expected verified signup user, got %+v", verifiedBody.User)
+	}
+
+	loginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "eval@example.com",
+		"password": "password123",
+	}, "")
+	if loginRes.Code != http.StatusOK {
+		t.Fatalf("expected verified signup login 200, got %d: %s", loginRes.Code, loginRes.Body.String())
+	}
+	loginBody := decodeBody[tokenBody](t, loginRes)
+
+	for i := 0; i < 5; i++ {
+		res := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/devices", devicePayload("eval-device-"+strconv.Itoa(i), "EVAL-"+strconv.Itoa(i)), loginBody.Tokens.AccessToken)
+		if res.Code != http.StatusCreated {
+			t.Fatalf("expected device %d create 201, got %d: %s", i, res.Code, res.Body.String())
+		}
+	}
+	quotaExceededRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/devices", devicePayload("eval-device-5", "EVAL-5"), loginBody.Tokens.AccessToken)
+	if quotaExceededRes.Code != http.StatusConflict {
+		t.Fatalf("expected quota exceeded 409, got %d: %s", quotaExceededRes.Code, quotaExceededRes.Body.String())
+	}
+	var quotaExceeded struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(quotaExceededRes.Body.Bytes(), &quotaExceeded); err != nil {
+		t.Fatal(err)
+	}
+	if quotaExceeded.Error.Code != "EVALUATION_QUOTA_EXCEEDED" {
+		t.Fatalf("expected evaluation quota error code, got %+v", quotaExceeded)
+	}
+
+	raiseReqRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", map[string]any{
+		"requested_quota": 8,
+		"use_case":        "pilot expansion",
+		"contact_info": map[string]any{
+			"email": "buyer@example.com",
+		},
+	}, loginBody.Tokens.AccessToken)
+	if raiseReqRes.Code != http.StatusCreated {
+		t.Fatalf("expected quota raise request 201, got %d: %s", raiseReqRes.Code, raiseReqRes.Body.String())
+	}
+	raiseReqBody := decodeBody[quotaRaiseRequestBody](t, raiseReqRes)
+	if raiseReqBody.QuotaRaiseRequest.Status != string(model.QuotaRaiseRequestStatusPending) {
+		t.Fatalf("expected pending quota raise request, got %+v", raiseReqBody.QuotaRaiseRequest)
+	}
+
+	admin := registerUser(t, env.router, "platform-admin@example.com", "Admin Org")
+	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{
+		"approved_quota": 8,
+	}, admin.Tokens.AccessToken)
+	if approveRes.Code != http.StatusOK {
+		t.Fatalf("expected quota approval 200, got %d: %s", approveRes.Code, approveRes.Body.String())
+	}
+	approvedBody := decodeBody[quotaRaiseDecisionBody](t, approveRes)
+	if approvedBody.Organization.EvaluationDeviceQuota != 8 {
+		t.Fatalf("expected approved quota 8, got %+v", approvedBody.Organization)
+	}
+
+	postApprovalRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/devices", devicePayload("eval-device-5", "EVAL-5"), loginBody.Tokens.AccessToken)
+	if postApprovalRes.Code != http.StatusCreated {
+		t.Fatalf("expected device create after approval 201, got %d: %s", postApprovalRes.Code, postApprovalRes.Body.String())
 	}
 }
 
@@ -1889,11 +1996,14 @@ func TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata(t *testing.T) {
 
 type registerBody struct {
 	User struct {
-		ID            string `json:"id"`
-		EmailVerified bool   `json:"email_verified"`
+		ID                        string `json:"id"`
+		EmailVerified             bool   `json:"email_verified"`
+		SignupPendingVerification bool   `json:"signup_pending_verification"`
 	} `json:"user"`
 	Organization struct {
-		ID string `json:"id"`
+		ID                    string `json:"id"`
+		Tier                  string `json:"tier"`
+		EvaluationDeviceQuota int    `json:"evaluation_device_quota"`
 	} `json:"organization"`
 	Tokens struct {
 		AccessToken  string `json:"access_token"`
@@ -1901,11 +2011,25 @@ type registerBody struct {
 	} `json:"tokens"`
 }
 
+type signupBody struct {
+	User struct {
+		ID                        string `json:"id"`
+		EmailVerified             bool   `json:"email_verified"`
+		SignupPendingVerification bool   `json:"signup_pending_verification"`
+	} `json:"user"`
+	Organization struct {
+		ID                    string `json:"id"`
+		Tier                  string `json:"tier"`
+		EvaluationDeviceQuota int    `json:"evaluation_device_quota"`
+	} `json:"organization"`
+}
+
 type userBody struct {
 	User struct {
-		ID              string     `json:"id"`
-		EmailVerified   bool       `json:"email_verified"`
-		EmailVerifiedAt *time.Time `json:"email_verified_at"`
+		ID                        string     `json:"id"`
+		EmailVerified             bool       `json:"email_verified"`
+		SignupPendingVerification bool       `json:"signup_pending_verification"`
+		EmailVerifiedAt           *time.Time `json:"email_verified_at"`
 	} `json:"user"`
 }
 
@@ -1975,9 +2099,32 @@ type organizationsBody struct {
 
 type organizationBody struct {
 	Organization struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		Role string `json:"role"`
+		ID                    string `json:"id"`
+		Name                  string `json:"name"`
+		Role                  string `json:"role"`
+		Tier                  string `json:"tier"`
+		EvaluationDeviceQuota int    `json:"evaluation_device_quota"`
+	} `json:"organization"`
+}
+
+type quotaRaiseRequestBody struct {
+	QuotaRaiseRequest struct {
+		ID             string `json:"id"`
+		Status         string `json:"status"`
+		RequestedQuota int    `json:"requested_quota"`
+	} `json:"quota_raise_request"`
+}
+
+type quotaRaiseDecisionBody struct {
+	QuotaRaiseRequest struct {
+		ID             string `json:"id"`
+		Status         string `json:"status"`
+		RequestedQuota int    `json:"requested_quota"`
+	} `json:"quota_raise_request"`
+	Organization struct {
+		ID                    string `json:"id"`
+		Tier                  string `json:"tier"`
+		EvaluationDeviceQuota int    `json:"evaluation_device_quota"`
 	} `json:"organization"`
 }
 

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"math"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type evalTierMetricsResponse struct {
+	Signups struct {
+		EvaluationCreated          int64   `json:"evaluation_created"`
+		CommercialCreated          int64   `json:"commercial_created"`
+		VerificationCompleted      int64   `json:"verification_completed"`
+		VerificationCompletionRate float64 `json:"verification_completion_rate"`
+	} `json:"signups"`
+	QuotaRaiseRequests struct {
+		Pending  int64 `json:"pending"`
+		Approved int64 `json:"approved"`
+		Declined int64 `json:"declined"`
+	} `json:"quota_raise_requests"`
+	EvaluationQuotaUsage []evaluationQuotaUsageResponse `json:"evaluation_quota_usage"`
+}
+
+type evaluationQuotaUsageResponse struct {
+	OrganizationID        string  `json:"organization_id"`
+	OrganizationName      string  `json:"organization_name"`
+	ActiveDevices         int     `json:"active_devices"`
+	EvaluationDeviceQuota int     `json:"evaluation_device_quota"`
+	Utilization           float64 `json:"utilization"`
+}
+
+func (s *Server) adminMetrics(c *gin.Context) {
+	evalCreated, commercialCreated, err := s.store.CountEvaluationSignupEvents(c.Request.Context())
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	verificationCompleted, err := s.store.CountEmailVerificationEventsFromSignup(c.Request.Context())
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	pending, approved, declined, err := s.store.CountQuotaRaiseRequestStatuses(c.Request.Context())
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	usages, err := s.store.ListEvaluationQuotaUsage(c.Request.Context())
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+
+	body := evalTierMetricsResponse{}
+	body.Signups.EvaluationCreated = evalCreated
+	body.Signups.CommercialCreated = commercialCreated
+	body.Signups.VerificationCompleted = verificationCompleted
+	if evalCreated > 0 {
+		body.Signups.VerificationCompletionRate = math.Round((float64(verificationCompleted)/float64(evalCreated))*10000) / 10000
+	}
+	body.QuotaRaiseRequests.Pending = pending
+	body.QuotaRaiseRequests.Approved = approved
+	body.QuotaRaiseRequests.Declined = declined
+	body.EvaluationQuotaUsage = make([]evaluationQuotaUsageResponse, 0, len(usages))
+	for _, usage := range usages {
+		body.EvaluationQuotaUsage = append(body.EvaluationQuotaUsage, evaluationQuotaUsageResponse{
+			OrganizationID:        usage.OrganizationID,
+			OrganizationName:      usage.OrganizationName,
+			ActiveDevices:         usage.ActiveDevices,
+			EvaluationDeviceQuota: usage.EvaluationDeviceQuota,
+			Utilization:           usage.Utilization(),
+		})
+	}
+
+	c.JSON(http.StatusOK, body)
+}

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -98,9 +98,7 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
 		t.Fatal(err)
 	}
-	approveReqRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{
-		"approved_quota": 8,
-	}, admin.Tokens.AccessToken)
+	approveReqRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", approveReqRes)
 
 	badDeviceRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+registered.Organization.ID+"/devices", map[string]any{

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -20,6 +20,15 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	env := newIntegrationEnv(t)
 	contract := newResponseContract(t)
 
+	signupRes := performJSON(env.router, http.MethodPost, "/v1/auth/signup", map[string]any{
+		"email":             "contract-signup@example.com",
+		"password":          "password123",
+		"display_name":      "Contract Signup",
+		"organization_name": "Contract Signup Org",
+	}, "")
+	contract.validate(t, http.MethodPost, "/v1/auth/signup", signupRes)
+	signupBody := decodeBody[signupBody](t, signupRes)
+
 	registered := registerUser(t, env.router, "contract-owner@example.com", "Contract Org")
 	registerRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
 		"email":    "contract-owner@example.com",
@@ -62,6 +71,37 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 
 	tagsRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/tags", nil, registered.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/tags", tagsRes)
+
+	verifyToken := latestAuthToken(t, env.tokenSink, "contract-signup@example.com", "email_verification")
+	verifyRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{
+		"token": verifyToken,
+	}, "")
+	contract.validate(t, http.MethodPost, "/v1/auth/verify-email", verifyRes)
+	signupLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "contract-signup@example.com",
+		"password": "password123",
+	}, "")
+	contract.validate(t, http.MethodPost, "/v1/auth/login", signupLoginRes)
+	signupLoginBody := decodeBody[tokenBody](t, signupLoginRes)
+
+	raiseReqRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", map[string]any{
+		"requested_quota": 8,
+		"use_case":        "contract test",
+		"contact_info": map[string]any{
+			"email": "contract@example.com",
+		},
+	}, signupLoginBody.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/orgs/"+signupBody.Organization.ID+"/quota-raise-requests", raiseReqRes)
+	raiseReqBody := decodeBody[quotaRaiseRequestBody](t, raiseReqRes)
+
+	admin := registerUser(t, env.router, "contract-platform-admin@example.com", "Contract Admin Org")
+	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	approveReqRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{
+		"approved_quota": 8,
+	}, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", approveReqRes)
 
 	badDeviceRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+registered.Organization.ID+"/devices", map[string]any{
 		"name":     "contract-device",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,11 @@ type Config struct {
 	RefreshTokenTTL               time.Duration
 	Port                          string
 	AuthTokenDelivery             string
+	SMTPHost                      string
+	SMTPPort                      string
+	SMTPUsername                  string
+	SMTPPassword                  string
+	SMTPFrom                      string
 	CrossServiceBroker            string
 	AzureEventHubConnectionString string
 	AzureEventHubCheckpointFile   string
@@ -61,6 +66,11 @@ func load() (Config, error) {
 		RefreshTokenTTL:               duration("REFRESH_TOKEN_TTL", 30*24*time.Hour),
 		Port:                          getenv("PORT", "8080"),
 		AuthTokenDelivery:             getenv("AUTH_TOKEN_DELIVERY", "log"),
+		SMTPHost:                      getenv("SMTP_HOST", ""),
+		SMTPPort:                      getenv("SMTP_PORT", "587"),
+		SMTPUsername:                  getenv("SMTP_USERNAME", ""),
+		SMTPPassword:                  getenv("SMTP_PASSWORD", ""),
+		SMTPFrom:                      getenv("SMTP_FROM", ""),
 		CrossServiceBroker:            getenv("CROSS_SERVICE_BROKER", "log"),
 		AzureEventHubConnectionString: getenv("AZURE_EVENTHUB_CONNECTION_STRING", ""),
 		AzureEventHubCheckpointFile:   getenv("AZURE_EVENTHUB_CHECKPOINT_FILE", ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,6 +48,11 @@ func TestLoadReadsEnvironmentAndDurations(t *testing.T) {
 	t.Setenv("REFRESH_TOKEN_TTL", "24h")
 	t.Setenv("PORT", "9090")
 	t.Setenv("AUTH_TOKEN_DELIVERY", "log")
+	t.Setenv("SMTP_HOST", "smtp.example")
+	t.Setenv("SMTP_PORT", "2525")
+	t.Setenv("SMTP_USERNAME", "smtp-user")
+	t.Setenv("SMTP_PASSWORD", "smtp-pass")
+	t.Setenv("SMTP_FROM", "noreply@example.com")
 	t.Setenv("AZURE_EVENTHUB_CONNECTION_STRING", "Endpoint=sb://example/")
 	t.Setenv("AZURE_EVENTHUB_CHECKPOINT_FILE", "/tmp/eventhub-checkpoints.json")
 
@@ -72,6 +77,9 @@ func TestLoadReadsEnvironmentAndDurations(t *testing.T) {
 	}
 	if cfg.AuthTokenDelivery != "log" {
 		t.Fatalf("unexpected auth token delivery: %q", cfg.AuthTokenDelivery)
+	}
+	if cfg.SMTPHost != "smtp.example" || cfg.SMTPPort != "2525" || cfg.SMTPUsername != "smtp-user" || cfg.SMTPPassword != "smtp-pass" || cfg.SMTPFrom != "noreply@example.com" {
+		t.Fatalf("unexpected smtp config: %+v", cfg)
 	}
 	if cfg.CrossServiceBroker != "log" {
 		t.Fatalf("unexpected broker: %q", cfg.CrossServiceBroker)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -10,6 +10,21 @@ const (
 	RoleMember Role = "member"
 )
 
+type OrganizationTier string
+
+const (
+	OrganizationTierEvaluation OrganizationTier = "evaluation"
+	OrganizationTierCommercial OrganizationTier = "commercial"
+)
+
+type QuotaRaiseRequestStatus string
+
+const (
+	QuotaRaiseRequestStatusPending  QuotaRaiseRequestStatus = "pending"
+	QuotaRaiseRequestStatusApproved QuotaRaiseRequestStatus = "approved"
+	QuotaRaiseRequestStatusDeclined QuotaRaiseRequestStatus = "declined"
+)
+
 type DeviceCategory string
 
 const (
@@ -110,22 +125,25 @@ const (
 )
 
 type User struct {
-	ID              string     `json:"id"`
-	Email           string     `json:"email"`
-	DisplayName     *string    `json:"display_name,omitempty"`
-	EmailVerified   bool       `json:"email_verified"`
-	EmailVerifiedAt *time.Time `json:"email_verified_at,omitempty"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
-	DisabledAt      *time.Time `json:"disabled_at,omitempty"`
+	ID                        string     `json:"id"`
+	Email                     string     `json:"email"`
+	DisplayName               *string    `json:"display_name,omitempty"`
+	EmailVerified             bool       `json:"email_verified"`
+	EmailVerifiedAt           *time.Time `json:"email_verified_at,omitempty"`
+	SignupPendingVerification bool       `json:"signup_pending_verification"`
+	CreatedAt                 time.Time  `json:"created_at"`
+	UpdatedAt                 time.Time  `json:"updated_at"`
+	DisabledAt                *time.Time `json:"disabled_at,omitempty"`
 }
 
 type Organization struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Role      Role      `json:"role,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID                    string           `json:"id"`
+	Name                  string           `json:"name"`
+	Role                  Role             `json:"role,omitempty"`
+	Tier                  OrganizationTier `json:"tier"`
+	EvaluationDeviceQuota int              `json:"evaluation_device_quota"`
+	CreatedAt             time.Time        `json:"created_at"`
+	UpdatedAt             time.Time        `json:"updated_at"`
 }
 
 type Member struct {
@@ -172,6 +190,21 @@ type DeviceTag struct {
 	Tag            string    `json:"tag"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type QuotaRaiseRequest struct {
+	ID             string                  `json:"id"`
+	OrganizationID string                  `json:"organization_id"`
+	RequestedBy    string                  `json:"requested_by"`
+	RequestedQuota int                     `json:"requested_quota"`
+	UseCase        string                  `json:"use_case"`
+	ContactInfo    map[string]any          `json:"contact_info"`
+	Status         QuotaRaiseRequestStatus `json:"status"`
+	DecidedBy      *string                 `json:"decided_by,omitempty"`
+	DecisionReason *string                 `json:"decision_reason,omitempty"`
+	CreatedAt      time.Time               `json:"created_at"`
+	UpdatedAt      time.Time               `json:"updated_at"`
+	DecidedAt      *time.Time              `json:"decided_at,omitempty"`
 }
 
 type DeviceOperation struct {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -25,6 +25,18 @@ const (
 	QuotaRaiseRequestStatusDeclined QuotaRaiseRequestStatus = "declined"
 )
 
+type AuditEvent struct {
+	ID             string         `json:"id"`
+	EventType      string         `json:"event_type"`
+	ActorUserID    *string        `json:"actor_user_id,omitempty"`
+	OrganizationID *string        `json:"organization_id,omitempty"`
+	SubjectType    string         `json:"subject_type"`
+	SubjectID      string         `json:"subject_id"`
+	Payload        map[string]any `json:"payload"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+}
+
 type DeviceCategory string
 
 const (

--- a/internal/store/audit.go
+++ b/internal/store/audit.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type AuditEventInput struct {
+	EventType      string
+	ActorUserID    *string
+	OrganizationID *string
+	SubjectType    string
+	SubjectID      string
+	Payload        map[string]any
+}
+
+func createAuditEventTx(ctx context.Context, tx pgx.Tx, in AuditEventInput) error {
+	payload := []byte(`{}`)
+	if len(in.Payload) > 0 {
+		raw, err := json.Marshal(in.Payload)
+		if err != nil {
+			return err
+		}
+		payload = raw
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO audit_events (
+			event_type,
+			actor_user_id,
+			organization_id,
+			subject_type,
+			subject_id,
+			payload
+		)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, in.EventType, in.ActorUserID, in.OrganizationID, in.SubjectType, in.SubjectID, payload)
+	return err
+}
+
+func (s *Store) ListAuditEvents(ctx context.Context, limit, offset int) ([]model.AuditEvent, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT
+			id::text,
+			event_type,
+			actor_user_id::text,
+			organization_id::text,
+			subject_type,
+			subject_id,
+			payload,
+			created_at,
+			updated_at
+		FROM audit_events
+		ORDER BY created_at ASC
+		LIMIT $1 OFFSET $2
+	`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	events := []model.AuditEvent{}
+	for rows.Next() {
+		var event model.AuditEvent
+		var rawPayload []byte
+		if err := rows.Scan(
+			&event.ID,
+			&event.EventType,
+			&event.ActorUserID,
+			&event.OrganizationID,
+			&event.SubjectType,
+			&event.SubjectID,
+			&rawPayload,
+			&event.CreatedAt,
+			&event.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(rawPayload, &event.Payload); err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
+}

--- a/internal/store/eval_tier.go
+++ b/internal/store/eval_tier.go
@@ -45,9 +45,15 @@ func (s *Store) CreateQuotaRaiseRequest(ctx context.Context, in QuotaRaiseReques
 	if err != nil {
 		return model.QuotaRaiseRequest{}, err
 	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.QuotaRaiseRequest{}, err
+	}
+	defer tx.Rollback(ctx)
+
 	var request model.QuotaRaiseRequest
 	var rawContactInfo []byte
-	err = s.db.QueryRow(ctx, `
+	err = tx.QueryRow(ctx, `
 		INSERT INTO quota_raise_requests (
 			organization_id,
 			requested_by,
@@ -90,6 +96,25 @@ func (s *Store) CreateQuotaRaiseRequest(ctx context.Context, in QuotaRaiseReques
 		if err := json.Unmarshal(rawContactInfo, &request.ContactInfo); err != nil {
 			return model.QuotaRaiseRequest{}, err
 		}
+	}
+	if err != nil {
+		return model.QuotaRaiseRequest{}, err
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      "quota_raise_requested",
+		ActorUserID:    &in.RequestedBy,
+		OrganizationID: &in.OrganizationID,
+		SubjectType:    "quota_raise_request",
+		SubjectID:      request.ID,
+		Payload: map[string]any{
+			"requested_quota": request.RequestedQuota,
+			"use_case":        request.UseCase,
+		},
+	}); err != nil {
+		return model.QuotaRaiseRequest{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.QuotaRaiseRequest{}, err
 	}
 	return request, err
 }
@@ -229,6 +254,18 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 		}
 	}
 
+	eventType := "quota_raise_declined"
+	payload := map[string]any{
+		"request_id":      request.ID,
+		"requested_quota": request.RequestedQuota,
+	}
+	if in.Approved {
+		eventType = "quota_raise_approved"
+		payload["approved_quota"] = approvedQuota
+	} else if in.DecisionReason != nil {
+		payload["decision_reason"] = *in.DecisionReason
+	}
+
 	now := time.Now().UTC()
 	tag, err := tx.Exec(ctx, `
 		UPDATE quota_raise_requests
@@ -244,6 +281,16 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 	}
 	if tag.RowsAffected() == 0 {
 		return model.QuotaRaiseRequest{}, model.Organization{}, ErrNotFound
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      eventType,
+		ActorUserID:    &in.DecidedBy,
+		OrganizationID: &org.ID,
+		SubjectType:    "quota_raise_request",
+		SubjectID:      request.ID,
+		Payload:        payload,
+	}); err != nil {
+		return model.QuotaRaiseRequest{}, model.Organization{}, err
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return model.QuotaRaiseRequest{}, model.Organization{}, err

--- a/internal/store/eval_tier.go
+++ b/internal/store/eval_tier.go
@@ -163,15 +163,16 @@ func (s *Store) GetQuotaRaiseRequest(ctx context.Context, requestID string) (mod
 	return request, err
 }
 
-func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisionInput) (model.QuotaRaiseRequest, model.Organization, error) {
+func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisionInput) (model.QuotaRaiseRequest, model.Organization, model.User, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return model.QuotaRaiseRequest{}, model.Organization{}, err
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 	}
 	defer tx.Rollback(ctx)
 
 	var request model.QuotaRaiseRequest
 	var org model.Organization
+	var requester model.User
 	var rawContactInfo []byte
 	err = tx.QueryRow(ctx, `
 		SELECT
@@ -192,9 +193,19 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 			o.tier,
 			o.evaluation_device_quota,
 			o.created_at,
-			o.updated_at
+			o.updated_at,
+			u.id::text,
+			u.email,
+			u.display_name,
+			u.email_verified,
+			u.email_verified_at,
+			u.signup_pending_verification,
+			u.created_at,
+			u.updated_at,
+			u.disabled_at
 		FROM quota_raise_requests q
 		JOIN organizations o ON o.id = q.organization_id
+		JOIN users u ON u.id = q.requested_by
 		WHERE q.id = $1
 		FOR UPDATE OF q, o
 	`, in.RequestID).Scan(
@@ -216,18 +227,27 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 		&org.EvaluationDeviceQuota,
 		&org.CreatedAt,
 		&org.UpdatedAt,
+		&requester.ID,
+		&requester.Email,
+		&requester.DisplayName,
+		&requester.EmailVerified,
+		&requester.EmailVerifiedAt,
+		&requester.SignupPendingVerification,
+		&requester.CreatedAt,
+		&requester.UpdatedAt,
+		&requester.DisabledAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return model.QuotaRaiseRequest{}, model.Organization{}, ErrNotFound
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, ErrNotFound
 	}
 	if err != nil {
-		return model.QuotaRaiseRequest{}, model.Organization{}, err
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 	}
 	if err := json.Unmarshal(rawContactInfo, &request.ContactInfo); err != nil {
-		return model.QuotaRaiseRequest{}, model.Organization{}, err
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 	}
 	if request.Status != model.QuotaRaiseRequestStatusPending {
-		return model.QuotaRaiseRequest{}, model.Organization{}, ErrConflict
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, ErrConflict
 	}
 
 	decision := model.QuotaRaiseRequestStatusDeclined
@@ -250,7 +270,7 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 			WHERE id = $1
 		`, org.ID, approvedQuota)
 		if err != nil {
-			return model.QuotaRaiseRequest{}, model.Organization{}, err
+			return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 		}
 	}
 
@@ -277,10 +297,10 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 		WHERE id = $1
 	`, request.ID, decision, in.DecidedBy, in.DecisionReason, now)
 	if err != nil {
-		return model.QuotaRaiseRequest{}, model.Organization{}, err
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 	}
 	if tag.RowsAffected() == 0 {
-		return model.QuotaRaiseRequest{}, model.Organization{}, ErrNotFound
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, ErrNotFound
 	}
 	if err := createAuditEventTx(ctx, tx, AuditEventInput{
 		EventType:      eventType,
@@ -290,15 +310,15 @@ func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisi
 		SubjectID:      request.ID,
 		Payload:        payload,
 	}); err != nil {
-		return model.QuotaRaiseRequest{}, model.Organization{}, err
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return model.QuotaRaiseRequest{}, model.Organization{}, err
+		return model.QuotaRaiseRequest{}, model.Organization{}, model.User{}, err
 	}
 	request.Status = decision
 	request.DecidedBy = &in.DecidedBy
 	request.DecisionReason = in.DecisionReason
 	request.DecidedAt = &now
 	org.EvaluationDeviceQuota = approvedQuota
-	return request, org, nil
+	return request, org, requester, nil
 }

--- a/internal/store/eval_tier.go
+++ b/internal/store/eval_tier.go
@@ -1,0 +1,257 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type QuotaRaiseRequestInput struct {
+	OrganizationID string
+	RequestedBy    string
+	RequestedQuota int
+	UseCase        string
+	ContactInfo    map[string]any
+}
+
+type QuotaRaiseDecisionInput struct {
+	RequestID      string
+	DecidedBy      string
+	ApprovedQuota  int
+	DecisionReason *string
+	Approved       bool
+}
+
+func (s *Store) IsPlatformAdmin(ctx context.Context, userID string) (bool, error) {
+	var platformAdmin bool
+	err := s.db.QueryRow(ctx, `
+		SELECT COALESCE(platform_admin, false)
+		FROM users
+		WHERE id = $1 AND disabled_at IS NULL
+	`, userID).Scan(&platformAdmin)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, ErrNotFound
+	}
+	return platformAdmin, err
+}
+
+func (s *Store) CreateQuotaRaiseRequest(ctx context.Context, in QuotaRaiseRequestInput) (model.QuotaRaiseRequest, error) {
+	contactInfo, err := json.Marshal(in.ContactInfo)
+	if err != nil {
+		return model.QuotaRaiseRequest{}, err
+	}
+	var request model.QuotaRaiseRequest
+	var rawContactInfo []byte
+	err = s.db.QueryRow(ctx, `
+		INSERT INTO quota_raise_requests (
+			organization_id,
+			requested_by,
+			requested_quota,
+			use_case,
+			contact_info
+		)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING
+			id::text,
+			organization_id::text,
+			requested_by::text,
+			requested_quota,
+			use_case,
+			contact_info,
+			status,
+			decided_by::text,
+			decision_reason,
+			created_at,
+			updated_at,
+			decided_at
+	`, in.OrganizationID, in.RequestedBy, in.RequestedQuota, in.UseCase, contactInfo).Scan(
+		&request.ID,
+		&request.OrganizationID,
+		&request.RequestedBy,
+		&request.RequestedQuota,
+		&request.UseCase,
+		&rawContactInfo,
+		&request.Status,
+		&request.DecidedBy,
+		&request.DecisionReason,
+		&request.CreatedAt,
+		&request.UpdatedAt,
+		&request.DecidedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.QuotaRaiseRequest{}, ErrNotFound
+	}
+	if err == nil {
+		if err := json.Unmarshal(rawContactInfo, &request.ContactInfo); err != nil {
+			return model.QuotaRaiseRequest{}, err
+		}
+	}
+	return request, err
+}
+
+func (s *Store) GetQuotaRaiseRequest(ctx context.Context, requestID string) (model.QuotaRaiseRequest, error) {
+	var request model.QuotaRaiseRequest
+	var rawContactInfo []byte
+	err := s.db.QueryRow(ctx, `
+		SELECT
+			id::text,
+			organization_id::text,
+			requested_by::text,
+			requested_quota,
+			use_case,
+			contact_info,
+			status,
+			decided_by::text,
+			decision_reason,
+			created_at,
+			updated_at,
+			decided_at
+		FROM quota_raise_requests
+		WHERE id = $1
+	`, requestID).Scan(
+		&request.ID,
+		&request.OrganizationID,
+		&request.RequestedBy,
+		&request.RequestedQuota,
+		&request.UseCase,
+		&rawContactInfo,
+		&request.Status,
+		&request.DecidedBy,
+		&request.DecisionReason,
+		&request.CreatedAt,
+		&request.UpdatedAt,
+		&request.DecidedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.QuotaRaiseRequest{}, ErrNotFound
+	}
+	if err == nil {
+		if err := json.Unmarshal(rawContactInfo, &request.ContactInfo); err != nil {
+			return model.QuotaRaiseRequest{}, err
+		}
+	}
+	return request, err
+}
+
+func (s *Store) DecideQuotaRaiseRequest(ctx context.Context, in QuotaRaiseDecisionInput) (model.QuotaRaiseRequest, model.Organization, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.QuotaRaiseRequest{}, model.Organization{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var request model.QuotaRaiseRequest
+	var org model.Organization
+	var rawContactInfo []byte
+	err = tx.QueryRow(ctx, `
+		SELECT
+			q.id::text,
+			q.organization_id::text,
+			q.requested_by::text,
+			q.requested_quota,
+			q.use_case,
+			q.contact_info,
+			q.status,
+			q.decided_by::text,
+			q.decision_reason,
+			q.created_at,
+			q.updated_at,
+			q.decided_at,
+			o.id::text,
+			o.name,
+			o.tier,
+			o.evaluation_device_quota,
+			o.created_at,
+			o.updated_at
+		FROM quota_raise_requests q
+		JOIN organizations o ON o.id = q.organization_id
+		WHERE q.id = $1
+		FOR UPDATE OF q, o
+	`, in.RequestID).Scan(
+		&request.ID,
+		&request.OrganizationID,
+		&request.RequestedBy,
+		&request.RequestedQuota,
+		&request.UseCase,
+		&rawContactInfo,
+		&request.Status,
+		&request.DecidedBy,
+		&request.DecisionReason,
+		&request.CreatedAt,
+		&request.UpdatedAt,
+		&request.DecidedAt,
+		&org.ID,
+		&org.Name,
+		&org.Tier,
+		&org.EvaluationDeviceQuota,
+		&org.CreatedAt,
+		&org.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.QuotaRaiseRequest{}, model.Organization{}, ErrNotFound
+	}
+	if err != nil {
+		return model.QuotaRaiseRequest{}, model.Organization{}, err
+	}
+	if err := json.Unmarshal(rawContactInfo, &request.ContactInfo); err != nil {
+		return model.QuotaRaiseRequest{}, model.Organization{}, err
+	}
+	if request.Status != model.QuotaRaiseRequestStatusPending {
+		return model.QuotaRaiseRequest{}, model.Organization{}, ErrConflict
+	}
+
+	decision := model.QuotaRaiseRequestStatusDeclined
+	approvedQuota := org.EvaluationDeviceQuota
+	if in.Approved {
+		decision = model.QuotaRaiseRequestStatusApproved
+		limit := in.ApprovedQuota
+		if limit <= 0 {
+			limit = request.RequestedQuota
+		}
+		if limit > 200 {
+			limit = 200
+		}
+		if limit > org.EvaluationDeviceQuota {
+			approvedQuota = limit
+		}
+		_, err = tx.Exec(ctx, `
+			UPDATE organizations
+			SET evaluation_device_quota = $2, updated_at = now()
+			WHERE id = $1
+		`, org.ID, approvedQuota)
+		if err != nil {
+			return model.QuotaRaiseRequest{}, model.Organization{}, err
+		}
+	}
+
+	now := time.Now().UTC()
+	tag, err := tx.Exec(ctx, `
+		UPDATE quota_raise_requests
+		SET status = $2,
+		    decided_by = $3,
+		    decision_reason = $4,
+		    decided_at = $5,
+		    updated_at = now()
+		WHERE id = $1
+	`, request.ID, decision, in.DecidedBy, in.DecisionReason, now)
+	if err != nil {
+		return model.QuotaRaiseRequest{}, model.Organization{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return model.QuotaRaiseRequest{}, model.Organization{}, ErrNotFound
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.QuotaRaiseRequest{}, model.Organization{}, err
+	}
+	request.Status = decision
+	request.DecidedBy = &in.DecidedBy
+	request.DecisionReason = in.DecisionReason
+	request.DecidedAt = &now
+	org.EvaluationDeviceQuota = approvedQuota
+	return request, org, nil
+}

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"context"
+)
+
+type EvaluationQuotaUsage struct {
+	OrganizationID        string
+	OrganizationName      string
+	ActiveDevices         int
+	EvaluationDeviceQuota int
+}
+
+func (s *Store) CountEvaluationSignupEvents(ctx context.Context) (evaluation int64, commercial int64, err error) {
+	err = s.db.QueryRow(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE payload->>'organization_tier' = 'evaluation'),
+			COUNT(*) FILTER (WHERE payload->>'organization_tier' = 'commercial')
+		FROM audit_events
+		WHERE event_type = 'signup_created'
+	`).Scan(&evaluation, &commercial)
+	return evaluation, commercial, err
+}
+
+func (s *Store) CountEmailVerificationEventsFromSignup(ctx context.Context) (int64, error) {
+	var total int64
+	err := s.db.QueryRow(ctx, `
+		SELECT count(*)
+		FROM audit_events
+		WHERE event_type = 'email_verified'
+		  AND payload->>'signup_pending_verification' = 'true'
+	`).Scan(&total)
+	return total, err
+}
+
+func (s *Store) CountQuotaRaiseRequestStatuses(ctx context.Context) (pending, approved, declined int64, err error) {
+	err = s.db.QueryRow(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'pending'),
+			COUNT(*) FILTER (WHERE status = 'approved'),
+			COUNT(*) FILTER (WHERE status = 'declined')
+		FROM quota_raise_requests
+	`).Scan(&pending, &approved, &declined)
+	return pending, approved, declined, err
+}
+
+func (s *Store) ListEvaluationQuotaUsage(ctx context.Context) ([]EvaluationQuotaUsage, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT
+			o.id::text,
+			o.name,
+			COUNT(d.id)::int,
+			o.evaluation_device_quota
+		FROM organizations o
+		LEFT JOIN devices d
+			ON d.organization_id = o.id
+		   AND d.disabled_at IS NULL
+		WHERE o.tier = 'evaluation'
+		GROUP BY o.id, o.name, o.evaluation_device_quota, o.created_at
+		ORDER BY o.created_at ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	usages := []EvaluationQuotaUsage{}
+	for rows.Next() {
+		var usage EvaluationQuotaUsage
+		if err := rows.Scan(&usage.OrganizationID, &usage.OrganizationName, &usage.ActiveDevices, &usage.EvaluationDeviceQuota); err != nil {
+			return nil, err
+		}
+		usages = append(usages, usage)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return usages, nil
+}
+
+func (u EvaluationQuotaUsage) Utilization() float64 {
+	if u.EvaluationDeviceQuota <= 0 {
+		return 0
+	}
+	return float64(u.ActiveDevices) / float64(u.EvaluationDeviceQuota)
+}

--- a/internal/store/metrics_integration_test.go
+++ b/internal/store/metrics_integration_test.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"rtk_account_manager/internal/model"
+)
+
+func TestListAuditEventsReturnsRecordedLifecycleEvents(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:                     "audit@example.com",
+		PasswordHash:              "hash",
+		OrganizationName:          "Audit Org",
+		OrganizationTier:          model.OrganizationTierEvaluation,
+		EvaluationDeviceQuota:     5,
+		SignupPendingVerification: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request, err := env.store.CreateQuotaRaiseRequest(ctx, QuotaRaiseRequestInput{
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		RequestedQuota: 12,
+		UseCase:        "pilot expansion",
+		ContactInfo:    map[string]any{"email": "audit@example.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadedRequest, err := env.store.GetQuotaRaiseRequest(ctx, request.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadedRequest.ID != request.ID || loadedRequest.Status != model.QuotaRaiseRequestStatusPending {
+		t.Fatalf("expected round-tripped pending request, got %+v", loadedRequest)
+	}
+	if _, err := env.store.GetQuotaRaiseRequest(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing quota raise request to return ErrNotFound, got %v", err)
+	}
+
+	device, err := env.store.CreateDevice(ctx, registered.Organization.ID, DeviceInput{
+		Name:     "Audit Camera",
+		Category: model.DeviceCategoryIPCamera,
+		Metadata: map[string]any{"location": "lab"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if device.ID == "" {
+		t.Fatal("expected created device ID")
+	}
+	activeDevices, err := env.store.countActiveDevices(ctx, registered.Organization.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if activeDevices != 1 {
+		t.Fatalf("expected one active device, got %d", activeDevices)
+	}
+
+	reason := "not enough detail"
+	decision, _, err := env.store.DecideQuotaRaiseRequest(ctx, QuotaRaiseDecisionInput{
+		RequestID:      request.ID,
+		DecidedBy:      registered.User.ID,
+		DecisionReason: &reason,
+		Approved:       false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Status != model.QuotaRaiseRequestStatusDeclined {
+		t.Fatalf("expected declined request, got %+v", decision)
+	}
+
+	events, err := env.store.ListAuditEvents(ctx, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 audit events, got %d: %+v", len(events), events)
+	}
+
+	byType := make(map[string]model.AuditEvent, len(events))
+	for _, event := range events {
+		byType[event.EventType] = event
+	}
+
+	signup := byType["signup_created"]
+	if signup.SubjectType != "organization" || signup.SubjectID != registered.Organization.ID {
+		t.Fatalf("expected signup audit event for organization %s, got %+v", registered.Organization.ID, signup)
+	}
+	if got, ok := signup.Payload["organization_tier"].(string); !ok || got != string(model.OrganizationTierEvaluation) {
+		t.Fatalf("expected evaluation tier payload, got %+v", signup.Payload)
+	}
+
+	quotaRequested := byType["quota_raise_requested"]
+	if got, ok := quotaRequested.Payload["requested_quota"].(float64); !ok || got != 12 {
+		t.Fatalf("expected requested quota payload, got %+v", quotaRequested.Payload)
+	}
+
+	quotaDeclined := byType["quota_raise_declined"]
+	if got, ok := quotaDeclined.Payload["decision_reason"].(string); !ok || got != reason {
+		t.Fatalf("expected decline reason payload, got %+v", quotaDeclined.Payload)
+	}
+}
+
+func TestEvaluationQuotaUsageUtilizationHandlesZeroAndNonZeroQuotas(t *testing.T) {
+	zero := EvaluationQuotaUsage{ActiveDevices: 3, EvaluationDeviceQuota: 0}
+	if zero.Utilization() != 0 {
+		t.Fatalf("expected zero quota utilization to be 0, got %f", zero.Utilization())
+	}
+
+	usage := EvaluationQuotaUsage{ActiveDevices: 3, EvaluationDeviceQuota: 12}
+	if usage.Utilization() != 0.25 {
+		t.Fatalf("expected utilization 0.25, got %f", usage.Utilization())
+	}
+}

--- a/internal/store/metrics_integration_test.go
+++ b/internal/store/metrics_integration_test.go
@@ -66,7 +66,7 @@ func TestListAuditEventsReturnsRecordedLifecycleEvents(t *testing.T) {
 	}
 
 	reason := "not enough detail"
-	decision, _, err := env.store.DecideQuotaRaiseRequest(ctx, QuotaRaiseDecisionInput{
+	decision, _, _, err := env.store.DecideQuotaRaiseRequest(ctx, QuotaRaiseDecisionInput{
 		RequestID:      request.ID,
 		DecidedBy:      registered.User.ID,
 		DecisionReason: &reason,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,12 +13,13 @@ import (
 )
 
 var (
-	ErrNotFound       = errors.New("not found")
-	ErrLastOwner      = errors.New("last owner cannot be removed or downgraded")
-	ErrDisabled       = errors.New("resource is disabled")
-	ErrConflict       = errors.New("conflict")
-	ErrNotProvisioned = errors.New("device is not provisioned")
-	ErrRateLimited    = errors.New("rate limited")
+	ErrNotFound                = errors.New("not found")
+	ErrLastOwner               = errors.New("last owner cannot be removed or downgraded")
+	ErrDisabled                = errors.New("resource is disabled")
+	ErrConflict                = errors.New("conflict")
+	ErrNotProvisioned          = errors.New("device is not provisioned")
+	ErrRateLimited             = errors.New("rate limited")
+	ErrEvaluationQuotaExceeded = errors.New("evaluation device quota exceeded")
 )
 
 type Store struct {
@@ -61,10 +62,13 @@ type DeviceTagPage struct {
 }
 
 type RegisterInput struct {
-	Email            string
-	PasswordHash     string
-	DisplayName      *string
-	OrganizationName string
+	Email                     string
+	PasswordHash              string
+	DisplayName               *string
+	OrganizationName          string
+	OrganizationTier          model.OrganizationTier
+	EvaluationDeviceQuota     int
+	SignupPendingVerification bool
 }
 
 type RegisterResult struct {
@@ -81,20 +85,28 @@ func (s *Store) Register(ctx context.Context, in RegisterInput) (RegisterResult,
 
 	var user model.User
 	err = tx.QueryRow(ctx, `
-		INSERT INTO users (email, password_hash, display_name)
-		VALUES ($1, $2, $3)
-		RETURNING id::text, email, display_name, email_verified, email_verified_at, created_at, updated_at, disabled_at
-	`, in.Email, in.PasswordHash, in.DisplayName).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+		INSERT INTO users (email, password_hash, display_name, signup_pending_verification)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+	`, in.Email, in.PasswordHash, in.DisplayName, in.SignupPendingVerification).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
 	if err != nil {
 		return RegisterResult{}, err
 	}
 
+	tier := in.OrganizationTier
+	if tier != model.OrganizationTierEvaluation {
+		tier = model.OrganizationTierCommercial
+	}
+	quota := in.EvaluationDeviceQuota
+	if quota <= 0 {
+		quota = 5
+	}
 	var org model.Organization
 	err = tx.QueryRow(ctx, `
-		INSERT INTO organizations (name)
-		VALUES ($1)
-		RETURNING id::text, name, created_at, updated_at
-	`, in.OrganizationName).Scan(&org.ID, &org.Name, &org.CreatedAt, &org.UpdatedAt)
+		INSERT INTO organizations (name, tier, evaluation_device_quota)
+		VALUES ($1, $2, $3)
+		RETURNING id::text, name, tier, evaluation_device_quota, created_at, updated_at
+	`, in.OrganizationName, tier, quota).Scan(&org.ID, &org.Name, &org.Tier, &org.EvaluationDeviceQuota, &org.CreatedAt, &org.UpdatedAt)
 	if err != nil {
 		return RegisterResult{}, err
 	}
@@ -118,10 +130,10 @@ func (s *Store) GetUserPassword(ctx context.Context, email string) (model.User, 
 	var user model.User
 	var hash string
 	err := s.db.QueryRow(ctx, `
-		SELECT id::text, email, password_hash, display_name, email_verified, email_verified_at, created_at, updated_at, disabled_at
+		SELECT id::text, email, password_hash, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
 		FROM users
 		WHERE email = $1 AND disabled_at IS NULL
-	`, email).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	`, email).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, "", ErrNotFound
 	}
@@ -132,10 +144,10 @@ func (s *Store) GetUserPasswordByID(ctx context.Context, userID string) (model.U
 	var user model.User
 	var hash string
 	err := s.db.QueryRow(ctx, `
-		SELECT id::text, email, password_hash, display_name, email_verified, email_verified_at, created_at, updated_at, disabled_at
+		SELECT id::text, email, password_hash, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
 		FROM users
 		WHERE id = $1 AND disabled_at IS NULL
-	`, userID).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	`, userID).Scan(&user.ID, &user.Email, &hash, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, "", ErrNotFound
 	}
@@ -145,10 +157,10 @@ func (s *Store) GetUserPasswordByID(ctx context.Context, userID string) (model.U
 func (s *Store) GetUser(ctx context.Context, userID string) (model.User, error) {
 	var user model.User
 	err := s.db.QueryRow(ctx, `
-		SELECT id::text, email, display_name, email_verified, email_verified_at, created_at, updated_at, disabled_at
+		SELECT id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
 		FROM users
 		WHERE id = $1 AND disabled_at IS NULL
-	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, ErrNotFound
 	}
@@ -210,10 +222,13 @@ func (s *Store) VerifyEmailToken(ctx context.Context, tokenHash string) (model.U
 	var user model.User
 	err = tx.QueryRow(ctx, `
 		UPDATE users
-		SET email_verified = true, email_verified_at = COALESCE(email_verified_at, now()), updated_at = now()
+		SET email_verified = true,
+		    email_verified_at = COALESCE(email_verified_at, now()),
+		    signup_pending_verification = false,
+		    updated_at = now()
 		WHERE id = $1 AND disabled_at IS NULL
-		RETURNING id::text, email, display_name, email_verified, email_verified_at, created_at, updated_at, disabled_at
-	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+		RETURNING id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, ErrNotFound
 	}
@@ -519,7 +534,7 @@ func (s *Store) ListOrganizations(ctx context.Context, userID string, limit, off
 		return OrganizationPage{}, err
 	}
 	rows, err := s.db.Query(ctx, `
-		SELECT o.id::text, o.name, m.role, o.created_at, o.updated_at
+		SELECT o.id::text, o.name, m.role, o.tier, o.evaluation_device_quota, o.created_at, o.updated_at
 		FROM organizations o
 		JOIN organization_members m ON m.organization_id = o.id
 		JOIN users u ON u.id = m.user_id
@@ -535,7 +550,7 @@ func (s *Store) ListOrganizations(ctx context.Context, userID string, limit, off
 	orgs := []model.Organization{}
 	for rows.Next() {
 		var org model.Organization
-		if err := rows.Scan(&org.ID, &org.Name, &org.Role, &org.CreatedAt, &org.UpdatedAt); err != nil {
+		if err := rows.Scan(&org.ID, &org.Name, &org.Role, &org.Tier, &org.EvaluationDeviceQuota, &org.CreatedAt, &org.UpdatedAt); err != nil {
 			return OrganizationPage{}, err
 		}
 		orgs = append(orgs, org)
@@ -555,10 +570,10 @@ func (s *Store) CreateOrganization(ctx context.Context, userID, name string) (mo
 
 	var org model.Organization
 	err = tx.QueryRow(ctx, `
-		INSERT INTO organizations (name)
-		VALUES ($1)
-		RETURNING id::text, name, created_at, updated_at
-	`, name).Scan(&org.ID, &org.Name, &org.CreatedAt, &org.UpdatedAt)
+		INSERT INTO organizations (name, tier, evaluation_device_quota)
+		VALUES ($1, 'commercial', 5)
+		RETURNING id::text, name, tier, evaluation_device_quota, created_at, updated_at
+	`, name).Scan(&org.ID, &org.Name, &org.Tier, &org.EvaluationDeviceQuota, &org.CreatedAt, &org.UpdatedAt)
 	if err != nil {
 		return model.Organization{}, err
 	}
@@ -579,11 +594,11 @@ func (s *Store) CreateOrganization(ctx context.Context, userID, name string) (mo
 func (s *Store) GetOrganization(ctx context.Context, orgID, userID string) (model.Organization, error) {
 	var org model.Organization
 	err := s.db.QueryRow(ctx, `
-		SELECT o.id::text, o.name, m.role, o.created_at, o.updated_at
+		SELECT o.id::text, o.name, m.role, o.tier, o.evaluation_device_quota, o.created_at, o.updated_at
 		FROM organizations o
 		JOIN organization_members m ON m.organization_id = o.id
 		WHERE o.id = $1 AND m.user_id = $2
-	`, orgID, userID).Scan(&org.ID, &org.Name, &org.Role, &org.CreatedAt, &org.UpdatedAt)
+	`, orgID, userID).Scan(&org.ID, &org.Name, &org.Role, &org.Tier, &org.EvaluationDeviceQuota, &org.CreatedAt, &org.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.Organization{}, ErrNotFound
 	}
@@ -599,8 +614,8 @@ func (s *Store) UpdateOrganization(ctx context.Context, orgID, userID, name stri
 		WHERE o.id = $1
 		  AND m.organization_id = o.id
 		  AND m.user_id = $2
-		RETURNING o.id::text, o.name, m.role, o.created_at, o.updated_at
-	`, orgID, userID, name).Scan(&org.ID, &org.Name, &org.Role, &org.CreatedAt, &org.UpdatedAt)
+		RETURNING o.id::text, o.name, m.role, o.tier, o.evaluation_device_quota, o.created_at, o.updated_at
+	`, orgID, userID, name).Scan(&org.ID, &org.Name, &org.Role, &org.Tier, &org.EvaluationDeviceQuota, &org.CreatedAt, &org.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.Organization{}, ErrNotFound
 	}
@@ -879,15 +894,55 @@ type DeviceGroupInput struct {
 }
 
 func (s *Store) CreateDevice(ctx context.Context, orgID string, in DeviceInput) (model.Device, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.Device{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var tier model.OrganizationTier
+	var quota int
+	err = tx.QueryRow(ctx, `
+		SELECT tier, evaluation_device_quota
+		FROM organizations
+		WHERE id = $1
+		FOR UPDATE
+	`, orgID).Scan(&tier, &quota)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.Device{}, ErrNotFound
+	}
+	if err != nil {
+		return model.Device{}, err
+	}
+	if tier == model.OrganizationTierEvaluation {
+		var activeDevices int
+		if err := tx.QueryRow(ctx, `
+			SELECT count(*)
+			FROM devices
+			WHERE organization_id = $1 AND disabled_at IS NULL
+		`, orgID).Scan(&activeDevices); err != nil {
+			return model.Device{}, err
+		}
+		if activeDevices >= quota {
+			return model.Device{}, ErrEvaluationQuotaExceeded
+		}
+	}
 	metadata, err := json.Marshal(defaultMetadata(in.Metadata))
 	if err != nil {
 		return model.Device{}, err
 	}
-	return s.scanDevice(s.db.QueryRow(ctx, `
+	device, err := s.scanDevice(tx.QueryRow(ctx, `
 		INSERT INTO devices (organization_id, name, category, serial_number, mac_address, manufacturer, model, metadata)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
 	`, orgID, in.Name, in.Category, in.SerialNumber, in.MACAddress, in.Manufacturer, in.Model, metadata))
+	if err != nil {
+		return model.Device{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.Device{}, err
+	}
+	return device, nil
 }
 
 func (s *Store) ListDevices(ctx context.Context, orgID string, limit, offset int) (DevicePage, error) {
@@ -948,6 +1003,16 @@ func (s *Store) countDevices(ctx context.Context, orgID string) (int, error) {
 	var total int
 	err := s.db.QueryRow(ctx, `
 		SELECT count(*) FROM devices WHERE organization_id = $1
+	`, orgID).Scan(&total)
+	return total, err
+}
+
+func (s *Store) countActiveDevices(ctx context.Context, orgID string) (int, error) {
+	var total int
+	err := s.db.QueryRow(ctx, `
+		SELECT count(*)
+		FROM devices
+		WHERE organization_id = $1 AND disabled_at IS NULL
 	`, orgID).Scan(&total)
 	return total, err
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -120,6 +120,24 @@ func (s *Store) Register(ctx context.Context, in RegisterInput) (RegisterResult,
 		return RegisterResult{}, err
 	}
 
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      "signup_created",
+		ActorUserID:    &user.ID,
+		OrganizationID: &org.ID,
+		SubjectType:    "organization",
+		SubjectID:      org.ID,
+		Payload: map[string]any{
+			"user_id":                     user.ID,
+			"email":                       user.Email,
+			"organization_name":           org.Name,
+			"organization_tier":           org.Tier,
+			"evaluation_device_quota":     org.EvaluationDeviceQuota,
+			"signup_pending_verification": in.SignupPendingVerification,
+		},
+	}); err != nil {
+		return RegisterResult{}, err
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return RegisterResult{}, err
 	}
@@ -219,6 +237,17 @@ func (s *Store) VerifyEmailToken(ctx context.Context, tokenHash string) (model.U
 	if err != nil {
 		return model.User{}, err
 	}
+	var signupPendingVerification bool
+	if err := tx.QueryRow(ctx, `
+		SELECT signup_pending_verification
+		FROM users
+		WHERE id = $1 AND disabled_at IS NULL
+	`, userID).Scan(&signupPendingVerification); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return model.User{}, ErrNotFound
+		}
+		return model.User{}, err
+	}
 	var user model.User
 	err = tx.QueryRow(ctx, `
 		UPDATE users
@@ -233,6 +262,18 @@ func (s *Store) VerifyEmailToken(ctx context.Context, tokenHash string) (model.U
 		return model.User{}, ErrNotFound
 	}
 	if err != nil {
+		return model.User{}, err
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:   "email_verified",
+		ActorUserID: &userID,
+		SubjectType: "user",
+		SubjectID:   userID,
+		Payload: map[string]any{
+			"token_purpose":               "email_verification",
+			"signup_pending_verification": signupPendingVerification,
+		},
+	}); err != nil {
 		return model.User{}, err
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/migrations/010_eval_tier_signup_quota.sql
+++ b/migrations/010_eval_tier_signup_quota.sql
@@ -1,0 +1,44 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS signup_pending_verification BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS platform_admin BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS tier TEXT NOT NULL DEFAULT 'commercial',
+    ADD COLUMN IF NOT EXISTS evaluation_device_quota INTEGER NOT NULL DEFAULT 5;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'organizations_tier_check'
+    ) THEN
+        ALTER TABLE organizations
+            ADD CONSTRAINT organizations_tier_check
+            CHECK (tier IN ('evaluation', 'commercial'));
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'organizations_evaluation_device_quota_check'
+    ) THEN
+        ALTER TABLE organizations
+            ADD CONSTRAINT organizations_evaluation_device_quota_check
+            CHECK (evaluation_device_quota BETWEEN 1 AND 200);
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS quota_raise_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    requested_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    requested_quota INTEGER NOT NULL CHECK (requested_quota BETWEEN 1 AND 200),
+    use_case TEXT NOT NULL,
+    contact_info JSONB NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'declined')) DEFAULT 'pending',
+    decided_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    decision_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    decided_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS quota_raise_requests_org_status_idx
+    ON quota_raise_requests (organization_id, status, created_at DESC);

--- a/migrations/011_audit_events.sql
+++ b/migrations/011_audit_events.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS audit_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type TEXT NOT NULL,
+    actor_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    organization_id UUID REFERENCES organizations(id) ON DELETE SET NULL,
+    subject_type TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS audit_events_event_type_idx
+    ON audit_events (event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS audit_events_subject_idx
+    ON audit_events (subject_type, subject_id, created_at DESC);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -393,6 +393,22 @@ paths:
           $ref: "#/components/responses/Error"
         "409":
           $ref: "#/components/responses/Error"
+  /v1/admin/metrics:
+    get:
+      security:
+        - bearerAuth: []
+      summary: Get evaluation-tier signup and quota metrics.
+      responses:
+        "200":
+          description: Evaluation-tier metrics snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EvalTierMetricsResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
   /v1/orgs/{orgId}/members:
     get:
       security:
@@ -1400,6 +1416,72 @@ components:
           $ref: "#/components/schemas/QuotaRaiseRequest"
         organization:
           $ref: "#/components/schemas/Organization"
+    EvalTierMetricsResponse:
+      type: object
+      required: [signups, quota_raise_requests, evaluation_quota_usage]
+      properties:
+        signups:
+          type: object
+          required: [evaluation_created, commercial_created, verification_completed, verification_completion_rate]
+          properties:
+            evaluation_created:
+              type: integer
+              format: int64
+              minimum: 0
+            commercial_created:
+              type: integer
+              format: int64
+              minimum: 0
+            verification_completed:
+              type: integer
+              format: int64
+              minimum: 0
+            verification_completion_rate:
+              type: number
+              format: double
+              minimum: 0
+        quota_raise_requests:
+          type: object
+          required: [pending, approved, declined]
+          properties:
+            pending:
+              type: integer
+              format: int64
+              minimum: 0
+            approved:
+              type: integer
+              format: int64
+              minimum: 0
+            declined:
+              type: integer
+              format: int64
+              minimum: 0
+        evaluation_quota_usage:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvaluationQuotaUsage"
+    EvaluationQuotaUsage:
+      type: object
+      required: [organization_id, organization_name, active_devices, evaluation_device_quota, utilization]
+      properties:
+        organization_id:
+          type: string
+          format: uuid
+        organization_name:
+          type: string
+        active_devices:
+          type: integer
+          format: int32
+          minimum: 0
+        evaluation_device_quota:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 200
+        utilization:
+          type: number
+          format: double
+          minimum: 0
     MembersResponse:
       type: object
       required: [members, pagination]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,28 @@ paths:
           $ref: "#/components/responses/Error"
         "409":
           $ref: "#/components/responses/Error"
+  /v1/auth/signup:
+    post:
+      summary: Create a public evaluation-tier account.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignupRequest"
+      responses:
+        "202":
+          description: Signup accepted and verification token issued.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignupResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+        "429":
+          $ref: "#/components/responses/Error"
   /v1/auth/login:
     post:
       summary: Login with email and password.
@@ -280,6 +302,96 @@ paths:
         "403":
           $ref: "#/components/responses/Error"
         "404":
+          $ref: "#/components/responses/Error"
+  /v1/orgs/{orgId}/quota-raise-requests:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Request an evaluation quota increase.
+      parameters:
+        - $ref: "#/components/parameters/OrgId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuotaRaiseRequestRequest"
+      responses:
+        "201":
+          description: Quota-raise request created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuotaRaiseRequestResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+  /v1/admin/quota-raise-requests/{requestId}/approve:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Approve a pending quota-raise request.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuotaRaiseDecisionRequest"
+      responses:
+        "200":
+          description: Quota-raise request approved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuotaRaiseDecisionResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+  /v1/admin/quota-raise-requests/{requestId}/decline:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Decline a pending quota-raise request.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuotaRaiseDecisionRequest"
+      responses:
+        "200":
+          description: Quota-raise request declined.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuotaRaiseDecisionResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "409":
           $ref: "#/components/responses/Error"
   /v1/orgs/{orgId}/members:
     get:
@@ -952,6 +1064,13 @@ components:
       schema:
         type: string
         format: uuid
+    RequestId:
+      name: requestId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     GroupId:
       name: groupId
       in: path
@@ -1013,6 +1132,23 @@ components:
         organization_name:
           type: string
           minLength: 1
+    SignupRequest:
+      type: object
+      required: [email, password, organization_name]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+        display_name:
+          type: string
+        organization_name:
+          type: string
+          minLength: 1
+        captcha_token:
+          type: string
     LoginRequest:
       type: object
       required: [email, password]
@@ -1163,6 +1299,29 @@ components:
           type: string
         reason:
           type: string
+    QuotaRaiseRequestRequest:
+      type: object
+      required: [requested_quota, use_case, contact_info]
+      properties:
+        requested_quota:
+          type: integer
+          minimum: 1
+          maximum: 200
+        use_case:
+          type: string
+          minLength: 1
+        contact_info:
+          type: object
+          additionalProperties: true
+    QuotaRaiseDecisionRequest:
+      type: object
+      properties:
+        approved_quota:
+          type: integer
+          minimum: 1
+          maximum: 200
+        decision_reason:
+          type: string
     RegisterResponse:
       type: object
       required: [user, organization, tokens]
@@ -1173,6 +1332,14 @@ components:
           $ref: "#/components/schemas/Organization"
         tokens:
           $ref: "#/components/schemas/Tokens"
+    SignupResponse:
+      type: object
+      required: [user, organization]
+      properties:
+        user:
+          $ref: "#/components/schemas/User"
+        organization:
+          $ref: "#/components/schemas/Organization"
     LoginResponse:
       type: object
       required: [user, tokens]
@@ -1217,6 +1384,20 @@ components:
       type: object
       required: [organization]
       properties:
+        organization:
+          $ref: "#/components/schemas/Organization"
+    QuotaRaiseRequestResponse:
+      type: object
+      required: [quota_raise_request]
+      properties:
+        quota_raise_request:
+          $ref: "#/components/schemas/QuotaRaiseRequest"
+    QuotaRaiseDecisionResponse:
+      type: object
+      required: [quota_raise_request, organization]
+      properties:
+        quota_raise_request:
+          $ref: "#/components/schemas/QuotaRaiseRequest"
         organization:
           $ref: "#/components/schemas/Organization"
     MembersResponse:
@@ -1328,7 +1509,7 @@ components:
               additionalProperties: true
     User:
       type: object
-      required: [id, email, email_verified, created_at, updated_at]
+      required: [id, email, email_verified, signup_pending_verification, created_at, updated_at]
       properties:
         id:
           type: string
@@ -1343,6 +1524,8 @@ components:
         email_verified_at:
           type: string
           format: date-time
+        signup_pending_verification:
+          type: boolean
         created_at:
           type: string
           format: date-time
@@ -1354,7 +1537,7 @@ components:
           format: date-time
     Organization:
       type: object
-      required: [id, name, created_at, updated_at]
+      required: [id, name, tier, evaluation_device_quota, created_at, updated_at]
       properties:
         id:
           type: string
@@ -1363,12 +1546,21 @@ components:
           type: string
         role:
           $ref: "#/components/schemas/Role"
+        tier:
+          $ref: "#/components/schemas/OrganizationTier"
+        evaluation_device_quota:
+          type: integer
+          minimum: 1
+          maximum: 200
         created_at:
           type: string
           format: date-time
         updated_at:
           type: string
           format: date-time
+    OrganizationTier:
+      type: string
+      enum: [evaluation, commercial]
     Member:
       type: object
       required: [organization_id, user_id, email, role, created_at, updated_at]
@@ -1475,6 +1667,47 @@ components:
         updated_at:
           type: string
           format: date-time
+    QuotaRaiseRequest:
+      type: object
+      required: [id, organization_id, requested_by, requested_quota, use_case, contact_info, status, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        organization_id:
+          type: string
+          format: uuid
+        requested_by:
+          type: string
+          format: uuid
+        requested_quota:
+          type: integer
+          minimum: 1
+          maximum: 200
+        use_case:
+          type: string
+        contact_info:
+          type: object
+          additionalProperties: true
+        status:
+          $ref: "#/components/schemas/QuotaRaiseRequestStatus"
+        decided_by:
+          type: string
+          format: uuid
+        decision_reason:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        decided_at:
+          type: string
+          format: date-time
+    QuotaRaiseRequestStatus:
+      type: string
+      enum: [pending, approved, declined]
     DeviceOperationSummary:
       type: object
       required: [operation_id, correlation_id, message_id, device_id, operation_type, status, created_at, updated_at]


### PR DESCRIPTION
Refs #75

Implemented in this repo:
- public `POST /v1/auth/signup` with pending-verification signup state and verification-token delivery
- evaluation/commercial organization tier fields and `evaluation_device_quota` persistence
- evaluation quota enforcement on device creation with typed error `EVALUATION_QUOTA_EXCEEDED`
- quota-raise request submission plus platform-admin approve/decline endpoints
- audit events for signup, email verification, and quota-raise request lifecycle
- admin metrics snapshot for signup counts, verification completion rate, quota-raise status counts, and live evaluation quota utilization
- OpenAPI, docs, migrations, and integration coverage

Paired contract update:
- hkt999rtk/rtk_cloud_contracts_doc#19 adds the AUTH, HTTP_API, and ERRORS contract docs for the signup and quota workflow.

Validation:
- `go test ./...`

Current state:
- quota-raise approval and decline notifications use the SMTP sender path when `SMTP_HOST` and `SMTP_FROM` are configured, with a log fallback for local dev/test
- the approve/decline request-body contract matches the empty-body API behavior and contract coverage

Remaining for close-out:
- none on the code path; ready for review