### PR TITLE
fix: return registry-only provisioning readiness

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -732,10 +732,11 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 				}
 			}
 
-			got := readinessFromProjection(tt.device, model.DeviceOperation{
+			provisioningOperation := model.DeviceOperation{
 				OperationType: model.DeviceOperationTypeProvision,
 				Status:        tt.provisioningStatus,
-			}, latestDeactivation)
+			}
+			got := readinessFromProjection(tt.device, &provisioningOperation, latestDeactivation)
 
 			if got.State != tt.want {
 				t.Fatalf("expected readiness %s, got %+v", tt.want, got)
@@ -743,7 +744,9 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			if got.ProductState != tt.wantProduct {
 				t.Fatalf("expected product readiness %s, got %+v", tt.wantProduct, got)
 			}
-			if got.Sources.DeviceStatus != tt.device.Status || got.Sources.ProvisioningOperationStatus != tt.provisioningStatus {
+			if got.Sources.DeviceStatus != tt.device.Status ||
+				got.Sources.ProvisioningOperationStatus == nil ||
+				*got.Sources.ProvisioningOperationStatus != tt.provisioningStatus {
 				t.Fatalf("expected source facts to reflect device and operation, got %+v", got.Sources)
 			}
 			if tt.deactivationStatus != nil && (got.Sources.DeactivationOperationStatus == nil || *got.Sources.DeactivationOperationStatus != *tt.deactivationStatus) {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1910,7 +1910,7 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 		t.Fatalf("expected member provisioning state 200, got %d: %s", memberStateRes.Code, memberStateRes.Body.String())
 	}
 	memberState := decodeBody[provisioningBody](t, memberStateRes)
-	if memberState.Operation.OperationID != "provision-op-1" {
+	if memberState.Operation == nil || memberState.Operation.OperationID != "provision-op-1" {
 		t.Fatalf("unexpected provisioning state operation: %+v", memberState.Operation)
 	}
 	if got := memberState.VideoMetadata[model.DeviceMetadataVideoCloudDevid]; got != "video-device-1" {
@@ -1932,7 +1932,8 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 		t.Fatalf("expected pending product readiness state, got %+v", memberState.Readiness)
 	}
 	if memberState.Readiness.Sources.DeviceStatus != model.DeviceStatusUnknown ||
-		memberState.Readiness.Sources.ProvisioningOperationStatus != model.DeviceOperationStatusPending ||
+		memberState.Readiness.Sources.ProvisioningOperationStatus == nil ||
+		*memberState.Readiness.Sources.ProvisioningOperationStatus != model.DeviceOperationStatusPending ||
 		memberState.Readiness.Sources.VideoCloudActivationStatus == nil ||
 		*memberState.Readiness.Sources.VideoCloudActivationStatus != string(model.VideoCloudActivationStatusPending) {
 		t.Fatalf("expected readiness sources to identify pending lifecycle facts, got %+v", memberState.Readiness.Sources)
@@ -2002,6 +2003,74 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 	}, admin.Tokens.AccessToken)
 	if adminProvisionRes.Code != http.StatusCreated {
 		t.Fatalf("expected admin provision 201, got %d: %s", adminProvisionRes.Code, adminProvisionRes.Body.String())
+	}
+}
+
+func TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	owner := registerUser(t, env.router, "registry-owner@example.com", "Registry Owner Org")
+	member := registerUser(t, env.router, "registry-member@example.com", "Registry Member Org")
+
+	addMemberRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/members", map[string]any{
+		"email": "registry-member@example.com",
+		"role":  "member",
+	}, owner.Tokens.AccessToken)
+	if addMemberRes.Code != http.StatusCreated {
+		t.Fatalf("expected add member 201, got %d: %s", addMemberRes.Code, addMemberRes.Body.String())
+	}
+
+	deviceRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices", devicePayload("registry-only-device", "REGISTRY-001"), owner.Tokens.AccessToken)
+	if deviceRes.Code != http.StatusCreated {
+		t.Fatalf("expected create device 201, got %d: %s", deviceRes.Code, deviceRes.Body.String())
+	}
+	device := decodeBody[deviceBody](t, deviceRes)
+
+	stateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, member.Tokens.AccessToken)
+	if stateRes.Code != http.StatusOK {
+		t.Fatalf("expected registry-only provisioning state 200, got %d: %s", stateRes.Code, stateRes.Body.String())
+	}
+	state := decodeBody[registryOnlyProvisioningBody](t, stateRes)
+	if state.Operation != nil {
+		t.Fatalf("expected registry-only operation to be nil, got %+v", state.Operation)
+	}
+	if state.Readiness.State != model.DeviceReadinessStateActivationPending {
+		t.Fatalf("expected registry-only readiness activation_pending, got %+v", state.Readiness)
+	}
+	if state.Readiness.ProductState != model.ProductReadinessStateRegistered {
+		t.Fatalf("expected registry-only product state registered, got %+v", state.Readiness)
+	}
+	if state.Readiness.Sources.ProvisioningOperationStatus != nil {
+		t.Fatalf("expected registry-only provisioning operation source to be nil, got %+v", state.Readiness.Sources)
+	}
+
+	disabledDeviceRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices", devicePayload("disabled-registry-device", "REGISTRY-002"), owner.Tokens.AccessToken)
+	if disabledDeviceRes.Code != http.StatusCreated {
+		t.Fatalf("expected create disabled fixture 201, got %d: %s", disabledDeviceRes.Code, disabledDeviceRes.Body.String())
+	}
+	disabledDevice := decodeBody[deviceBody](t, disabledDeviceRes)
+	deleteDisabledRes := performJSON(env.router, http.MethodDelete, "/v1/orgs/"+owner.Organization.ID+"/devices/"+disabledDevice.Device.ID, nil, owner.Tokens.AccessToken)
+	if deleteDisabledRes.Code != http.StatusNoContent {
+		t.Fatalf("expected disable registry fixture 204, got %d: %s", deleteDisabledRes.Code, deleteDisabledRes.Body.String())
+	}
+	disabledStateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/"+disabledDevice.Device.ID+"/provisioning", nil, owner.Tokens.AccessToken)
+	if disabledStateRes.Code != http.StatusOK {
+		t.Fatalf("expected disabled registry-only provisioning state 200, got %d: %s", disabledStateRes.Code, disabledStateRes.Body.String())
+	}
+	disabledState := decodeBody[registryOnlyProvisioningBody](t, disabledStateRes)
+	if disabledState.Operation != nil {
+		t.Fatalf("expected disabled registry-only operation to be nil, got %+v", disabledState.Operation)
+	}
+	if disabledState.Readiness.State != model.DeviceReadinessStateDisabled {
+		t.Fatalf("expected disabled registry-only readiness disabled, got %+v", disabledState.Readiness)
+	}
+	if disabledState.Readiness.ProductState != model.ProductReadinessStateRegistered {
+		t.Fatalf("expected disabled registry-only product state registered, got %+v", disabledState.Readiness)
+	}
+
+	missingStateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/00000000-0000-0000-0000-000000000000/provisioning", nil, owner.Tokens.AccessToken)
+	if missingStateRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing device provisioning state 404, got %d: %s", missingStateRes.Code, missingStateRes.Body.String())
 	}
 }
 
@@ -2388,6 +2457,17 @@ type claimResolveBody struct {
 		ActivityID      string `json:"activity_id"`
 		ClipPublicKey   string `json:"clip_public_key"`
 	} `json:"provision_input"`
+}
+
+type registryOnlyProvisioningBody struct {
+	Operation *operationResponse `json:"operation"`
+	Readiness struct {
+		State        model.DeviceReadinessState  `json:"state"`
+		ProductState model.ProductReadinessState `json:"product_state"`
+		Sources      struct {
+			ProvisioningOperationStatus *model.DeviceOperationStatus `json:"provisioning_operation_status"`
+		} `json:"sources"`
+	} `json:"readiness"`
 }
 
 type devicesBody struct {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -77,6 +77,9 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	tagsRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/tags", nil, registered.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/tags", tagsRes)
 
+	registryOnlyStateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, registered.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/orgs/"+registered.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", registryOnlyStateRes)
+
 	registeredOrgID := registered.Organization.ID
 	if _, err := store.New(env.db).CreateDeviceClaimToken(context.Background(), store.DeviceClaimTokenCreateInput{
 		OrganizationID:  &registeredOrgID,

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -55,9 +55,9 @@ type claimResolveResponse struct {
 }
 
 type provisioningBody struct {
-	Operation     operationResponse `json:"operation"`
-	Readiness     readinessResponse `json:"readiness"`
-	VideoMetadata map[string]any    `json:"video_metadata"`
+	Operation     *operationResponse `json:"operation"`
+	Readiness     readinessResponse  `json:"readiness"`
+	VideoMetadata map[string]any     `json:"video_metadata"`
 }
 
 type operationResponse struct {
@@ -85,7 +85,7 @@ type readinessResponse struct {
 type readinessSourcesResponse struct {
 	DeviceEnabled               bool                         `json:"device_enabled"`
 	DeviceStatus                model.DeviceStatus           `json:"device_status"`
-	ProvisioningOperationStatus model.DeviceOperationStatus  `json:"provisioning_operation_status"`
+	ProvisioningOperationStatus *model.DeviceOperationStatus `json:"provisioning_operation_status,omitempty"`
 	VideoCloudActivationStatus  *string                      `json:"video_cloud_activation_status,omitempty"`
 	DeactivationOperationStatus *model.DeviceOperationStatus `json:"deactivation_operation_status,omitempty"`
 	VideoCloudLastError         any                          `json:"video_cloud_last_error,omitempty"`
@@ -235,19 +235,25 @@ func (s *Server) getProvisioningState(c *gin.Context) {
 	}
 
 	operation, err := s.store.GetLatestDeviceOperationByType(c.Request.Context(), c.Param("orgId"), c.Param("deviceId"), model.DeviceOperationTypeProvision)
-	if err != nil {
+	var latestProvision *model.DeviceOperation
+	var operationResponseValue *operationResponse
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
 		writeStoreError(c, err)
 		return
 	}
-
-	message, err := s.store.GetLatestOutboxMessageByOperationID(c.Request.Context(), operation.OperationID)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			writeStoreError(c, errOperationStateInconsistent)
+	if err == nil {
+		latestProvision = &operation
+		message, err := s.store.GetLatestOutboxMessageByOperationID(c.Request.Context(), operation.OperationID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				writeStoreError(c, errOperationStateInconsistent)
+				return
+			}
+			writeStoreError(c, err)
 			return
 		}
-		writeStoreError(c, err)
-		return
+		value := operationFromResult(operation, message)
+		operationResponseValue = &value
 	}
 
 	deactivationOperation, err := s.store.GetLatestDeviceOperationByType(c.Request.Context(), c.Param("orgId"), c.Param("deviceId"), model.DeviceOperationTypeDeactivate)
@@ -261,8 +267,8 @@ func (s *Server) getProvisioningState(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, provisioningBody{
-		Operation:     operationFromResult(operation, message),
-		Readiness:     readinessFromProjection(device, operation, latestDeactivation),
+		Operation:     operationResponseValue,
+		Readiness:     readinessFromProjection(device, latestProvision, latestDeactivation),
 		VideoMetadata: projectedVideoMetadata(device.Metadata),
 	})
 }
@@ -434,11 +440,13 @@ func projectedVideoMetadata(metadata map[string]any) map[string]any {
 	return projected
 }
 
-func readinessFromProjection(device model.Device, provisioningOperation model.DeviceOperation, latestDeactivation *model.DeviceOperation) readinessResponse {
+func readinessFromProjection(device model.Device, provisioningOperation *model.DeviceOperation, latestDeactivation *model.DeviceOperation) readinessResponse {
 	sources := readinessSourcesResponse{
-		DeviceEnabled:               device.DisabledAt == nil,
-		DeviceStatus:                device.Status,
-		ProvisioningOperationStatus: provisioningOperation.Status,
+		DeviceEnabled: device.DisabledAt == nil,
+		DeviceStatus:  device.Status,
+	}
+	if provisioningOperation != nil {
+		sources.ProvisioningOperationStatus = &provisioningOperation.Status
 	}
 	if activationStatus, ok := metadataString(device.Metadata, model.DeviceMetadataVideoCloudActivationStatus); ok {
 		sources.VideoCloudActivationStatus = &activationStatus
@@ -477,14 +485,16 @@ func readinessStateFromSources(sources readinessSourcesResponse) model.DeviceRea
 		return model.DeviceReadinessStateDisabled
 	}
 
-	if sources.ProvisioningOperationStatus == model.DeviceOperationStatusFailed ||
-		sources.ProvisioningOperationStatus == model.DeviceOperationStatusDeadLettered ||
+	if (sources.ProvisioningOperationStatus != nil &&
+		(*sources.ProvisioningOperationStatus == model.DeviceOperationStatusFailed ||
+			*sources.ProvisioningOperationStatus == model.DeviceOperationStatusDeadLettered)) ||
 		(sources.VideoCloudActivationStatus != nil && *sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusFailed)) ||
 		sources.VideoCloudLastError != nil {
 		return model.DeviceReadinessStateActivationFailed
 	}
 
-	if sources.ProvisioningOperationStatus == model.DeviceOperationStatusSucceeded &&
+	if sources.ProvisioningOperationStatus != nil &&
+		*sources.ProvisioningOperationStatus == model.DeviceOperationStatusSucceeded &&
 		sources.VideoCloudActivationStatus != nil &&
 		*sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusActivated) {
 		if sources.DeviceStatus == model.DeviceStatusOnline {
@@ -516,20 +526,26 @@ func productReadinessStateFromSources(sources readinessSourcesResponse) model.Pr
 		return model.ProductReadinessStateRegistered
 	}
 
-	if sources.ProvisioningOperationStatus == model.DeviceOperationStatusFailed ||
-		sources.ProvisioningOperationStatus == model.DeviceOperationStatusDeadLettered ||
+	if (sources.ProvisioningOperationStatus != nil &&
+		(*sources.ProvisioningOperationStatus == model.DeviceOperationStatusFailed ||
+			*sources.ProvisioningOperationStatus == model.DeviceOperationStatusDeadLettered)) ||
 		(sources.VideoCloudActivationStatus != nil && *sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusFailed)) ||
 		sources.VideoCloudLastError != nil {
 		return model.ProductReadinessStateFailed
 	}
 
-	if sources.ProvisioningOperationStatus == model.DeviceOperationStatusSucceeded &&
+	if sources.ProvisioningOperationStatus != nil &&
+		*sources.ProvisioningOperationStatus == model.DeviceOperationStatusSucceeded &&
 		sources.VideoCloudActivationStatus != nil &&
 		*sources.VideoCloudActivationStatus == string(model.VideoCloudActivationStatusActivated) {
 		if sources.DeviceStatus == model.DeviceStatusOnline {
 			return model.ProductReadinessStateOnline
 		}
 		return model.ProductReadinessStateActivated
+	}
+
+	if sources.ProvisioningOperationStatus == nil {
+		return model.ProductReadinessStateRegistered
 	}
 
 	return model.ProductReadinessStateCloudActivationPending

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1633,7 +1633,9 @@ components:
       required: [operation, readiness, video_metadata]
       properties:
         operation:
-          $ref: "#/components/schemas/DeviceOperationSummary"
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/DeviceOperationSummary"
         readiness:
           $ref: "#/components/schemas/DeviceReadinessProjection"
         video_metadata:
@@ -1649,13 +1651,14 @@ components:
           $ref: "#/components/schemas/ProductReadinessState"
         sources:
           type: object
-          required: [device_enabled, device_status, provisioning_operation_status]
+          required: [device_enabled, device_status]
           properties:
             device_enabled:
               type: boolean
             device_status:
               $ref: "#/components/schemas/DeviceStatus"
             provisioning_operation_status:
+              nullable: true
               $ref: "#/components/schemas/DeviceOperationStatus"
             video_cloud_activation_status:
               $ref: "#/components/schemas/VideoCloudActivationStatus"


### PR DESCRIPTION
## Summary
- return /provisioning readiness for registry-only devices without provisioning operations
- keep missing/inaccessible devices as 404
- return operation:null and account-side product_state=registered for registry-only devices
- update OpenAPI and contract coverage for nullable provisioning operation responses

Closes #89

## Tests
- TEST_DATABASE_URL=postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable go test ./internal/api -run 'TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness|TestIntegrationResponsesMatchOpenAPIContract|TestIntegrationProvisioningEndpoints|TestReadinessFromProjectionStates' -count=1\n- TEST_DATABASE_URL=postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable go test ./...\n