### PR TITLE
feat: add claim resolve endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -234,6 +234,7 @@ func (s *Server) Router() *gin.Engine {
 
 	protected.POST("/orgs/:orgId/devices", s.requireOrgRole(model.RoleOwner, model.RoleAdmin), s.createDevice)
 	protected.GET("/orgs/:orgId/devices", s.requireOrgRole(model.RoleOwner, model.RoleAdmin, model.RoleMember), s.listDevices)
+	protected.POST("/orgs/:orgId/devices/claim/resolve", s.requireOrgRole(model.RoleOwner, model.RoleAdmin), s.resolveDeviceClaim)
 	protected.GET("/orgs/:orgId/devices/:deviceId", s.requireOrgRole(model.RoleOwner, model.RoleAdmin, model.RoleMember), s.getDevice)
 	protected.GET("/orgs/:orgId/devices/:deviceId/tags", s.requireOrgRole(model.RoleOwner, model.RoleAdmin, model.RoleMember), s.listDeviceTags)
 	protected.PUT("/orgs/:orgId/devices/:deviceId/tags/:tag", s.requireOrgRole(model.RoleOwner, model.RoleAdmin), s.addDeviceTag)
@@ -1147,6 +1148,27 @@ func writeStoreError(c *gin.Context, err error) {
 		writeError(c, http.StatusConflict, "conflict", "Resource already exists")
 	default:
 		writeError(c, http.StatusInternalServerError, "internal_error", "Internal server error")
+	}
+}
+
+func writeClaimResolveError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		writeError(c, http.StatusNotFound, "invalid_claim_token", "Invalid claim token")
+	case errors.Is(err, store.ErrClaimExpired):
+		writeError(c, http.StatusBadRequest, "expired_claim_token", "Claim token has expired")
+	case errors.Is(err, store.ErrClaimAlreadyClaimed):
+		writeError(c, http.StatusConflict, "already_claimed", "Claim token has already been claimed")
+	case errors.Is(err, store.ErrClaimCrossOrganization):
+		writeError(c, http.StatusForbidden, "forbidden", "Claim token does not belong to this organization")
+	case errors.Is(err, store.ErrClaimUnsupportedCategory):
+		writeError(c, http.StatusBadRequest, "unsupported_device_category", "Claim token device category is not supported")
+	case errors.Is(err, store.ErrEvaluationQuotaExceeded):
+		writeError(c, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", "Evaluation device quota exceeded")
+	case strings.Contains(err.Error(), "duplicate key"):
+		writeError(c, http.StatusConflict, "conflict", "Resource already exists")
+	default:
+		writeError(c, http.StatusServiceUnavailable, "service_unavailable", "Claim resolve is temporarily unavailable")
 	}
 }
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -2005,6 +2005,137 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 	}
 }
 
+func TestIntegrationClaimResolveEndpoint(t *testing.T) {
+	env := newIntegrationEnv(t)
+	ctx := context.Background()
+	claims := store.New(env.db)
+
+	owner := registerUser(t, env.router, "claim-owner@example.com", "Claim Owner Org")
+	admin := registerUser(t, env.router, "claim-admin@example.com", "Claim Admin Org")
+	member := registerUser(t, env.router, "claim-member@example.com", "Claim Member Org")
+	otherOwner := registerUser(t, env.router, "claim-other@example.com", "Claim Other Org")
+
+	for _, membership := range []struct {
+		email string
+		role  string
+	}{
+		{email: "claim-admin@example.com", role: "admin"},
+		{email: "claim-member@example.com", role: "member"},
+	} {
+		res := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/members", map[string]any{
+			"email": membership.email,
+			"role":  membership.role,
+		}, owner.Tokens.AccessToken)
+		if res.Code != http.StatusCreated {
+			t.Fatalf("expected add member %s 201, got %d: %s", membership.email, res.Code, res.Body.String())
+		}
+	}
+
+	seedClaimToken := func(rawToken, videoDevid string, expiresAt time.Time, orgID *string, category model.DeviceCategory) {
+		t.Helper()
+		if _, err := claims.CreateDeviceClaimToken(ctx, store.DeviceClaimTokenCreateInput{
+			OrganizationID:  orgID,
+			TokenHash:       auth.HashToken(rawToken),
+			Category:        category,
+			VideoCloudDevid: videoDevid,
+			ActivityID:      "activity-" + videoDevid,
+			ClipPublicKey:   "clip-key-" + videoDevid,
+			ExpiresAt:       expiresAt,
+			Now:             time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ownerOrgID := owner.Organization.ID
+	seedClaimToken("claim-token-owner", "claim-video-owner", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
+	claimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-owner",
+		"device_name": "Front Door Camera",
+	}, owner.Tokens.AccessToken)
+	if claimRes.Code != http.StatusCreated {
+		t.Fatalf("expected claim resolve 201, got %d: %s", claimRes.Code, claimRes.Body.String())
+	}
+	claimBody := decodeBody[claimResolveBody](t, claimRes)
+	if claimBody.ClaimID == "" || claimBody.Device.ID == "" {
+		t.Fatalf("expected claim id and device id, got %+v", claimBody)
+	}
+	if claimBody.Device.Name != "Front Door Camera" {
+		t.Fatalf("expected resolved device name, got %+v", claimBody.Device)
+	}
+	if claimBody.ProvisionInput.VideoCloudDevid != "claim-video-owner" ||
+		claimBody.ProvisionInput.ActivityID != "activity-claim-video-owner" ||
+		claimBody.ProvisionInput.ClipPublicKey != "clip-key-claim-video-owner" {
+		t.Fatalf("unexpected provision input: %+v", claimBody.ProvisionInput)
+	}
+
+	var operationCount int
+	if err := env.db.QueryRow(ctx, `SELECT count(*) FROM device_operations WHERE device_id = $1`, claimBody.Device.ID).Scan(&operationCount); err != nil {
+		t.Fatal(err)
+	}
+	if operationCount != 0 {
+		t.Fatalf("claim resolve must not create provisioning operations, got %d", operationCount)
+	}
+	var outboxCount int
+	if err := env.db.QueryRow(ctx, `SELECT count(*) FROM device_message_outbox WHERE partition_key = $1`, claimBody.Device.ID).Scan(&outboxCount); err != nil {
+		t.Fatal(err)
+	}
+	if outboxCount != 0 {
+		t.Fatalf("claim resolve must not publish outbox messages, got %d", outboxCount)
+	}
+
+	seedClaimToken("claim-token-admin", "claim-video-admin", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
+	adminClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-admin",
+		"device_name": "Admin Camera",
+	}, admin.Tokens.AccessToken)
+	if adminClaimRes.Code != http.StatusCreated {
+		t.Fatalf("expected admin claim resolve 201, got %d: %s", adminClaimRes.Code, adminClaimRes.Body.String())
+	}
+
+	seedClaimToken("claim-token-member", "claim-video-member", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
+	memberClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-member",
+		"device_name": "Member Camera",
+	}, member.Tokens.AccessToken)
+	if memberClaimRes.Code != http.StatusForbidden {
+		t.Fatalf("expected member claim resolve 403, got %d: %s", memberClaimRes.Code, memberClaimRes.Body.String())
+	}
+
+	invalidClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "missing-token",
+		"device_name": "Missing Camera",
+	}, owner.Tokens.AccessToken)
+	assertErrorCode(t, invalidClaimRes, http.StatusNotFound, "invalid_claim_token")
+
+	seedClaimToken("claim-token-expired", "claim-video-expired", time.Now().Add(-time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
+	expiredClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-expired",
+		"device_name": "Expired Camera",
+	}, owner.Tokens.AccessToken)
+	assertErrorCode(t, expiredClaimRes, http.StatusBadRequest, "expired_claim_token")
+
+	alreadyClaimedRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-owner",
+		"device_name": "Front Door Again",
+	}, owner.Tokens.AccessToken)
+	assertErrorCode(t, alreadyClaimedRes, http.StatusConflict, "already_claimed")
+
+	seedClaimToken("claim-token-cross-org", "claim-video-cross-org", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
+	crossOrgClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+otherOwner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-cross-org",
+		"device_name": "Cross Org Camera",
+	}, otherOwner.Tokens.AccessToken)
+	assertErrorCode(t, crossOrgClaimRes, http.StatusForbidden, "forbidden")
+
+	seedClaimToken("claim-token-unsupported", "claim-video-unsupported", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryMQTT)
+	unsupportedClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-unsupported",
+		"device_name": "MQTT Device",
+	}, owner.Tokens.AccessToken)
+	assertErrorCode(t, unsupportedClaimRes, http.StatusBadRequest, "unsupported_device_category")
+}
+
 func TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata(t *testing.T) {
 	env := newIntegrationEnv(t)
 
@@ -2246,6 +2377,19 @@ type deviceBody struct {
 	} `json:"device"`
 }
 
+type claimResolveBody struct {
+	ClaimID string `json:"claim_id"`
+	Device  struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"device"`
+	ProvisionInput struct {
+		VideoCloudDevid string `json:"video_cloud_devid"`
+		ActivityID      string `json:"activity_id"`
+		ClipPublicKey   string `json:"clip_public_key"`
+	} `json:"provision_input"`
+}
+
 type devicesBody struct {
 	Devices []struct {
 		ID string `json:"id"`
@@ -2425,6 +2569,24 @@ func decodeBody[T any](t *testing.T, res *httptest.ResponseRecorder) T {
 		t.Fatalf("decode response: %v: %s", err, res.Body.String())
 	}
 	return out
+}
+
+func assertErrorCode(t *testing.T, res *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	if res.Code != status {
+		t.Fatalf("expected status %d, got %d: %s", status, res.Code, res.Body.String())
+	}
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error response: %v: %s", err, res.Body.String())
+	}
+	if body.Error.Code != code {
+		t.Fatalf("expected error code %q, got %q: %s", code, body.Error.Code, res.Body.String())
+	}
 }
 
 func validateAccountCommandEnvelope(t *testing.T, message model.DeviceMessageOutbox) channel.Payload {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -8,12 +8,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers"
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 	"github.com/gin-gonic/gin"
+
+	"rtk_account_manager/internal/auth"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
 )
 
 func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
@@ -71,6 +76,24 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 
 	tagsRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/tags", nil, registered.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/tags", tagsRes)
+
+	registeredOrgID := registered.Organization.ID
+	if _, err := store.New(env.db).CreateDeviceClaimToken(context.Background(), store.DeviceClaimTokenCreateInput{
+		OrganizationID:  &registeredOrgID,
+		TokenHash:       auth.HashToken("contract-claim-token"),
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "contract-claim-video-1",
+		ActivityID:      "contract-claim-activity-1",
+		ClipPublicKey:   "contract-claim-clip-key-1",
+		ExpiresAt:       time.Now().UTC().Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	claimResolveRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+registered.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "contract-claim-token",
+		"device_name": "Contract Claimed Camera",
+	}, registered.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/orgs/"+registered.Organization.ID+"/devices/claim/resolve", claimResolveRes)
 
 	verifyToken := latestAuthToken(t, env.tokenSink, "contract-signup@example.com", "email_verification")
 	verifyRes := performJSON(env.router, http.MethodPost, "/v1/auth/verify-email", map[string]any{

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"rtk_account_manager/internal/auth"
 	"rtk_account_manager/internal/channel"
 	"rtk_account_manager/internal/model"
 	"rtk_account_manager/internal/store"
@@ -38,8 +39,19 @@ type deactivateRequest struct {
 	OperationID string `json:"operation_id"`
 }
 
+type claimResolveRequest struct {
+	ClaimToken string `json:"claim_token"`
+	DeviceName string `json:"device_name"`
+}
+
 type operationBody struct {
 	Operation operationResponse `json:"operation"`
+}
+
+type claimResolveResponse struct {
+	ClaimID        string                     `json:"claim_id"`
+	Device         model.Device               `json:"device"`
+	ProvisionInput store.DeviceProvisionInput `json:"provision_input"`
 }
 
 type provisioningBody struct {
@@ -162,6 +174,38 @@ func (s *Server) provisionDevice(c *gin.Context) {
 		status = http.StatusOK
 	}
 	c.JSON(status, operationBody{Operation: operationFromResult(result.Operation, result.Message)})
+}
+
+func (s *Server) resolveDeviceClaim(c *gin.Context) {
+	var req claimResolveRequest
+	if !bindStrict(c, &req) {
+		return
+	}
+
+	claimToken := strings.TrimSpace(req.ClaimToken)
+	deviceName := strings.TrimSpace(req.DeviceName)
+	if !requireNonBlank(c, "claim_token", claimToken) ||
+		!requireNonBlank(c, "device_name", deviceName) {
+		return
+	}
+
+	result, err := s.store.ResolveDeviceClaimToken(c.Request.Context(), store.DeviceClaimResolveInput{
+		TokenHash:      auth.HashToken(claimToken),
+		OrganizationID: c.Param("orgId"),
+		RequestedBy:    currentUserID(c),
+		DeviceName:     deviceName,
+		Now:            time.Now().UTC(),
+	})
+	if err != nil {
+		writeClaimResolveError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, claimResolveResponse{
+		ClaimID:        result.Claim.ID,
+		Device:         result.Device,
+		ProvisionInput: result.ProvisionInput,
+	})
 }
 
 func rejectUnsupportedClaimMaterial(c *gin.Context, req provisionRequest) bool {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -783,6 +783,48 @@ paths:
           $ref: "#/components/responses/Error"
         "409":
           $ref: "#/components/responses/Error"
+  /v1/orgs/{orgId}/devices/claim/resolve:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Resolve a device Claim Token.
+      description: >
+        Resolves an account-manager-owned Claim Token into an
+        organization-owned registry device and returns the normalized video
+        provisioning input. This endpoint does not create a provisioning
+        operation, publish outbox messages, or call the Realtek video service.
+      parameters:
+        - $ref: "#/components/parameters/OrgId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimResolveRequest"
+            examples:
+              claim_token:
+                value:
+                  claim_token: claim-token-from-qr
+                  device_name: Front Door Camera
+      responses:
+        "201":
+          description: Claim Token resolved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimResolveResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+        "503":
+          $ref: "#/components/responses/Error"
   /v1/orgs/{orgId}/devices/{deviceId}:
     get:
       security:
@@ -1308,6 +1350,40 @@ components:
         operation_id:
           type: string
           description: Optional client idempotency key; reuse with different claim material returns 409 Conflict.
+    ClaimResolveRequest:
+      type: object
+      required: [claim_token, device_name]
+      additionalProperties: false
+      properties:
+        claim_token:
+          type: string
+          minLength: 1
+          description: Raw Claim Token scanned from onboarding material. The server hashes this value before lookup.
+        device_name:
+          type: string
+          minLength: 1
+          description: Registry device name to use when the claim creates a new device.
+    ClaimProvisionInput:
+      type: object
+      required: [video_cloud_devid, activity_id, clip_public_key]
+      properties:
+        video_cloud_devid:
+          type: string
+        activity_id:
+          type: string
+        clip_public_key:
+          type: string
+    ClaimResolveResponse:
+      type: object
+      required: [claim_id, device, provision_input]
+      properties:
+        claim_id:
+          type: string
+          format: uuid
+        device:
+          $ref: "#/components/schemas/Device"
+        provision_input:
+          $ref: "#/components/schemas/ClaimProvisionInput"
     DeactivateDeviceRequest:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- add POST /v1/orgs/:orgId/devices/claim/resolve for account-manager Claim Token resolution
- map claim-specific store errors to contract error codes
- document the endpoint and schemas in OpenAPI
- add integration and OpenAPI response contract coverage

Closes #88

## Tests
- TEST_DATABASE_URL=postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable go test ./internal/api -run 'TestIntegrationClaimResolveEndpoint|TestIntegrationResponsesMatchOpenAPIContract' -count=1 -v\n- TEST_DATABASE_URL=postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable go test ./...\n