### PR TITLE
feat: add readiness failure attribution

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -713,6 +713,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 		deactivationStatus *model.DeviceOperationStatus
 		want               model.DeviceReadinessState
 		wantProduct        model.ProductReadinessState
+		wantFailureLayer   string
 	}{
 		{
 			name: "accepted provisioning waits for activation",
@@ -734,6 +735,7 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			provisioningStatus: model.DeviceOperationStatusFailed,
 			want:               model.DeviceReadinessStateActivationFailed,
 			wantProduct:        model.ProductReadinessStateFailed,
+			wantFailureLayer:   "cloud_activation",
 		},
 		{
 			name: "activation succeeded but offline waits for transport",
@@ -764,6 +766,17 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			wantProduct:        model.ProductReadinessStateDeactivationPending,
 		},
 		{
+			name: "deactivation failure is attributed",
+			device: readinessDevice(model.DeviceStatusOffline, map[string]any{
+				model.DeviceMetadataVideoCloudActivationStatus: string(model.VideoCloudActivationStatusActivated),
+			}),
+			provisioningStatus: model.DeviceOperationStatusSucceeded,
+			deactivationStatus: operationStatusPtr(model.DeviceOperationStatusDeadLettered),
+			want:               model.DeviceReadinessStateDeactivationFailed,
+			wantProduct:        model.ProductReadinessStateFailed,
+			wantFailureLayer:   "deactivation",
+		},
+		{
 			name: "deactivation success is deactivated",
 			device: readinessDevice(model.DeviceStatusOffline, map[string]any{
 				model.DeviceMetadataVideoCloudActivationStatus: string(model.VideoCloudActivationStatusDeactivated),
@@ -787,14 +800,22 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			var latestDeactivation *model.DeviceOperation
 			if tt.deactivationStatus != nil {
 				latestDeactivation = &model.DeviceOperation{
+					OperationID:   "deactivate-op",
 					OperationType: model.DeviceOperationTypeDeactivate,
 					Status:        *tt.deactivationStatus,
+					ErrorCode:     stringPtr("deactivate_failed"),
+					ErrorMessage:  stringPtr("Deactivate failed"),
+					UpdatedAt:     time.Now().UTC(),
 				}
 			}
 
 			provisioningOperation := model.DeviceOperation{
+				OperationID:   "provision-op",
 				OperationType: model.DeviceOperationTypeProvision,
 				Status:        tt.provisioningStatus,
+				ErrorCode:     stringPtr("activation_failed"),
+				ErrorMessage:  stringPtr("Activation failed"),
+				UpdatedAt:     time.Now().UTC(),
 			}
 			got := readinessFromProjection(tt.device, &provisioningOperation, latestDeactivation)
 
@@ -811,6 +832,13 @@ func TestReadinessFromProjectionStates(t *testing.T) {
 			}
 			if tt.deactivationStatus != nil && (got.Sources.DeactivationOperationStatus == nil || *got.Sources.DeactivationOperationStatus != *tt.deactivationStatus) {
 				t.Fatalf("expected deactivation source status %s, got %+v", *tt.deactivationStatus, got.Sources.DeactivationOperationStatus)
+			}
+			if tt.wantFailureLayer == "" {
+				if got.Failure != nil {
+					t.Fatalf("did not expect failure attribution, got %+v", got.Failure)
+				}
+			} else if got.Failure == nil || got.Failure.FailedLayer != tt.wantFailureLayer || got.Failure.OperationID == nil {
+				t.Fatalf("expected %s failure attribution with operation id, got %+v", tt.wantFailureLayer, got.Failure)
 			}
 		})
 	}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1938,6 +1938,37 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 		*memberState.Readiness.Sources.VideoCloudActivationStatus != string(model.VideoCloudActivationStatusPending) {
 		t.Fatalf("expected readiness sources to identify pending lifecycle facts, got %+v", memberState.Readiness.Sources)
 	}
+	if memberState.Readiness.Failure != nil {
+		t.Fatalf("pending provisioning must not return failure attribution, got %+v", memberState.Readiness.Failure)
+	}
+
+	if _, err := env.db.Exec(context.Background(), `
+		UPDATE device_operations
+		SET status = 'failed',
+			error_code = 'video_activation_timeout',
+			error_message = 'Video activation timed out',
+			retryable = true,
+			completed_at = now(),
+			updated_at = now()
+		WHERE operation_id = 'provision-op-1'
+	`); err != nil {
+		t.Fatal(err)
+	}
+	failedStateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, member.Tokens.AccessToken)
+	if failedStateRes.Code != http.StatusOK {
+		t.Fatalf("expected failed provisioning state 200, got %d: %s", failedStateRes.Code, failedStateRes.Body.String())
+	}
+	failedState := decodeBody[provisioningBody](t, failedStateRes)
+	if failedState.Readiness.State != model.DeviceReadinessStateActivationFailed ||
+		failedState.Readiness.Failure == nil ||
+		failedState.Readiness.Failure.FailedLayer != "cloud_activation" ||
+		failedState.Readiness.Failure.SourceState != string(model.DeviceOperationStatusFailed) ||
+		!failedState.Readiness.Failure.Retryable ||
+		failedState.Readiness.Failure.ErrorCode != "video_activation_timeout" ||
+		failedState.Readiness.Failure.OperationID == nil ||
+		*failedState.Readiness.Failure.OperationID != "provision-op-1" {
+		t.Fatalf("expected cloud activation failure attribution, got %+v", failedState.Readiness)
+	}
 
 	pendingDevice, err := store.New(env.db).GetDevice(context.Background(), owner.Organization.ID, device.Device.ID)
 	if err != nil {
@@ -2402,6 +2433,34 @@ func TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata(t *testing.T) {
 	}
 	if deactivated.Operation.RequestedBy == nil || *deactivated.Operation.RequestedBy != admin.User.ID {
 		t.Fatalf("expected admin requester in operation, got %+v", deactivated.Operation)
+	}
+
+	if _, err := env.db.Exec(context.Background(), `
+		UPDATE device_operations
+		SET status = 'dead_lettered',
+			error_code = 'deactivate_dead_lettered',
+			error_message = 'Deactivate command exhausted retries',
+			retryable = false,
+			completed_at = now(),
+			updated_at = now()
+		WHERE operation_id = 'deactivate-op-1'
+	`); err != nil {
+		t.Fatal(err)
+	}
+	deactivateFailedStateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, admin.Tokens.AccessToken)
+	if deactivateFailedStateRes.Code != http.StatusOK {
+		t.Fatalf("expected failed deactivation state 200, got %d: %s", deactivateFailedStateRes.Code, deactivateFailedStateRes.Body.String())
+	}
+	deactivateFailedState := decodeBody[provisioningBody](t, deactivateFailedStateRes)
+	if deactivateFailedState.Readiness.State != model.DeviceReadinessStateDeactivationFailed ||
+		deactivateFailedState.Readiness.Failure == nil ||
+		deactivateFailedState.Readiness.Failure.FailedLayer != "deactivation" ||
+		deactivateFailedState.Readiness.Failure.SourceState != string(model.DeviceOperationStatusDeadLettered) ||
+		deactivateFailedState.Readiness.Failure.Retryable ||
+		deactivateFailedState.Readiness.Failure.ErrorCode != "deactivate_dead_lettered" ||
+		deactivateFailedState.Readiness.Failure.OperationID == nil ||
+		*deactivateFailedState.Readiness.Failure.OperationID != "deactivate-op-1" {
+		t.Fatalf("expected deactivation failure attribution, got %+v", deactivateFailedState.Readiness)
 	}
 
 	reusedDeactivateRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/deactivate", map[string]any{

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -80,6 +80,7 @@ type readinessResponse struct {
 	State        model.DeviceReadinessState  `json:"state"`
 	ProductState model.ProductReadinessState `json:"product_state"`
 	Sources      readinessSourcesResponse    `json:"sources"`
+	Failure      *readinessFailureResponse   `json:"failure,omitempty"`
 }
 
 type readinessSourcesResponse struct {
@@ -89,6 +90,16 @@ type readinessSourcesResponse struct {
 	VideoCloudActivationStatus  *string                      `json:"video_cloud_activation_status,omitempty"`
 	DeactivationOperationStatus *model.DeviceOperationStatus `json:"deactivation_operation_status,omitempty"`
 	VideoCloudLastError         any                          `json:"video_cloud_last_error,omitempty"`
+}
+
+type readinessFailureResponse struct {
+	FailedLayer  string     `json:"failed_layer"`
+	SourceState  string     `json:"source_state"`
+	Retryable    bool       `json:"retryable"`
+	ErrorCode    string     `json:"error_code"`
+	ErrorMessage string     `json:"error_message"`
+	OperationID  *string    `json:"operation_id,omitempty"`
+	OccurredAt   *time.Time `json:"occurred_at,omitempty"`
 }
 
 func (s *Server) provisionDevice(c *gin.Context) {
@@ -462,6 +473,77 @@ func readinessFromProjection(device model.Device, provisioningOperation *model.D
 		State:        readinessStateFromSources(sources),
 		ProductState: productReadinessStateFromSources(sources),
 		Sources:      sources,
+		Failure:      readinessFailureFromProjection(device, provisioningOperation, latestDeactivation),
+	}
+}
+
+func readinessFailureFromProjection(device model.Device, provisioningOperation *model.DeviceOperation, latestDeactivation *model.DeviceOperation) *readinessFailureResponse {
+	if latestDeactivation != nil && operationFailed(latestDeactivation.Status) {
+		return failureFromOperation("deactivation", *latestDeactivation)
+	}
+	if provisioningOperation != nil && operationFailed(provisioningOperation.Status) {
+		return failureFromOperation("cloud_activation", *provisioningOperation)
+	}
+	if lastError, ok := device.Metadata[model.DeviceMetadataVideoCloudLastError]; ok {
+		return failureFromMetadata(lastError, device.UpdatedAt)
+	}
+	return nil
+}
+
+func operationFailed(status model.DeviceOperationStatus) bool {
+	return status == model.DeviceOperationStatusFailed || status == model.DeviceOperationStatusDeadLettered
+}
+
+func failureFromOperation(layer string, operation model.DeviceOperation) *readinessFailureResponse {
+	retryable := false
+	if operation.Retryable != nil {
+		retryable = *operation.Retryable
+	}
+	errorCode := "operation_failed"
+	if operation.Status == model.DeviceOperationStatusDeadLettered {
+		errorCode = "dead_lettered"
+	}
+	if operation.ErrorCode != nil && strings.TrimSpace(*operation.ErrorCode) != "" {
+		errorCode = strings.TrimSpace(*operation.ErrorCode)
+	}
+	errorMessage := "Operation failed"
+	if operation.ErrorMessage != nil && strings.TrimSpace(*operation.ErrorMessage) != "" {
+		errorMessage = strings.TrimSpace(*operation.ErrorMessage)
+	}
+	occurredAt := operation.CompletedAt
+	if occurredAt == nil {
+		occurredAt = &operation.UpdatedAt
+	}
+	return &readinessFailureResponse{
+		FailedLayer:  layer,
+		SourceState:  string(operation.Status),
+		Retryable:    retryable,
+		ErrorCode:    errorCode,
+		ErrorMessage: errorMessage,
+		OperationID:  &operation.OperationID,
+		OccurredAt:   occurredAt,
+	}
+}
+
+func failureFromMetadata(lastError any, updatedAt time.Time) *readinessFailureResponse {
+	errorCode := "video_cloud_last_error"
+	errorMessage := "Projected video cloud error"
+	if values, ok := lastError.(map[string]any); ok {
+		if code, ok := metadataString(values, "code"); ok {
+			errorCode = code
+		}
+		if message, ok := metadataString(values, "message"); ok {
+			errorMessage = message
+		}
+	}
+	occurredAt := updatedAt
+	return &readinessFailureResponse{
+		FailedLayer:  "cloud_activation",
+		SourceState:  "video_cloud_last_error",
+		Retryable:    false,
+		ErrorCode:    errorCode,
+		ErrorMessage: errorMessage,
+		OccurredAt:   &occurredAt,
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1832,6 +1832,29 @@ components:
               type: object
               nullable: true
               additionalProperties: true
+        failure:
+          $ref: "#/components/schemas/DeviceReadinessFailure"
+    DeviceReadinessFailure:
+      type: object
+      required: [failed_layer, source_state, retryable, error_code, error_message]
+      properties:
+        failed_layer:
+          type: string
+          enum: [cloud_activation, deactivation]
+        source_state:
+          type: string
+          description: Operation status or local source fact that produced the failure.
+        retryable:
+          type: boolean
+        error_code:
+          type: string
+        error_message:
+          type: string
+        operation_id:
+          type: string
+        occurred_at:
+          type: string
+          format: date-time
     User:
       type: object
       required: [id, email, email_verified, signup_pending_verification, created_at, updated_at]


### PR DESCRIPTION
## Summary
- Add optional readiness.failure attribution for failed/dead-lettered provisioning and deactivation states
- Source failure layer, source state, retryability, error fields, operation id, and occurred_at from existing operation facts
- Update OpenAPI plus unit/integration coverage while keeping pending/registry-only states failure-free

Closes #99

## Tests
- `go test ./...`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable' go test ./internal/api`
