### PR TITLE
feat: add admin device claim token workflow

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -249,6 +249,10 @@ func (s *Server) Router() *gin.Engine {
 	protected.POST("/admin/quota-raise-requests/:requestId/approve", s.requirePlatformAdmin(), s.approveQuotaRaiseRequest)
 	protected.POST("/admin/quota-raise-requests/:requestId/decline", s.requirePlatformAdmin(), s.declineQuotaRaiseRequest)
 	protected.GET("/admin/metrics", s.requirePlatformAdmin(), s.adminMetrics)
+	protected.POST("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.createDeviceClaimToken)
+	protected.GET("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.listDeviceClaimTokens)
+	protected.GET("/admin/device-claim-tokens/:tokenId", s.requirePlatformAdmin(), s.getDeviceClaimToken)
+	protected.POST("/admin/device-claim-tokens/:tokenId/revoke", s.requirePlatformAdmin(), s.revokeDeviceClaimToken)
 
 	return r
 }
@@ -1159,6 +1163,8 @@ func writeClaimResolveError(c *gin.Context, err error) {
 		writeError(c, http.StatusBadRequest, "expired_claim_token", "Claim token has expired")
 	case errors.Is(err, store.ErrClaimAlreadyClaimed):
 		writeError(c, http.StatusConflict, "already_claimed", "Claim token has already been claimed")
+	case errors.Is(err, store.ErrClaimRevoked):
+		writeError(c, http.StatusNotFound, "invalid_claim_token", "Invalid claim token")
 	case errors.Is(err, store.ErrClaimCrossOrganization):
 		writeError(c, http.StatusForbidden, "forbidden", "Claim token does not belong to this organization")
 	case errors.Is(err, store.ErrClaimUnsupportedCategory):

--- a/internal/api/device_claim_tokens_admin.go
+++ b/internal/api/device_claim_tokens_admin.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"rtk_account_manager/internal/auth"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type deviceClaimTokenAdminCreateRequest struct {
+	OrganizationID  *string        `json:"organization_id"`
+	ClaimToken      *string        `json:"claim_token"`
+	Category        string         `json:"category" binding:"required"`
+	VideoCloudDevid string         `json:"video_cloud_devid" binding:"required"`
+	ActivityID      string         `json:"activity_id" binding:"required"`
+	ClipPublicKey   string         `json:"clip_public_key" binding:"required"`
+	ExpiresAt       time.Time      `json:"expires_at" binding:"required"`
+	Metadata        map[string]any `json:"metadata"`
+	Notes           *string        `json:"notes"`
+}
+
+type deviceClaimTokenResponse struct {
+	DeviceClaimToken model.DeviceClaimToken `json:"device_claim_token"`
+	ClaimToken       *string                `json:"claim_token,omitempty"`
+}
+
+type deviceClaimTokensResponse struct {
+	DeviceClaimTokens []model.DeviceClaimToken `json:"device_claim_tokens"`
+	Pagination        store.Page               `json:"pagination"`
+}
+
+func (s *Server) createDeviceClaimToken(c *gin.Context) {
+	var req deviceClaimTokenAdminCreateRequest
+	if !bindStrict(c, &req) {
+		return
+	}
+
+	category, ok := parseDeviceClaimTokenCategory(c, req.Category)
+	if !ok {
+		return
+	}
+	videoCloudDevid := strings.TrimSpace(req.VideoCloudDevid)
+	activityID := strings.TrimSpace(req.ActivityID)
+	clipPublicKey := strings.TrimSpace(req.ClipPublicKey)
+	if !requireNonBlank(c, "video_cloud_devid", videoCloudDevid) ||
+		!requireNonBlank(c, "activity_id", activityID) ||
+		!requireNonBlank(c, "clip_public_key", clipPublicKey) {
+		return
+	}
+	if !req.ExpiresAt.After(time.Now().UTC()) {
+		writeError(c, http.StatusBadRequest, "invalid_request", "expires_at must be in the future")
+		return
+	}
+
+	rawToken, generated, ok := adminClaimTokenRawValue(c, req.ClaimToken)
+	if !ok {
+		return
+	}
+	var responseRaw *string
+	if generated {
+		responseRaw = &rawToken
+	}
+
+	token, err := s.store.CreateDeviceClaimToken(c.Request.Context(), store.DeviceClaimTokenCreateInput{
+		OrganizationID:  trimPtr(req.OrganizationID),
+		CreatedBy:       stringPtr(currentUserID(c)),
+		TokenHash:       auth.HashToken(rawToken),
+		Category:        category,
+		VideoCloudDevid: videoCloudDevid,
+		ActivityID:      activityID,
+		ClipPublicKey:   clipPublicKey,
+		Metadata:        req.Metadata,
+		Notes:           trimPtr(req.Notes),
+		ExpiresAt:       req.ExpiresAt,
+		Now:             time.Now().UTC(),
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, deviceClaimTokenResponse{DeviceClaimToken: token, ClaimToken: responseRaw})
+}
+
+func (s *Server) listDeviceClaimTokens(c *gin.Context) {
+	limit, offset := pagination(c)
+	page, err := s.store.ListDeviceClaimTokens(c.Request.Context(), store.DeviceClaimTokenListFilter{
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, deviceClaimTokensResponse{DeviceClaimTokens: page.Tokens, Pagination: page.Page})
+}
+
+func (s *Server) getDeviceClaimToken(c *gin.Context) {
+	token, err := s.store.GetDeviceClaimToken(c.Request.Context(), c.Param("tokenId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, deviceClaimTokenResponse{DeviceClaimToken: token})
+}
+
+func (s *Server) revokeDeviceClaimToken(c *gin.Context) {
+	token, err := s.store.RevokeDeviceClaimToken(c.Request.Context(), c.Param("tokenId"), time.Now().UTC())
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, deviceClaimTokenResponse{DeviceClaimToken: token})
+}
+
+func parseDeviceClaimTokenCategory(c *gin.Context, raw string) (model.DeviceCategory, bool) {
+	switch model.DeviceCategory(strings.TrimSpace(raw)) {
+	case model.DeviceCategoryIPCamera:
+		return model.DeviceCategoryIPCamera, true
+	case model.DeviceCategoryMQTT:
+		return model.DeviceCategoryMQTT, true
+	case model.DeviceCategoryGeneric:
+		return model.DeviceCategoryGeneric, true
+	default:
+		writeError(c, http.StatusBadRequest, "invalid_request", "category must be ip_camera, mqtt_device, or generic")
+		return "", false
+	}
+}
+
+func adminClaimTokenRawValue(c *gin.Context, raw *string) (string, bool, bool) {
+	if raw != nil {
+		trimmed := strings.TrimSpace(*raw)
+		if trimmed == "" {
+			writeError(c, http.StatusBadRequest, "invalid_request", "claim_token must not be blank")
+			return "", false, false
+		}
+		return trimmed, false, true
+	}
+	first, err := newOpaqueID()
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "id_generation_failed", "Could not generate claim token")
+		return "", false, false
+	}
+	second, err := newOpaqueID()
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "id_generation_failed", "Could not generate claim token")
+		return "", false, false
+	}
+	return "claim_" + first + second, true, true
+}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -69,7 +69,7 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-		TRUNCATE auth_tokens, quota_raise_requests, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
+		TRUNCATE auth_tokens, quota_raise_requests, device_claims, device_claim_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
 		RESTART IDENTITY CASCADE
 	`); err != nil {
 		t.Fatal(err)
@@ -2205,6 +2205,115 @@ func TestIntegrationClaimResolveEndpoint(t *testing.T) {
 	assertErrorCode(t, unsupportedClaimRes, http.StatusBadRequest, "unsupported_device_category")
 }
 
+func TestIntegrationAdminDeviceClaimTokenWorkflow(t *testing.T) {
+	env := newIntegrationEnv(t)
+	ctx := context.Background()
+
+	admin := registerUser(t, env.router, "claim-token-platform-admin@example.com", "Claim Token Admin Org")
+	nonAdmin := registerUser(t, env.router, "claim-token-non-admin@example.com", "Claim Token Non Admin Org")
+	if _, err := env.db.Exec(ctx, `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	createPayload := map[string]any{
+		"organization_id":   nonAdmin.Organization.ID,
+		"category":          "ip_camera",
+		"video_cloud_devid": "admin-claim-video-1",
+		"activity_id":       "admin-claim-activity-1",
+		"clip_public_key":   "admin-claim-clip-key-1",
+		"expires_at":        time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		"metadata":          map[string]any{"batch": "generated"},
+		"notes":             "generated token",
+	}
+	nonAdminCreateRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens", createPayload, nonAdmin.Tokens.AccessToken)
+	if nonAdminCreateRes.Code != http.StatusForbidden {
+		t.Fatalf("expected non-admin create 403, got %d: %s", nonAdminCreateRes.Code, nonAdminCreateRes.Body.String())
+	}
+
+	createRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens", createPayload, admin.Tokens.AccessToken)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected claim token create 201, got %d: %s", createRes.Code, createRes.Body.String())
+	}
+	generated := decodeBody[deviceClaimTokenAdminBody](t, createRes)
+	if generated.DeviceClaimToken.ID == "" || generated.ClaimToken == nil || *generated.ClaimToken == "" {
+		t.Fatalf("expected generated raw token once, got %+v", generated)
+	}
+	if generated.DeviceClaimToken.CreatedBy == nil || *generated.DeviceClaimToken.CreatedBy != admin.User.ID {
+		t.Fatalf("expected created_by platform admin, got %+v", generated.DeviceClaimToken)
+	}
+
+	listRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens", nil, admin.Tokens.AccessToken)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d: %s", listRes.Code, listRes.Body.String())
+	}
+	listBody := decodeBody[deviceClaimTokensAdminBody](t, listRes)
+	if listBody.Pagination.Total != 1 || len(listBody.DeviceClaimTokens) != 1 {
+		t.Fatalf("expected one claim token in list, got %+v", listBody)
+	}
+
+	getRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens/"+generated.DeviceClaimToken.ID, nil, admin.Tokens.AccessToken)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("expected get 200, got %d: %s", getRes.Code, getRes.Body.String())
+	}
+	got := decodeBody[deviceClaimTokenAdminBody](t, getRes)
+	if got.ClaimToken != nil {
+		t.Fatalf("raw generated token must not be returned after create, got %+v", got)
+	}
+
+	resolveGeneratedRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+nonAdmin.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": *generated.ClaimToken,
+		"device_name": "Generated Camera",
+	}, nonAdmin.Tokens.AccessToken)
+	if resolveGeneratedRes.Code != http.StatusCreated {
+		t.Fatalf("expected generated token resolve 201, got %d: %s", resolveGeneratedRes.Code, resolveGeneratedRes.Body.String())
+	}
+
+	importedRaw := "imported-claim-token-secret"
+	importRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens", map[string]any{
+		"claim_token":       importedRaw,
+		"category":          "ip_camera",
+		"video_cloud_devid": "admin-claim-video-2",
+		"activity_id":       "admin-claim-activity-2",
+		"clip_public_key":   "admin-claim-clip-key-2",
+		"expires_at":        time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		"metadata":          map[string]any{"batch": "imported"},
+	}, admin.Tokens.AccessToken)
+	if importRes.Code != http.StatusCreated {
+		t.Fatalf("expected imported claim token create 201, got %d: %s", importRes.Code, importRes.Body.String())
+	}
+	imported := decodeBody[deviceClaimTokenAdminBody](t, importRes)
+	if imported.ClaimToken != nil {
+		t.Fatalf("imported raw token must not be echoed, got %+v", imported)
+	}
+
+	var rawTokenCount int
+	if err := env.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM device_claim_tokens
+		WHERE token_hash = $1 OR metadata::text LIKE '%' || $1 || '%' OR COALESCE(notes, '') LIKE '%' || $1 || '%'
+	`, importedRaw).Scan(&rawTokenCount); err != nil {
+		t.Fatal(err)
+	}
+	if rawTokenCount != 0 {
+		t.Fatal("raw imported claim token was persisted")
+	}
+
+	revokeRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens/"+imported.DeviceClaimToken.ID+"/revoke", nil, admin.Tokens.AccessToken)
+	if revokeRes.Code != http.StatusOK {
+		t.Fatalf("expected revoke 200, got %d: %s", revokeRes.Code, revokeRes.Body.String())
+	}
+	revoked := decodeBody[deviceClaimTokenAdminBody](t, revokeRes)
+	if revoked.DeviceClaimToken.RevokedAt == nil {
+		t.Fatalf("expected revoked_at, got %+v", revoked.DeviceClaimToken)
+	}
+
+	resolveRevokedRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+nonAdmin.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": importedRaw,
+		"device_name": "Revoked Camera",
+	}, nonAdmin.Tokens.AccessToken)
+	assertErrorCode(t, resolveRevokedRes, http.StatusNotFound, "invalid_claim_token")
+}
+
 func TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata(t *testing.T) {
 	env := newIntegrationEnv(t)
 
@@ -2457,6 +2566,24 @@ type claimResolveBody struct {
 		ActivityID      string `json:"activity_id"`
 		ClipPublicKey   string `json:"clip_public_key"`
 	} `json:"provision_input"`
+}
+
+type deviceClaimTokenAdminBody struct {
+	DeviceClaimToken struct {
+		ID              string     `json:"id"`
+		OrganizationID  *string    `json:"organization_id"`
+		CreatedBy       *string    `json:"created_by"`
+		VideoCloudDevid string     `json:"video_cloud_devid"`
+		RevokedAt       *time.Time `json:"revoked_at"`
+	} `json:"device_claim_token"`
+	ClaimToken *string `json:"claim_token"`
+}
+
+type deviceClaimTokensAdminBody struct {
+	DeviceClaimTokens []struct {
+		ID string `json:"id"`
+	} `json:"device_claim_tokens"`
+	Pagination paginationBody `json:"pagination"`
 }
 
 type registryOnlyProvisioningBody struct {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -124,6 +124,22 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
 		t.Fatal(err)
 	}
+	adminClaimTokenRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens", map[string]any{
+		"organization_id":   registered.Organization.ID,
+		"category":          "ip_camera",
+		"video_cloud_devid": "contract-admin-claim-video-1",
+		"activity_id":       "contract-admin-claim-activity-1",
+		"clip_public_key":   "contract-admin-claim-clip-key-1",
+		"expires_at":        time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339Nano),
+	}, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/device-claim-tokens", adminClaimTokenRes)
+	adminClaimTokenBody := decodeBody[deviceClaimTokenAdminBody](t, adminClaimTokenRes)
+	adminClaimTokensRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/admin/device-claim-tokens", adminClaimTokensRes)
+	adminClaimTokenGetRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID, nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID, adminClaimTokenGetRes)
+	adminClaimTokenRevokeRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID+"/revoke", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID+"/revoke", adminClaimTokenRevokeRes)
 	approveReqRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", approveReqRes)
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -40,13 +40,16 @@ type AuditEvent struct {
 type DeviceClaimToken struct {
 	ID              string         `json:"id"`
 	OrganizationID  *string        `json:"organization_id,omitempty"`
+	CreatedBy       *string        `json:"created_by,omitempty"`
 	Category        DeviceCategory `json:"category"`
 	VideoCloudDevid string         `json:"video_cloud_devid"`
 	ActivityID      string         `json:"activity_id"`
 	ClipPublicKey   string         `json:"clip_public_key"`
 	Metadata        map[string]any `json:"metadata"`
+	Notes           *string        `json:"notes,omitempty"`
 	ExpiresAt       time.Time      `json:"expires_at"`
 	ClaimedAt       *time.Time     `json:"claimed_at,omitempty"`
+	RevokedAt       *time.Time     `json:"revoked_at,omitempty"`
 	CreatedAt       time.Time      `json:"created_at"`
 	UpdatedAt       time.Time      `json:"updated_at"`
 }

--- a/internal/store/device_claims.go
+++ b/internal/store/device_claims.go
@@ -14,14 +14,21 @@ import (
 
 type DeviceClaimTokenCreateInput struct {
 	OrganizationID  *string
+	CreatedBy       *string
 	TokenHash       string
 	Category        model.DeviceCategory
 	VideoCloudDevid string
 	ActivityID      string
 	ClipPublicKey   string
 	Metadata        map[string]any
+	Notes           *string
 	ExpiresAt       time.Time
 	Now             time.Time
+}
+
+type DeviceClaimTokenListFilter struct {
+	Limit  int
+	Offset int
 }
 
 type DeviceClaimResolveInput struct {
@@ -56,23 +63,83 @@ func (s *Store) CreateDeviceClaimToken(ctx context.Context, in DeviceClaimTokenC
 	token, err := scanDeviceClaimToken(s.db.QueryRow(ctx, `
 		INSERT INTO device_claim_tokens (
 			organization_id,
+			created_by,
 			token_hash,
 			category,
 			video_cloud_devid,
 			activity_id,
 			clip_public_key,
 			metadata,
+			notes,
 			expires_at,
 			created_at,
 			updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
-		RETURNING id::text, organization_id::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, expires_at, claimed_at, created_at, updated_at
-	`, in.OrganizationID, in.TokenHash, in.Category, in.VideoCloudDevid, in.ActivityID, in.ClipPublicKey, metadata, in.ExpiresAt, now))
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $11)
+		RETURNING id::text, organization_id::text, created_by::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, notes, expires_at, claimed_at, revoked_at, created_at, updated_at
+	`, in.OrganizationID, in.CreatedBy, in.TokenHash, in.Category, in.VideoCloudDevid, in.ActivityID, in.ClipPublicKey, metadata, in.Notes, in.ExpiresAt, now))
 	if err != nil {
 		return model.DeviceClaimToken{}, err
 	}
 	return token, nil
+}
+
+func (s *Store) ListDeviceClaimTokens(ctx context.Context, in DeviceClaimTokenListFilter) (DeviceClaimTokenPage, error) {
+	var total int
+	if err := s.db.QueryRow(ctx, `SELECT count(*)::int FROM device_claim_tokens`).Scan(&total); err != nil {
+		return DeviceClaimTokenPage{}, err
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT id::text, organization_id::text, created_by::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, notes, expires_at, claimed_at, revoked_at, created_at, updated_at
+		FROM device_claim_tokens
+		ORDER BY created_at DESC
+		LIMIT $1 OFFSET $2
+	`, in.Limit, in.Offset)
+	if err != nil {
+		return DeviceClaimTokenPage{}, err
+	}
+	defer rows.Close()
+
+	tokens := []model.DeviceClaimToken{}
+	for rows.Next() {
+		token, err := scanDeviceClaimToken(rows)
+		if err != nil {
+			return DeviceClaimTokenPage{}, err
+		}
+		tokens = append(tokens, token)
+	}
+	if err := rows.Err(); err != nil {
+		return DeviceClaimTokenPage{}, err
+	}
+	return DeviceClaimTokenPage{Tokens: tokens, Page: Page{Limit: in.Limit, Offset: in.Offset, Total: total}}, nil
+}
+
+func (s *Store) GetDeviceClaimToken(ctx context.Context, tokenID string) (model.DeviceClaimToken, error) {
+	token, err := scanDeviceClaimToken(s.db.QueryRow(ctx, `
+		SELECT id::text, organization_id::text, created_by::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, notes, expires_at, claimed_at, revoked_at, created_at, updated_at
+		FROM device_claim_tokens
+		WHERE id = $1
+	`, tokenID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceClaimToken{}, ErrNotFound
+	}
+	return token, err
+}
+
+func (s *Store) RevokeDeviceClaimToken(ctx context.Context, tokenID string, now time.Time) (model.DeviceClaimToken, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	token, err := scanDeviceClaimToken(s.db.QueryRow(ctx, `
+		UPDATE device_claim_tokens
+		SET revoked_at = COALESCE(revoked_at, $2), updated_at = $2
+		WHERE id = $1
+		RETURNING id::text, organization_id::text, created_by::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, notes, expires_at, claimed_at, revoked_at, created_at, updated_at
+	`, tokenID, now))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.DeviceClaimToken{}, ErrNotFound
+	}
+	return token, err
 }
 
 func (s *Store) ResolveDeviceClaimToken(ctx context.Context, in DeviceClaimResolveInput) (DeviceClaimResolveResult, error) {
@@ -88,7 +155,7 @@ func (s *Store) ResolveDeviceClaimToken(ctx context.Context, in DeviceClaimResol
 	}
 
 	token, err := scanDeviceClaimToken(tx.QueryRow(ctx, `
-		SELECT id::text, organization_id::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, expires_at, claimed_at, created_at, updated_at
+		SELECT id::text, organization_id::text, created_by::text, category, video_cloud_devid, activity_id, clip_public_key, metadata, notes, expires_at, claimed_at, revoked_at, created_at, updated_at
 		FROM device_claim_tokens
 		WHERE token_hash = $1
 		FOR UPDATE
@@ -101,6 +168,9 @@ func (s *Store) ResolveDeviceClaimToken(ctx context.Context, in DeviceClaimResol
 	}
 	if token.ClaimedAt != nil {
 		return DeviceClaimResolveResult{}, ErrClaimAlreadyClaimed
+	}
+	if token.RevokedAt != nil {
+		return DeviceClaimResolveResult{}, ErrClaimRevoked
 	}
 	if !token.ExpiresAt.After(now) {
 		return DeviceClaimResolveResult{}, ErrClaimExpired
@@ -250,13 +320,16 @@ func scanDeviceClaimToken(row rowScanner) (model.DeviceClaimToken, error) {
 	err := row.Scan(
 		&token.ID,
 		&token.OrganizationID,
+		&token.CreatedBy,
 		&token.Category,
 		&token.VideoCloudDevid,
 		&token.ActivityID,
 		&token.ClipPublicKey,
 		&metadata,
+		&token.Notes,
 		&token.ExpiresAt,
 		&token.ClaimedAt,
+		&token.RevokedAt,
 		&token.CreatedAt,
 		&token.UpdatedAt,
 	)

--- a/internal/store/device_claims_integration_test.go
+++ b/internal/store/device_claims_integration_test.go
@@ -204,6 +204,78 @@ func TestResolveDeviceClaimTokenRejectsExpiredToken(t *testing.T) {
 	}
 }
 
+func TestDeviceClaimTokenAdminLifecycle(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "claim-admin-store@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Claim Admin Store Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	notes := "factory batch 7"
+	token, err := env.store.CreateDeviceClaimToken(ctx, DeviceClaimTokenCreateInput{
+		TokenHash:       "hashed-admin-token",
+		OrganizationID:  &registered.Organization.ID,
+		CreatedBy:       &registered.User.ID,
+		Category:        model.DeviceCategoryIPCamera,
+		VideoCloudDevid: "admin-video-device",
+		ActivityID:      "admin-activity",
+		ClipPublicKey:   "admin-clip-key",
+		Metadata:        map[string]any{"batch": "7"},
+		Notes:           &notes,
+		ExpiresAt:       now.Add(time.Hour),
+		Now:             now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.CreatedBy == nil || *token.CreatedBy != registered.User.ID {
+		t.Fatalf("expected created_by to be tracked, got %+v", token)
+	}
+	if token.Notes == nil || *token.Notes != notes {
+		t.Fatalf("expected notes to be tracked, got %+v", token)
+	}
+
+	listed, err := env.store.ListDeviceClaimTokens(ctx, DeviceClaimTokenListFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listed.Page.Total != 1 || len(listed.Tokens) != 1 || listed.Tokens[0].ID != token.ID {
+		t.Fatalf("expected token in list, got %+v", listed)
+	}
+
+	fetched, err := env.store.GetDeviceClaimToken(ctx, token.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != token.ID || fetched.VideoCloudDevid != "admin-video-device" {
+		t.Fatalf("unexpected fetched token: %+v", fetched)
+	}
+
+	revoked, err := env.store.RevokeDeviceClaimToken(ctx, token.ID, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revoked.RevokedAt == nil {
+		t.Fatalf("expected revoked_at, got %+v", revoked)
+	}
+
+	_, err = env.store.ResolveDeviceClaimToken(ctx, DeviceClaimResolveInput{
+		TokenHash:      "hashed-admin-token",
+		OrganizationID: registered.Organization.ID,
+		RequestedBy:    registered.User.ID,
+		DeviceName:     "Revoked Camera",
+		Now:            now.Add(2 * time.Minute),
+	})
+	if !errors.Is(err, ErrClaimRevoked) {
+		t.Fatalf("expected ErrClaimRevoked, got %v", err)
+	}
+}
+
 func TestResolveDeviceClaimTokenRejectsAlreadyClaimedToken(t *testing.T) {
 	env := newStoreIntegrationEnv(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,6 +22,7 @@ var (
 	ErrEvaluationQuotaExceeded  = errors.New("evaluation device quota exceeded")
 	ErrClaimExpired             = errors.New("claim token expired")
 	ErrClaimAlreadyClaimed      = errors.New("claim token already claimed")
+	ErrClaimRevoked             = errors.New("claim token revoked")
 	ErrClaimCrossOrganization   = errors.New("claim token belongs to another organization")
 	ErrClaimUnsupportedCategory = errors.New("claim token category is unsupported")
 )
@@ -63,6 +64,11 @@ type DeviceGroupPage struct {
 type DeviceTagPage struct {
 	Tags []model.DeviceTag
 	Page Page
+}
+
+type DeviceClaimTokenPage struct {
+	Tokens []model.DeviceClaimToken
+	Page   Page
 }
 
 type RegisterInput struct {

--- a/migrations/013_device_claim_token_admin.sql
+++ b/migrations/013_device_claim_token_admin.sql
@@ -1,0 +1,12 @@
+ALTER TABLE device_claim_tokens
+    ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS notes TEXT;
+
+DROP INDEX IF EXISTS device_claim_tokens_active_idx;
+CREATE INDEX IF NOT EXISTS device_claim_tokens_active_idx
+    ON device_claim_tokens (token_hash)
+    WHERE claimed_at IS NULL AND revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS device_claim_tokens_created_by_idx
+    ON device_claim_tokens (created_by, created_at DESC);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -409,6 +409,95 @@ paths:
           $ref: "#/components/responses/Error"
         "403":
           $ref: "#/components/responses/Error"
+  /v1/admin/device-claim-tokens:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Create or import a device Claim Token.
+      description: >
+        Platform-admin only. The server stores only a hash of the raw Claim
+        Token. When `claim_token` is omitted, the server generates a raw token
+        and returns it exactly once in the create response. Imported raw tokens
+        are never echoed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminDeviceClaimTokenCreateRequest"
+      responses:
+        "201":
+          description: Device Claim Token created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminDeviceClaimTokenResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+    get:
+      security:
+        - bearerAuth: []
+      summary: List device Claim Tokens.
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Device Claim Token list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminDeviceClaimTokensResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+  /v1/admin/device-claim-tokens/{tokenId}:
+    get:
+      security:
+        - bearerAuth: []
+      summary: Get a device Claim Token.
+      parameters:
+        - $ref: "#/components/parameters/TokenId"
+      responses:
+        "200":
+          description: Device Claim Token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminDeviceClaimTokenResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v1/admin/device-claim-tokens/{tokenId}/revoke:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Revoke a device Claim Token.
+      parameters:
+        - $ref: "#/components/parameters/TokenId"
+      responses:
+        "200":
+          description: Device Claim Token revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminDeviceClaimTokenResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
   /v1/orgs/{orgId}/members:
     get:
       security:
@@ -1129,6 +1218,13 @@ components:
       schema:
         type: string
         format: uuid
+    TokenId:
+      name: tokenId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     GroupId:
       name: groupId
       in: path
@@ -1384,6 +1480,57 @@ components:
           $ref: "#/components/schemas/Device"
         provision_input:
           $ref: "#/components/schemas/ClaimProvisionInput"
+    AdminDeviceClaimTokenCreateRequest:
+      type: object
+      required: [category, video_cloud_devid, activity_id, clip_public_key, expires_at]
+      additionalProperties: false
+      properties:
+        organization_id:
+          type: string
+          format: uuid
+          description: Optional organization scope; omitted tokens can be resolved by any organization until claimed.
+        claim_token:
+          type: string
+          minLength: 1
+          description: Optional imported raw Claim Token. Stored as a hash and never echoed.
+        category:
+          $ref: "#/components/schemas/DeviceCategory"
+        video_cloud_devid:
+          type: string
+          minLength: 1
+        activity_id:
+          type: string
+          minLength: 1
+        clip_public_key:
+          type: string
+          minLength: 1
+        expires_at:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties: true
+        notes:
+          type: string
+    AdminDeviceClaimTokenResponse:
+      type: object
+      required: [device_claim_token]
+      properties:
+        device_claim_token:
+          $ref: "#/components/schemas/DeviceClaimToken"
+        claim_token:
+          type: string
+          description: Present only when the server generated the raw token for this create response.
+    AdminDeviceClaimTokensResponse:
+      type: object
+      required: [device_claim_tokens, pagination]
+      properties:
+        device_claim_tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeviceClaimToken"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
     DeactivateDeviceRequest:
       type: object
       properties:
@@ -1869,6 +2016,47 @@ components:
     QuotaRaiseRequestStatus:
       type: string
       enum: [pending, approved, declined]
+    DeviceClaimToken:
+      type: object
+      required: [id, category, video_cloud_devid, activity_id, clip_public_key, metadata, expires_at, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        organization_id:
+          type: string
+          format: uuid
+        created_by:
+          type: string
+          format: uuid
+        category:
+          $ref: "#/components/schemas/DeviceCategory"
+        video_cloud_devid:
+          type: string
+        activity_id:
+          type: string
+        clip_public_key:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        notes:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+        claimed_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     DeviceOperationSummary:
       type: object
       required: [operation_id, correlation_id, message_id, device_id, operation_type, status, created_at, updated_at]


### PR DESCRIPTION
## Summary
- Add platform-admin APIs to create/import, list, get, and revoke device Claim Tokens
- Store only token hashes while returning generated raw tokens once in the create response
- Add revocation persistence and reject revoked tokens during claim resolve
- Update OpenAPI and API/store tests for admin workflow and raw-token non-persistence

Closes #97

## Tests
- `go test ./...`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable' go test ./internal/api ./internal/store`
