### PR TITLE
feat: add claim resolve retryability hints

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1158,24 +1158,28 @@ func writeStoreError(c *gin.Context, err error) {
 func writeClaimResolveError(c *gin.Context, err error) {
 	switch {
 	case errors.Is(err, store.ErrNotFound):
-		writeError(c, http.StatusNotFound, "invalid_claim_token", "Invalid claim token")
+		writeClaimError(c, http.StatusNotFound, "invalid_claim_token", "Invalid claim token", false, "scan_or_enter_a_valid_claim_token")
 	case errors.Is(err, store.ErrClaimExpired):
-		writeError(c, http.StatusBadRequest, "expired_claim_token", "Claim token has expired")
+		writeClaimError(c, http.StatusBadRequest, "expired_claim_token", "Claim token has expired", false, "request_new_claim_token")
 	case errors.Is(err, store.ErrClaimAlreadyClaimed):
-		writeError(c, http.StatusConflict, "already_claimed", "Claim token has already been claimed")
+		writeClaimError(c, http.StatusConflict, "already_claimed", "Claim token has already been claimed", false, "use_existing_device_or_contact_support")
 	case errors.Is(err, store.ErrClaimRevoked):
-		writeError(c, http.StatusNotFound, "invalid_claim_token", "Invalid claim token")
+		writeClaimError(c, http.StatusNotFound, "invalid_claim_token", "Invalid claim token", false, "scan_or_enter_a_valid_claim_token")
 	case errors.Is(err, store.ErrClaimCrossOrganization):
-		writeError(c, http.StatusForbidden, "forbidden", "Claim token does not belong to this organization")
+		writeClaimError(c, http.StatusForbidden, "forbidden", "Claim token does not belong to this organization", false, "switch_organization_or_contact_support")
 	case errors.Is(err, store.ErrClaimUnsupportedCategory):
-		writeError(c, http.StatusBadRequest, "unsupported_device_category", "Claim token device category is not supported")
+		writeClaimError(c, http.StatusBadRequest, "unsupported_device_category", "Claim token device category is not supported", false, "use_supported_device_category")
 	case errors.Is(err, store.ErrEvaluationQuotaExceeded):
-		writeError(c, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", "Evaluation device quota exceeded")
+		writeClaimError(c, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", "Evaluation device quota exceeded", false, "request_quota_raise_or_contact_admin")
 	case strings.Contains(err.Error(), "duplicate key"):
-		writeError(c, http.StatusConflict, "conflict", "Resource already exists")
+		writeClaimError(c, http.StatusConflict, "conflict", "Resource already exists", false, "retry_with_current_claim_state")
 	default:
-		writeError(c, http.StatusServiceUnavailable, "service_unavailable", "Claim resolve is temporarily unavailable")
+		writeClaimError(c, http.StatusServiceUnavailable, "service_unavailable", "Claim resolve is temporarily unavailable", true, "retry_later")
 	}
+}
+
+func writeClaimError(c *gin.Context, status int, code, message string, retryable bool, resolutionAction string) {
+	writeErrorWithFields(c, status, code, message, &retryable, &resolutionAction)
 }
 
 func writeAuthTokenStoreError(c *gin.Context, err error, message string) {
@@ -1187,5 +1191,16 @@ func writeAuthTokenStoreError(c *gin.Context, err error, message string) {
 }
 
 func writeError(c *gin.Context, status int, code, message string) {
-	c.JSON(status, gin.H{"error": gin.H{"code": code, "message": message}})
+	writeErrorWithFields(c, status, code, message, nil, nil)
+}
+
+func writeErrorWithFields(c *gin.Context, status int, code, message string, retryable *bool, resolutionAction *string) {
+	errBody := gin.H{"code": code, "message": message}
+	if retryable != nil {
+		errBody["retryable"] = *retryable
+	}
+	if resolutionAction != nil && strings.TrimSpace(*resolutionAction) != "" {
+		errBody["resolution_action"] = strings.TrimSpace(*resolutionAction)
+	}
+	c.JSON(status, gin.H{"error": errBody})
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -61,6 +61,66 @@ func TestHealthRoute(t *testing.T) {
 	}
 }
 
+func TestWriteClaimResolveErrorIncludesRetryability(t *testing.T) {
+	tests := []struct {
+		name             string
+		err              error
+		status           int
+		code             string
+		retryable        bool
+		resolutionAction string
+	}{
+		{
+			name:             "invalid token",
+			err:              store.ErrNotFound,
+			status:           http.StatusNotFound,
+			code:             "invalid_claim_token",
+			retryable:        false,
+			resolutionAction: "scan_or_enter_a_valid_claim_token",
+		},
+		{
+			name:             "quota exceeded",
+			err:              store.ErrEvaluationQuotaExceeded,
+			status:           http.StatusConflict,
+			code:             "EVALUATION_QUOTA_EXCEEDED",
+			retryable:        false,
+			resolutionAction: "request_quota_raise_or_contact_admin",
+		},
+		{
+			name:             "service unavailable",
+			err:              errors.New("temporary backend failure"),
+			status:           http.StatusServiceUnavailable,
+			code:             "service_unavailable",
+			retryable:        true,
+			resolutionAction: "retry_later",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			res := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(res)
+			writeClaimResolveError(c, tt.err)
+			if res.Code != tt.status {
+				t.Fatalf("expected status %d, got %d: %s", tt.status, res.Code, res.Body.String())
+			}
+			var body struct {
+				Error struct {
+					Code             string `json:"code"`
+					Retryable        bool   `json:"retryable"`
+					ResolutionAction string `json:"resolution_action"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v: %s", err, res.Body.String())
+			}
+			if body.Error.Code != tt.code || body.Error.Retryable != tt.retryable || body.Error.ResolutionAction != tt.resolutionAction {
+				t.Fatalf("unexpected error body: %+v", body.Error)
+			}
+		})
+	}
+}
+
 func TestAuthTokenDeliveryHook(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -2175,34 +2175,48 @@ func TestIntegrationClaimResolveEndpoint(t *testing.T) {
 		"claim_token": "missing-token",
 		"device_name": "Missing Camera",
 	}, owner.Tokens.AccessToken)
-	assertErrorCode(t, invalidClaimRes, http.StatusNotFound, "invalid_claim_token")
+	assertErrorDetails(t, invalidClaimRes, http.StatusNotFound, "invalid_claim_token", false, "scan_or_enter_a_valid_claim_token")
 
 	seedClaimToken("claim-token-expired", "claim-video-expired", time.Now().Add(-time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
 	expiredClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
 		"claim_token": "claim-token-expired",
 		"device_name": "Expired Camera",
 	}, owner.Tokens.AccessToken)
-	assertErrorCode(t, expiredClaimRes, http.StatusBadRequest, "expired_claim_token")
+	assertErrorDetails(t, expiredClaimRes, http.StatusBadRequest, "expired_claim_token", false, "request_new_claim_token")
 
 	alreadyClaimedRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
 		"claim_token": "claim-token-owner",
 		"device_name": "Front Door Again",
 	}, owner.Tokens.AccessToken)
-	assertErrorCode(t, alreadyClaimedRes, http.StatusConflict, "already_claimed")
+	assertErrorDetails(t, alreadyClaimedRes, http.StatusConflict, "already_claimed", false, "use_existing_device_or_contact_support")
 
 	seedClaimToken("claim-token-cross-org", "claim-video-cross-org", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
 	crossOrgClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+otherOwner.Organization.ID+"/devices/claim/resolve", map[string]any{
 		"claim_token": "claim-token-cross-org",
 		"device_name": "Cross Org Camera",
 	}, otherOwner.Tokens.AccessToken)
-	assertErrorCode(t, crossOrgClaimRes, http.StatusForbidden, "forbidden")
+	assertErrorDetails(t, crossOrgClaimRes, http.StatusForbidden, "forbidden", false, "switch_organization_or_contact_support")
 
 	seedClaimToken("claim-token-unsupported", "claim-video-unsupported", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryMQTT)
 	unsupportedClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
 		"claim_token": "claim-token-unsupported",
 		"device_name": "MQTT Device",
 	}, owner.Tokens.AccessToken)
-	assertErrorCode(t, unsupportedClaimRes, http.StatusBadRequest, "unsupported_device_category")
+	assertErrorDetails(t, unsupportedClaimRes, http.StatusBadRequest, "unsupported_device_category", false, "use_supported_device_category")
+
+	if _, err := env.db.Exec(ctx, `
+		UPDATE organizations
+		SET tier = 'evaluation', evaluation_device_quota = 1
+		WHERE id = $1
+	`, owner.Organization.ID); err != nil {
+		t.Fatal(err)
+	}
+	seedClaimToken("claim-token-quota", "claim-video-quota", time.Now().Add(time.Hour), &ownerOrgID, model.DeviceCategoryIPCamera)
+	quotaClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/claim/resolve", map[string]any{
+		"claim_token": "claim-token-quota",
+		"device_name": "Quota Camera",
+	}, owner.Tokens.AccessToken)
+	assertErrorDetails(t, quotaClaimRes, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", false, "request_quota_raise_or_contact_admin")
 }
 
 func TestIntegrationAdminDeviceClaimTokenWorkflow(t *testing.T) {
@@ -2793,6 +2807,32 @@ func assertErrorCode(t *testing.T, res *httptest.ResponseRecorder, status int, c
 	}
 	if body.Error.Code != code {
 		t.Fatalf("expected error code %q, got %q: %s", code, body.Error.Code, res.Body.String())
+	}
+}
+
+func assertErrorDetails(t *testing.T, res *httptest.ResponseRecorder, status int, code string, retryable bool, resolutionAction string) {
+	t.Helper()
+	if res.Code != status {
+		t.Fatalf("expected status %d, got %d: %s", status, res.Code, res.Body.String())
+	}
+	var body struct {
+		Error struct {
+			Code             string `json:"code"`
+			Retryable        bool   `json:"retryable"`
+			ResolutionAction string `json:"resolution_action"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error response: %v: %s", err, res.Body.String())
+	}
+	if body.Error.Code != code {
+		t.Fatalf("expected error code %q, got %q: %s", code, body.Error.Code, res.Body.String())
+	}
+	if body.Error.Retryable != retryable {
+		t.Fatalf("expected retryable %v, got %v: %s", retryable, body.Error.Retryable, res.Body.String())
+	}
+	if body.Error.ResolutionAction != resolutionAction {
+		t.Fatalf("expected resolution_action %q, got %q: %s", resolutionAction, body.Error.ResolutionAction, res.Body.String())
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1263,6 +1263,23 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            invalid_claim_token:
+              summary: Non-retryable Claim Token error.
+              value:
+                error:
+                  code: invalid_claim_token
+                  message: Invalid claim token
+                  retryable: false
+                  resolution_action: scan_or_enter_a_valid_claim_token
+            claim_service_unavailable:
+              summary: Retryable Claim Token service error.
+              value:
+                error:
+                  code: service_unavailable
+                  message: Claim resolve is temporarily unavailable
+                  retryable: true
+                  resolution_action: retry_later
   schemas:
     HealthResponse:
       type: object
@@ -2151,3 +2168,9 @@ components:
               type: string
             message:
               type: string
+            retryable:
+              type: boolean
+              description: Optional machine-readable hint for Claim Token resolve failures.
+            resolution_action:
+              type: string
+              description: Optional client action hint for Claim Token resolve failures.


### PR DESCRIPTION
## Summary
- Add retryable and resolution_action hints to Claim Token resolve error responses
- Cover invalid/expired/already-claimed/cross-org/unsupported/quota mappings and service_unavailable retryability
- Update OpenAPI error schema/examples for Claim Token clients

Closes #98

## Tests
- `go test ./...`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable' go test ./internal/api`
