### PR TITLE
docs: close out v2 follow-up drift

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -26,12 +26,21 @@ The current account manager now implements:
 - Local `log` broker support plus Azure Event Hubs adapter wiring.
 - Maintained v2 test reporting and a local worker runbook.
 - Lifecycle admin commands for listing, inspecting, and requeueing eligible inbox/outbox rows.
+- Hashed Claim Token persistence and the app-facing `POST /v1/orgs/:orgId/devices/claim/resolve` endpoint.
+- Registry-only readiness responses for existing devices before a provisioning operation exists.
+- Test-report coverage for Claim Token resolve and registry-only readiness correctness.
 
 Verified contract follow-up closure for this milestone snapshot:
 
 - Account-manager Claim Token persistence and `POST /v1/orgs/:orgId/devices/claim/resolve` are implemented.
 - `GET /provisioning` returns registry-only readiness for existing devices before a provisioning operation exists.
 - `make test-report`, `docs/TESTING.md`, and `docs/TEST_REPORT.md` cover Claim Token and registry-only readiness correctness.
+
+Remaining post-v2 contract follow-up gaps for this milestone snapshot:
+
+- Add a platform-admin Claim Token issuance/import/revoke workflow so tokens do not need to be seeded through store/test paths.
+- Define and later implement transfer, reclaim, and factory-reset policy for already-claimed devices.
+- Add product-readiness failure attribution fields for failed provisioning and deactivation states.
 - Keep this repo's contract docs explicit that `DELETE /devices/:deviceId` remains registry-only while product teardown still requires `POST /deactivate`, unless product policy changes later.
 
 ## Milestone And Issue Map
@@ -58,10 +67,10 @@ These issues were follow-ups to the merged account-manager v2 implementation. Th
 
 | Issue | Status | Evidence | Deliverable |
 | --- | --- | --- | --- |
-| `#87 [API/DB] Add Claim Token resolve persistence and policy model` | implemented | `openapi.yaml`, `docs/TEST_REPORT.md` | Hashed Claim Token persistence, claim/bind policy state, registry-device create/match behavior, and provisioning input projection. |
-| `#88 [API] Implement POST /v1/orgs/:orgId/devices/claim/resolve` | implemented | `openapi.yaml`, `docs/SPEC.md` | App-facing Claim Token resolve endpoint defined by `contracts/PROVISION.md` and `contracts/PRODUCT_ONBOARDING.md`. |
-| `#89 [API] Return registry-only readiness from GET /provisioning` | implemented | `docs/TEST_REPORT.md` | Account-side readiness for existing registry devices that have no provisioning operation yet. |
-| `#90 [Testing] Extend report for Claim Token and readiness gaps` | verified | `make test-report`, `docs/TESTING.md`, `docs/TEST_REPORT.md` | Maintained evidence for Claim Token and registry-only readiness correctness. |
+| `#87 [API/DB] Add Claim Token resolve persistence and policy model` | verified | PR #92, `openapi.yaml`, `docs/TEST_REPORT.md` | Hashed Claim Token persistence, claim/bind policy state, registry-device create/match behavior, and provisioning input projection. |
+| `#88 [API] Implement POST /v1/orgs/:orgId/devices/claim/resolve` | verified | PR #93, `openapi.yaml`, `docs/SPEC.md` | App-facing Claim Token resolve endpoint defined by `contracts/PROVISION.md` and `contracts/PRODUCT_ONBOARDING.md`. |
+| `#89 [API] Return registry-only readiness from GET /provisioning` | verified | PR #94, `docs/TEST_REPORT.md` | Account-side readiness for existing registry devices that have no provisioning operation yet. |
+| `#90 [Testing] Extend report for Claim Token and readiness gaps` | verified | PR #95, `make test-report`, `docs/TESTING.md`, `docs/TEST_REPORT.md` | Maintained evidence for Claim Token and registry-only readiness correctness. |
 
 Status values:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -628,8 +628,8 @@ owned by that organization; submitted video lifecycle material is stored as
 provisioning request payload and projected video metadata, not as a replacement
 for account-manager ownership.
 
-The shared contracts now define the first app-facing Claim Token resolution
-surface:
+The shared contracts define the first implemented app-facing Claim Token
+resolution surface:
 
 ```http
 POST /v1/orgs/:orgId/devices/claim/resolve
@@ -640,7 +640,7 @@ makes the account-manager-owned claim/bind policy decision, creates or matches t
 organization registry device, and returns `claim_id`, `device`, and
 `provision_input` containing `video_cloud_devid`, `activity_id`, and
 `clip_public_key`. Claim resolution remains separate from cloud provisioning:
-resolving a Claim Token must not create a provisioning operation, publish an
+resolving a Claim Token does not create a provisioning operation, publish an
 outbox message, or call Realtek video server directly.
 
 Raw claim-material endpoint decision:
@@ -1034,6 +1034,14 @@ Current verified behavior:
 
 - Claim Token persistence and `POST /v1/orgs/:orgId/devices/claim/resolve` are implemented and covered by `openapi.yaml`, `docs/TESTING.md`, and `docs/TEST_REPORT.md`.
 - `GET /provisioning` returns registry-only readiness for an existing device with no provisioning operation.
+- These behaviors were merged through PR #92, PR #93, and PR #94.
+- The maintained test report includes Claim Token and registry-only readiness correctness evidence, verified by PR #95.
+
+Remaining post-v2 follow-up items:
+
+- Add a platform-admin Claim Token issuance/import/revoke workflow so tokens do not need to be seeded through store/test paths.
+- Define and implement transfer, reclaim, and factory-reset policy for already-claimed devices.
+- Add product-readiness failure attribution fields to failed provisioning and deactivation readiness responses.
 - Retry and dead-letter rows are inspectable in Postgres, and `cmd/lifecycle-admin` exposes list, inspect, and safe requeue workflows for operators.
 - Account registry soft-delete and product-level video deactivation remain separate. Product teardown requires explicit `POST /deactivate`; `DELETE /devices/:deviceId` only disables the account-side registry record.
 - Account manager exposes an account-side readiness projection on `GET /provisioning`, but it still does not own a final cross-service "product ready" boolean. Any future unified readiness surface must compose account record, video activation, subject-bound token issuance, device info/config, and transport ownership across service boundaries.


### PR DESCRIPTION
## Summary
- Mark #87/#88/#89/#90 as implemented/verified in the v2 plan
- Update SPEC follow-up scope so Claim Token resolve and registry-only readiness are no longer described as pending
- Preserve the remaining post-v2 gaps for token issuance/import, transfer/reclaim policy, and readiness failure attribution

Closes #96

## Tests
- `go test ./...`
