### PR TITLE
feat: add device claim token persistence

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -37,6 +37,32 @@ type AuditEvent struct {
 	UpdatedAt      time.Time      `json:"updated_at"`
 }
 
+type DeviceClaimToken struct {
+	ID              string         `json:"id"`
+	OrganizationID  *string        `json:"organization_id,omitempty"`
+	Category        DeviceCategory `json:"category"`
+	VideoCloudDevid string         `json:"video_cloud_devid"`
+	ActivityID      string         `json:"activity_id"`
+	ClipPublicKey   string         `json:"clip_public_key"`
+	Metadata        map[string]any `json:"metadata"`
+	ExpiresAt       time.Time      `json:"expires_at"`
+	ClaimedAt       *time.Time     `json:"claimed_at,omitempty"`
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+}
+
+type DeviceClaim struct {
+	ID             string         `json:"id"`
+	TokenID        string         `json:"claim_token_id"`
+	OrganizationID string         `json:"organization_id"`
+	DeviceID       string         `json:"device_id"`
+	ClaimedBy      string         `json:"claimed_by"`
+	Status         string         `json:"status"`
+	ProvisionInput map[string]any `json:"provision_input"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+}
+
 type DeviceCategory string
 
 const (

--- a/internal/store/device_claims.go
+++ b/internal/store/device_claims.go
@@ -1,0 +1,295 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type DeviceClaimTokenCreateInput struct {
+	OrganizationID  *string
+	TokenHash       string
+	Category        model.DeviceCategory
+	VideoCloudDevid string
+	ActivityID      string
+	ClipPublicKey   string
+	Metadata        map[string]any
+	ExpiresAt       time.Time
+	Now             time.Time
+}
+
+type DeviceClaimResolveInput struct {
+	TokenHash      string
+	OrganizationID string
+	RequestedBy    string
+	DeviceName     string
+	Now            time.Time
+}
+
+type DeviceProvisionInput struct {
+	VideoCloudDevid string `json:"video_cloud_devid"`
+	ActivityID      string `json:"activity_id"`
+	ClipPublicKey   string `json:"clip_public_key"`
+}
+
+type DeviceClaimResolveResult struct {
+	Claim          model.DeviceClaim    `json:"claim"`
+	Device         model.Device         `json:"device"`
+	ProvisionInput DeviceProvisionInput `json:"provision_input"`
+}
+
+func (s *Store) CreateDeviceClaimToken(ctx context.Context, in DeviceClaimTokenCreateInput) (model.DeviceClaimToken, error) {
+	metadata, err := json.Marshal(defaultMetadata(in.Metadata))
+	if err != nil {
+		return model.DeviceClaimToken{}, err
+	}
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	token, err := scanDeviceClaimToken(s.db.QueryRow(ctx, `
+		INSERT INTO device_claim_tokens (
+			organization_id,
+			token_hash,
+			category,
+			video_cloud_devid,
+			activity_id,
+			clip_public_key,
+			metadata,
+			expires_at,
+			created_at,
+			updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+		RETURNING id::text, organization_id::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, expires_at, claimed_at, created_at, updated_at
+	`, in.OrganizationID, in.TokenHash, in.Category, in.VideoCloudDevid, in.ActivityID, in.ClipPublicKey, metadata, in.ExpiresAt, now))
+	if err != nil {
+		return model.DeviceClaimToken{}, err
+	}
+	return token, nil
+}
+
+func (s *Store) ResolveDeviceClaimToken(ctx context.Context, in DeviceClaimResolveInput) (DeviceClaimResolveResult, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	token, err := scanDeviceClaimToken(tx.QueryRow(ctx, `
+		SELECT id::text, organization_id::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, expires_at, claimed_at, created_at, updated_at
+		FROM device_claim_tokens
+		WHERE token_hash = $1
+		FOR UPDATE
+	`, in.TokenHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return DeviceClaimResolveResult{}, ErrNotFound
+	}
+	if err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+	if token.ClaimedAt != nil {
+		return DeviceClaimResolveResult{}, ErrClaimAlreadyClaimed
+	}
+	if !token.ExpiresAt.After(now) {
+		return DeviceClaimResolveResult{}, ErrClaimExpired
+	}
+	if token.OrganizationID != nil && *token.OrganizationID != in.OrganizationID {
+		return DeviceClaimResolveResult{}, ErrClaimCrossOrganization
+	}
+	if token.Category != model.DeviceCategoryIPCamera {
+		return DeviceClaimResolveResult{}, ErrClaimUnsupportedCategory
+	}
+
+	if err := lockOrganizationAndCheckQuota(ctx, tx, in.OrganizationID); err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+
+	deviceName := strings.TrimSpace(in.DeviceName)
+	if deviceName == "" {
+		deviceName = "Claimed Device"
+	}
+	device, err := getClaimedDeviceByVideoDevidTx(ctx, tx, in.OrganizationID, token.VideoCloudDevid)
+	if errors.Is(err, ErrNotFound) {
+		device, err = createClaimedDeviceTx(ctx, tx, in.OrganizationID, deviceName, token)
+	}
+	if err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+
+	provisionInput := map[string]any{
+		"video_cloud_devid": token.VideoCloudDevid,
+		"activity_id":       token.ActivityID,
+		"clip_public_key":   token.ClipPublicKey,
+	}
+	provisionInputJSON, err := json.Marshal(provisionInput)
+	if err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+
+	claim, err := scanDeviceClaim(tx.QueryRow(ctx, `
+		INSERT INTO device_claims (
+			claim_token_id,
+			organization_id,
+			device_id,
+			claimed_by,
+			status,
+			provision_input,
+			created_at,
+			updated_at
+		)
+		VALUES ($1, $2, $3, $4, 'resolved', $5, $6, $6)
+		RETURNING id::text, claim_token_id::text, organization_id::text, device_id::text, claimed_by::text, status, provision_input, created_at, updated_at
+	`, token.ID, in.OrganizationID, device.ID, in.RequestedBy, provisionInputJSON, now))
+	if err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE device_claim_tokens
+		SET claimed_at = $2, updated_at = $2
+		WHERE id = $1
+	`, token.ID, now); err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return DeviceClaimResolveResult{}, err
+	}
+
+	return DeviceClaimResolveResult{
+		Claim:  claim,
+		Device: device,
+		ProvisionInput: DeviceProvisionInput{
+			VideoCloudDevid: token.VideoCloudDevid,
+			ActivityID:      token.ActivityID,
+			ClipPublicKey:   token.ClipPublicKey,
+		},
+	}, nil
+}
+
+func lockOrganizationAndCheckQuota(ctx context.Context, tx pgx.Tx, orgID string) error {
+	var tier model.OrganizationTier
+	var quota int
+	err := tx.QueryRow(ctx, `
+		SELECT tier, evaluation_device_quota
+		FROM organizations
+		WHERE id = $1
+		FOR UPDATE
+	`, orgID).Scan(&tier, &quota)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if tier != model.OrganizationTierEvaluation {
+		return nil
+	}
+	var activeDevices int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*)
+		FROM devices
+		WHERE organization_id = $1 AND disabled_at IS NULL
+	`, orgID).Scan(&activeDevices); err != nil {
+		return err
+	}
+	if activeDevices >= quota {
+		return ErrEvaluationQuotaExceeded
+	}
+	return nil
+}
+
+func getClaimedDeviceByVideoDevidTx(ctx context.Context, tx pgx.Tx, orgID, videoCloudDevid string) (model.Device, error) {
+	device, err := scanDevice(tx.QueryRow(ctx, `
+		SELECT id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
+		FROM devices
+		WHERE organization_id = $1
+			AND disabled_at IS NULL
+			AND metadata->>$2 = $3
+		ORDER BY created_at ASC
+		LIMIT 1
+	`, orgID, model.DeviceMetadataVideoCloudDevid, videoCloudDevid))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.Device{}, ErrNotFound
+	}
+	return device, err
+}
+
+func createClaimedDeviceTx(ctx context.Context, tx pgx.Tx, orgID, name string, token model.DeviceClaimToken) (model.Device, error) {
+	metadata := map[string]any{
+		model.DeviceMetadataVideoCloudDevid:         token.VideoCloudDevid,
+		model.DeviceMetadataVideoCloudActivityID:    token.ActivityID,
+		model.DeviceMetadataVideoCloudClipPublicKey: token.ClipPublicKey,
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return model.Device{}, err
+	}
+	return scanDevice(tx.QueryRow(ctx, `
+		INSERT INTO devices (organization_id, name, category, metadata)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
+	`, orgID, name, token.Category, metadataJSON))
+}
+
+func scanDeviceClaimToken(row rowScanner) (model.DeviceClaimToken, error) {
+	var token model.DeviceClaimToken
+	var metadata []byte
+	err := row.Scan(
+		&token.ID,
+		&token.OrganizationID,
+		&token.Category,
+		&token.VideoCloudDevid,
+		&token.ActivityID,
+		&token.ClipPublicKey,
+		&metadata,
+		&token.ExpiresAt,
+		&token.ClaimedAt,
+		&token.CreatedAt,
+		&token.UpdatedAt,
+	)
+	if err != nil {
+		return model.DeviceClaimToken{}, err
+	}
+	token.Metadata, err = unmarshalJSONMap(metadata)
+	if err != nil {
+		return model.DeviceClaimToken{}, err
+	}
+	return token, nil
+}
+
+func scanDeviceClaim(row rowScanner) (model.DeviceClaim, error) {
+	var claim model.DeviceClaim
+	var provisionInput []byte
+	err := row.Scan(
+		&claim.ID,
+		&claim.TokenID,
+		&claim.OrganizationID,
+		&claim.DeviceID,
+		&claim.ClaimedBy,
+		&claim.Status,
+		&provisionInput,
+		&claim.CreatedAt,
+		&claim.UpdatedAt,
+	)
+	if err != nil {
+		return model.DeviceClaim{}, err
+	}
+	claim.ProvisionInput, err = unmarshalJSONMap(provisionInput)
+	if err != nil {
+		return model.DeviceClaim{}, err
+	}
+	return claim, nil
+}

--- a/internal/store/device_claims_integration_test.go
+++ b/internal/store/device_claims_integration_test.go
@@ -1,0 +1,328 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"rtk_account_manager/internal/model"
+)
+
+func TestResolveDeviceClaimTokenCreatesDeviceAndClaim(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "claim-owner@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Claim Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	token, err := env.store.CreateDeviceClaimToken(ctx, DeviceClaimTokenCreateInput{
+		TokenHash:       "hashed-claim-token-1",
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "video-device-1",
+		ActivityID:      "activity-1",
+		ClipPublicKey:   "clip-key-1",
+		ExpiresAt:       now.Add(time.Hour),
+		Now:             now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-claim-token-1",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Front Door Camera",
+		Now:            now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Claim.TokenID != token.ID {
+		t.Fatalf("expected claim token id %s, got %+v", token.ID, result.Claim)
+	}
+	if result.Claim.OrganizationID != registered.Organization.ID || result.Claim.DeviceID != result.Device.ID {
+		t.Fatalf("expected claim to bind org/device, got %+v device %+v", result.Claim, result.Device)
+	}
+	if result.Device.Name != "Front Door Camera" || result.Device.Category != model.DeviceCategoryIPCamera {
+		t.Fatalf("unexpected claimed device: %+v", result.Device)
+	}
+	if got := result.Device.Metadata[model.DeviceMetadataVideoCloudDevid]; got != "video-device-1" {
+		t.Fatalf("expected video devid metadata, got %+v", result.Device.Metadata)
+	}
+	if result.ProvisionInput.VideoCloudDevid != "video-device-1" ||
+		result.ProvisionInput.ActivityID != "activity-1" ||
+		result.ProvisionInput.ClipPublicKey != "clip-key-1" {
+		t.Fatalf("unexpected provision input: %+v", result.ProvisionInput)
+	}
+
+	var rawTokenCount int
+	if err := env.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM device_claim_tokens
+		WHERE token_hash = 'claim-token-1' OR metadata::text LIKE '%claim-token-1%'
+	`).Scan(&rawTokenCount); err != nil {
+		t.Fatal(err)
+	}
+	if rawTokenCount != 0 {
+		t.Fatal("raw claim token value was persisted")
+	}
+
+	var operations, outbox int
+	if err := env.db.QueryRow(ctx, `SELECT count(*)::int FROM device_operations`).Scan(&operations); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.db.QueryRow(ctx, `SELECT count(*)::int FROM device_message_outbox`).Scan(&outbox); err != nil {
+		t.Fatal(err)
+	}
+	if operations != 0 || outbox != 0 {
+		t.Fatalf("claim resolve must not start provisioning, operations=%d outbox=%d", operations, outbox)
+	}
+}
+
+func TestResolveDeviceClaimTokenMatchesExistingDevice(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "claim-match@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Claim Match Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing, err := env.store.CreateDevice(ctx, registered.Organization.ID, DeviceInput{
+		Name:     "Existing Camera",
+		Category: model.DeviceCategoryIPCamera,
+		Metadata: map[string]any{
+			model.DeviceMetadataVideoCloudDevid: "video-device-match",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateDeviceClaimToken(ctx, DeviceClaimTokenCreateInput{
+		TokenHash:       "hashed-claim-match",
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "video-device-match",
+		ActivityID:      "activity-match",
+		ClipPublicKey:   "clip-key-match",
+		ExpiresAt:       now.Add(time.Hour),
+		Now:             now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-claim-match",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Ignored New Name",
+		Now:            now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Device.ID != existing.ID {
+		t.Fatalf("expected existing device %s to be matched, got %+v", existing.ID, result.Device)
+	}
+
+	var deviceCount int
+	if err := env.db.QueryRow(ctx, `SELECT count(*)::int FROM devices`).Scan(&deviceCount); err != nil {
+		t.Fatal(err)
+	}
+	if deviceCount != 1 {
+		t.Fatalf("expected claim resolve to match instead of creating a device, got %d devices", deviceCount)
+	}
+}
+
+func TestResolveDeviceClaimTokenRejectsInvalidToken(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "invalid-claim@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Invalid Claim Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "missing-token-hash",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Invalid Camera",
+		Now:            time.Now().UTC(),
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for invalid token, got %v", err)
+	}
+}
+
+func TestResolveDeviceClaimTokenRejectsExpiredToken(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "expired-claim@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Expired Claim Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateDeviceClaimToken(ctx, DeviceClaimTokenCreateInput{
+		TokenHash:       "hashed-expired-claim",
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "video-device-expired",
+		ActivityID:      "activity-expired",
+		ClipPublicKey:   "clip-key-expired",
+		ExpiresAt:       now.Add(-time.Minute),
+		Now:             now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-expired-claim",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Expired Camera",
+		Now:            now,
+	})
+	if !errors.Is(err, ErrClaimExpired) {
+		t.Fatalf("expected ErrClaimExpired, got %v", err)
+	}
+}
+
+func TestResolveDeviceClaimTokenRejectsAlreadyClaimedToken(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "first-claim@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "First Claim Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateDeviceClaimToken(ctx, DeviceClaimTokenCreateInput{
+		TokenHash:       "hashed-already-claimed",
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "video-device-claimed",
+		ActivityID:      "activity-claimed",
+		ClipPublicKey:   "clip-key-claimed",
+		ExpiresAt:       now.Add(time.Hour),
+		Now:             now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-already-claimed",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Claimed Camera",
+		Now:            now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-already-claimed",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Claimed Camera Again",
+		Now:            now.Add(2 * time.Minute),
+	})
+	if !errors.Is(err, ErrClaimAlreadyClaimed) {
+		t.Fatalf("expected ErrClaimAlreadyClaimed, got %v", err)
+	}
+}
+
+func TestResolveDeviceClaimTokenRejectsCrossOrganizationToken(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	first, err := env.store.Register(ctx, RegisterInput{
+		Email:            "claim-scope-owner@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Claim Scope Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := env.store.Register(ctx, RegisterInput{
+		Email:            "claim-scope-other@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Other Claim Scope Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateDeviceClaimToken(ctx, DeviceClaimTokenCreateInput{
+		TokenHash:       "hashed-cross-org",
+		OrganizationID:  &first.Organization.ID,
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "video-device-cross-org",
+		ActivityID:      "activity-cross-org",
+		ClipPublicKey:   "clip-key-cross-org",
+		ExpiresAt:       now.Add(time.Hour),
+		Now:             now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-cross-org",
+		OrganizationID: second.Organization.ID,
+		RequestedBy:    second.User.ID,
+		DeviceName:     "Cross Org Camera",
+		Now:            now.Add(time.Minute),
+	})
+	if !errors.Is(err, ErrClaimCrossOrganization) {
+		t.Fatalf("expected ErrClaimCrossOrganization, got %v", err)
+	}
+}
+
+func TestResolveDeviceClaimTokenRejectsUnsupportedCategory(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "unsupported-claim@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Unsupported Claim Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.db.Exec(ctx, `
+		INSERT INTO device_claim_tokens (
+			token_hash, category, video_cloud_devid, activity_id, clip_public_key, expires_at, created_at, updated_at
+		)
+		VALUES ('hashed-unsupported-category', 'unsupported_camera', 'video-device-unsupported', 'activity-unsupported', 'clip-key-unsupported', $1, $2, $2)
+	`, now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-unsupported-category",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Unsupported Camera",
+		Now:            now.Add(time.Minute),
+	})
+	if !errors.Is(err, ErrClaimUnsupportedCategory) {
+		t.Fatalf("expected ErrClaimUnsupportedCategory, got %v", err)
+	}
+}

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -43,9 +43,9 @@ func newStoreIntegrationEnv(t *testing.T) storeIntegrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-		TRUNCATE device_message_inbox, device_message_outbox, device_operations, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
-		RESTART IDENTITY CASCADE
-	`); err != nil {
+			TRUNCATE device_claims, device_claim_tokens, device_message_inbox, device_message_outbox, device_operations, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
+			RESTART IDENTITY CASCADE
+		`); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,13 +13,17 @@ import (
 )
 
 var (
-	ErrNotFound                = errors.New("not found")
-	ErrLastOwner               = errors.New("last owner cannot be removed or downgraded")
-	ErrDisabled                = errors.New("resource is disabled")
-	ErrConflict                = errors.New("conflict")
-	ErrNotProvisioned          = errors.New("device is not provisioned")
-	ErrRateLimited             = errors.New("rate limited")
-	ErrEvaluationQuotaExceeded = errors.New("evaluation device quota exceeded")
+	ErrNotFound                 = errors.New("not found")
+	ErrLastOwner                = errors.New("last owner cannot be removed or downgraded")
+	ErrDisabled                 = errors.New("resource is disabled")
+	ErrConflict                 = errors.New("conflict")
+	ErrNotProvisioned           = errors.New("device is not provisioned")
+	ErrRateLimited              = errors.New("rate limited")
+	ErrEvaluationQuotaExceeded  = errors.New("evaluation device quota exceeded")
+	ErrClaimExpired             = errors.New("claim token expired")
+	ErrClaimAlreadyClaimed      = errors.New("claim token already claimed")
+	ErrClaimCrossOrganization   = errors.New("claim token belongs to another organization")
+	ErrClaimUnsupportedCategory = errors.New("claim token category is unsupported")
 )
 
 type Store struct {

--- a/migrations/012_device_claim_tokens.sql
+++ b/migrations/012_device_claim_tokens.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS device_claim_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID REFERENCES organizations(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    category TEXT NOT NULL,
+    video_cloud_devid TEXT NOT NULL,
+    activity_id TEXT NOT NULL,
+    clip_public_key TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    expires_at TIMESTAMPTZ NOT NULL,
+    claimed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS device_claim_tokens_org_idx
+    ON device_claim_tokens (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS device_claim_tokens_active_idx
+    ON device_claim_tokens (token_hash)
+    WHERE claimed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS device_claims (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim_token_id UUID NOT NULL REFERENCES device_claim_tokens(id) ON DELETE CASCADE,
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    device_id UUID NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    claimed_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status TEXT NOT NULL CHECK (status IN ('resolved')) DEFAULT 'resolved',
+    provision_input JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (claim_token_id)
+);
+
+CREATE INDEX IF NOT EXISTS device_claims_org_created_idx
+    ON device_claims (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS device_claims_device_idx
+    ON device_claims (device_id);
+
+DROP TRIGGER IF EXISTS device_claim_tokens_set_updated_at ON device_claim_tokens;
+CREATE TRIGGER device_claim_tokens_set_updated_at
+    BEFORE UPDATE ON device_claim_tokens
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS device_claims_set_updated_at ON device_claims;
+CREATE TRIGGER device_claims_set_updated_at
+    BEFORE UPDATE ON device_claims
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Summary
- add `device_claim_tokens` and `device_claims` persistence for account-owned Claim Token resolution
- add store-level claim token creation and resolve primitives that create or match registry devices
- enforce expired, already-claimed, cross-organization, and unsupported-category policy errors
- verify raw claim token values are not persisted and resolve does not create lifecycle operations or outbox messages

## Verification
- go test ./internal/store -run 'TestResolveDeviceClaimToken'
- git diff --check
- go test ./...

Closes #87
