### PR TITLE
feat: add admin quota and audit visibility

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -253,6 +253,9 @@ func (s *Server) Router() *gin.Engine {
 	protected.GET("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.listDeviceClaimTokens)
 	protected.GET("/admin/device-claim-tokens/:tokenId", s.requirePlatformAdmin(), s.getDeviceClaimToken)
 	protected.POST("/admin/device-claim-tokens/:tokenId/revoke", s.requirePlatformAdmin(), s.revokeDeviceClaimToken)
+	protected.GET("/admin/quota-raise-requests", s.requirePlatformAdmin(), s.listAdminQuotaRaiseRequests)
+	protected.GET("/admin/quota-raise-requests/:requestId", s.requirePlatformAdmin(), s.getAdminQuotaRaiseRequest)
+	protected.GET("/admin/audit-events", s.requirePlatformAdmin(), s.listAdminAuditEvents)
 
 	return r
 }

--- a/internal/api/eval_tier.go
+++ b/internal/api/eval_tier.go
@@ -38,6 +38,16 @@ type quotaRaiseRequestResponse struct {
 	QuotaRaiseRequest model.QuotaRaiseRequest `json:"quota_raise_request"`
 }
 
+type quotaRaiseRequestsResponse struct {
+	QuotaRaiseRequests []model.QuotaRaiseRequest `json:"quota_raise_requests"`
+	Pagination         store.Page                `json:"pagination"`
+}
+
+type auditEventsResponse struct {
+	AuditEvents []model.AuditEvent `json:"audit_events"`
+	Pagination  store.Page         `json:"pagination"`
+}
+
 type quotaRaiseDecisionRequest struct {
 	ApprovedQuota  *int    `json:"approved_quota"`
 	DecisionReason *string `json:"decision_reason"`
@@ -197,6 +207,61 @@ func (s *Server) approveQuotaRaiseRequest(c *gin.Context) {
 
 func (s *Server) declineQuotaRaiseRequest(c *gin.Context) {
 	s.decideQuotaRaiseRequest(c, false)
+}
+
+func (s *Server) listAdminQuotaRaiseRequests(c *gin.Context) {
+	limit, offset := pagination(c)
+	status, ok := parseQuotaRaiseStatusFilter(c)
+	if !ok {
+		return
+	}
+	page, err := s.store.ListQuotaRaiseRequests(c.Request.Context(), store.QuotaRaiseRequestListFilter{
+		Status: status,
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, quotaRaiseRequestsResponse{QuotaRaiseRequests: page.Requests, Pagination: page.Page})
+}
+
+func (s *Server) getAdminQuotaRaiseRequest(c *gin.Context) {
+	request, err := s.store.GetQuotaRaiseRequest(c.Request.Context(), c.Param("requestId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, quotaRaiseRequestResponse{QuotaRaiseRequest: request})
+}
+
+func (s *Server) listAdminAuditEvents(c *gin.Context) {
+	limit, offset := pagination(c)
+	page, err := s.store.ListAuditEvents(c.Request.Context(), store.AuditEventListFilter{
+		EventType:   strings.TrimSpace(c.Query("event_type")),
+		SubjectType: strings.TrimSpace(c.Query("subject_type")),
+		Limit:       limit,
+		Offset:      offset,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, auditEventsResponse{AuditEvents: page.Events, Pagination: page.Page})
+}
+
+func parseQuotaRaiseStatusFilter(c *gin.Context) (model.QuotaRaiseRequestStatus, bool) {
+	status := model.QuotaRaiseRequestStatus(strings.TrimSpace(c.Query("status")))
+	switch status {
+	case "":
+		return "", true
+	case model.QuotaRaiseRequestStatusPending, model.QuotaRaiseRequestStatusApproved, model.QuotaRaiseRequestStatusDeclined:
+		return status, true
+	default:
+		writeError(c, http.StatusBadRequest, "invalid_request", "status must be pending, approved, or declined")
+		return "", false
+	}
 }
 
 func (s *Server) decideQuotaRaiseRequest(c *gin.Context, approved bool) {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -502,6 +502,26 @@ func TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow(t *testing.T) {
 	if _, err := env.db.Exec(context.Background(), `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
 		t.Fatal(err)
 	}
+	nonAdminListRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests", nil, loginBody.Tokens.AccessToken)
+	if nonAdminListRes.Code != http.StatusForbidden {
+		t.Fatalf("expected non-admin quota list 403, got %d: %s", nonAdminListRes.Code, nonAdminListRes.Body.String())
+	}
+	pendingListRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests?status=pending&limit=1&offset=0", nil, admin.Tokens.AccessToken)
+	if pendingListRes.Code != http.StatusOK {
+		t.Fatalf("expected pending quota list 200, got %d: %s", pendingListRes.Code, pendingListRes.Body.String())
+	}
+	pendingList := decodeBody[quotaRaiseRequestsBody](t, pendingListRes)
+	if pendingList.Pagination.Total != 1 || len(pendingList.QuotaRaiseRequests) != 1 || pendingList.QuotaRaiseRequests[0].ID != raiseReqBody.QuotaRaiseRequest.ID {
+		t.Fatalf("expected pending quota list to include request, got %+v", pendingList)
+	}
+	showReqRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID, nil, admin.Tokens.AccessToken)
+	if showReqRes.Code != http.StatusOK {
+		t.Fatalf("expected quota show 200, got %d: %s", showReqRes.Code, showReqRes.Body.String())
+	}
+	showReqBody := decodeBody[quotaRaiseRequestBody](t, showReqRes)
+	if showReqBody.QuotaRaiseRequest.ID != raiseReqBody.QuotaRaiseRequest.ID {
+		t.Fatalf("expected quota show to return request, got %+v", showReqBody)
+	}
 	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", map[string]any{
 		"approved_quota": 500,
 	}, admin.Tokens.AccessToken)
@@ -536,6 +556,36 @@ func TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow(t *testing.T) {
 	}
 	if declinedBody.Organization.EvaluationDeviceQuota != 200 {
 		t.Fatalf("expected decline to keep capped quota at 200, got %+v", declinedBody.Organization)
+	}
+
+	approvedListRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests?status=approved", nil, admin.Tokens.AccessToken)
+	if approvedListRes.Code != http.StatusOK {
+		t.Fatalf("expected approved quota list 200, got %d: %s", approvedListRes.Code, approvedListRes.Body.String())
+	}
+	approvedList := decodeBody[quotaRaiseRequestsBody](t, approvedListRes)
+	if approvedList.Pagination.Total != 1 || len(approvedList.QuotaRaiseRequests) != 1 || approvedList.QuotaRaiseRequests[0].Status != string(model.QuotaRaiseRequestStatusApproved) {
+		t.Fatalf("expected one approved quota request, got %+v", approvedList)
+	}
+	invalidStatusRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests?status=unknown", nil, admin.Tokens.AccessToken)
+	if invalidStatusRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid status 400, got %d: %s", invalidStatusRes.Code, invalidStatusRes.Body.String())
+	}
+
+	auditListRes := performJSON(env.router, http.MethodGet, "/v1/admin/audit-events?event_type=quota_raise_approved", nil, admin.Tokens.AccessToken)
+	if auditListRes.Code != http.StatusOK {
+		t.Fatalf("expected audit list 200, got %d: %s", auditListRes.Code, auditListRes.Body.String())
+	}
+	auditList := decodeBody[auditEventsBody](t, auditListRes)
+	if auditList.Pagination.Total != 1 || len(auditList.AuditEvents) != 1 || auditList.AuditEvents[0].EventType != "quota_raise_approved" {
+		t.Fatalf("expected one quota_raise_approved audit event, got %+v", auditList)
+	}
+	auditSubjectListRes := performJSON(env.router, http.MethodGet, "/v1/admin/audit-events?subject_type=quota_raise_request&limit=2", nil, admin.Tokens.AccessToken)
+	if auditSubjectListRes.Code != http.StatusOK {
+		t.Fatalf("expected audit subject list 200, got %d: %s", auditSubjectListRes.Code, auditSubjectListRes.Body.String())
+	}
+	auditSubjectList := decodeBody[auditEventsBody](t, auditSubjectListRes)
+	if auditSubjectList.Pagination.Total != 4 || len(auditSubjectList.AuditEvents) != 2 {
+		t.Fatalf("expected paginated quota_raise_request audit events, got %+v", auditSubjectList)
 	}
 
 	metricsRes := performJSON(env.router, http.MethodGet, "/v1/admin/metrics", nil, admin.Tokens.AccessToken)
@@ -2725,6 +2775,23 @@ type quotaRaiseRequestBody struct {
 		Status         string `json:"status"`
 		RequestedQuota int    `json:"requested_quota"`
 	} `json:"quota_raise_request"`
+}
+
+type quotaRaiseRequestsBody struct {
+	QuotaRaiseRequests []struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	} `json:"quota_raise_requests"`
+	Pagination paginationBody `json:"pagination"`
+}
+
+type auditEventsBody struct {
+	AuditEvents []struct {
+		ID          string `json:"id"`
+		EventType   string `json:"event_type"`
+		SubjectType string `json:"subject_type"`
+	} `json:"audit_events"`
+	Pagination paginationBody `json:"pagination"`
 }
 
 type quotaRaiseDecisionBody struct {

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -140,6 +140,12 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	contract.validate(t, http.MethodGet, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID, adminClaimTokenGetRes)
 	adminClaimTokenRevokeRes := performJSON(env.router, http.MethodPost, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID+"/revoke", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID+"/revoke", adminClaimTokenRevokeRes)
+	quotaRaiseListRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/admin/quota-raise-requests", quotaRaiseListRes)
+	quotaRaiseShowRes := performJSON(env.router, http.MethodGet, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID, nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID, quotaRaiseShowRes)
+	auditEventsRes := performJSON(env.router, http.MethodGet, "/v1/admin/audit-events", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/admin/audit-events", auditEventsRes)
 	approveReqRes := performJSON(env.router, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/quota-raise-requests/"+raiseReqBody.QuotaRaiseRequest.ID+"/approve", approveReqRes)
 

--- a/internal/store/audit.go
+++ b/internal/store/audit.go
@@ -18,6 +18,13 @@ type AuditEventInput struct {
 	Payload        map[string]any
 }
 
+type AuditEventListFilter struct {
+	EventType   string
+	SubjectType string
+	Limit       int
+	Offset      int
+}
+
 func createAuditEventTx(ctx context.Context, tx pgx.Tx, in AuditEventInput) error {
 	payload := []byte(`{}`)
 	if len(in.Payload) > 0 {
@@ -41,7 +48,16 @@ func createAuditEventTx(ctx context.Context, tx pgx.Tx, in AuditEventInput) erro
 	return err
 }
 
-func (s *Store) ListAuditEvents(ctx context.Context, limit, offset int) ([]model.AuditEvent, error) {
+func (s *Store) ListAuditEvents(ctx context.Context, in AuditEventListFilter) (AuditEventPage, error) {
+	var total int
+	if err := s.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM audit_events
+		WHERE ($1 = '' OR event_type = $1)
+			AND ($2 = '' OR subject_type = $2)
+	`, in.EventType, in.SubjectType).Scan(&total); err != nil {
+		return AuditEventPage{}, err
+	}
 	rows, err := s.db.Query(ctx, `
 		SELECT
 			id::text,
@@ -54,11 +70,13 @@ func (s *Store) ListAuditEvents(ctx context.Context, limit, offset int) ([]model
 			created_at,
 			updated_at
 		FROM audit_events
+		WHERE ($1 = '' OR event_type = $1)
+			AND ($2 = '' OR subject_type = $2)
 		ORDER BY created_at ASC
-		LIMIT $1 OFFSET $2
-	`, limit, offset)
+		LIMIT $3 OFFSET $4
+	`, in.EventType, in.SubjectType, in.Limit, in.Offset)
 	if err != nil {
-		return nil, err
+		return AuditEventPage{}, err
 	}
 	defer rows.Close()
 
@@ -77,15 +95,15 @@ func (s *Store) ListAuditEvents(ctx context.Context, limit, offset int) ([]model
 			&event.CreatedAt,
 			&event.UpdatedAt,
 		); err != nil {
-			return nil, err
+			return AuditEventPage{}, err
 		}
 		if err := json.Unmarshal(rawPayload, &event.Payload); err != nil {
-			return nil, err
+			return AuditEventPage{}, err
 		}
 		events = append(events, event)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return AuditEventPage{}, err
 	}
-	return events, nil
+	return AuditEventPage{Events: events, Page: Page{Limit: in.Limit, Offset: in.Offset, Total: total}}, nil
 }

--- a/internal/store/eval_tier.go
+++ b/internal/store/eval_tier.go
@@ -27,6 +27,12 @@ type QuotaRaiseDecisionInput struct {
 	Approved       bool
 }
 
+type QuotaRaiseRequestListFilter struct {
+	Status model.QuotaRaiseRequestStatus
+	Limit  int
+	Offset int
+}
+
 func (s *Store) IsPlatformAdmin(ctx context.Context, userID string) (bool, error) {
 	var platformAdmin bool
 	err := s.db.QueryRow(ctx, `
@@ -120,9 +126,7 @@ func (s *Store) CreateQuotaRaiseRequest(ctx context.Context, in QuotaRaiseReques
 }
 
 func (s *Store) GetQuotaRaiseRequest(ctx context.Context, requestID string) (model.QuotaRaiseRequest, error) {
-	var request model.QuotaRaiseRequest
-	var rawContactInfo []byte
-	err := s.db.QueryRow(ctx, `
+	request, err := scanQuotaRaiseRequest(s.db.QueryRow(ctx, `
 		SELECT
 			id::text,
 			organization_id::text,
@@ -138,7 +142,64 @@ func (s *Store) GetQuotaRaiseRequest(ctx context.Context, requestID string) (mod
 			decided_at
 		FROM quota_raise_requests
 		WHERE id = $1
-	`, requestID).Scan(
+	`, requestID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.QuotaRaiseRequest{}, ErrNotFound
+	}
+	return request, err
+}
+
+func (s *Store) ListQuotaRaiseRequests(ctx context.Context, in QuotaRaiseRequestListFilter) (QuotaRaiseRequestPage, error) {
+	var total int
+	if err := s.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM quota_raise_requests
+		WHERE ($1 = '' OR status = $1)
+	`, in.Status).Scan(&total); err != nil {
+		return QuotaRaiseRequestPage{}, err
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT
+			id::text,
+			organization_id::text,
+			requested_by::text,
+			requested_quota,
+			use_case,
+			contact_info,
+			status,
+			decided_by::text,
+			decision_reason,
+			created_at,
+			updated_at,
+			decided_at
+		FROM quota_raise_requests
+		WHERE ($1 = '' OR status = $1)
+		ORDER BY created_at DESC
+		LIMIT $2 OFFSET $3
+	`, in.Status, in.Limit, in.Offset)
+	if err != nil {
+		return QuotaRaiseRequestPage{}, err
+	}
+	defer rows.Close()
+
+	requests := []model.QuotaRaiseRequest{}
+	for rows.Next() {
+		request, err := scanQuotaRaiseRequest(rows)
+		if err != nil {
+			return QuotaRaiseRequestPage{}, err
+		}
+		requests = append(requests, request)
+	}
+	if err := rows.Err(); err != nil {
+		return QuotaRaiseRequestPage{}, err
+	}
+	return QuotaRaiseRequestPage{Requests: requests, Page: Page{Limit: in.Limit, Offset: in.Offset, Total: total}}, nil
+}
+
+func scanQuotaRaiseRequest(row rowScanner) (model.QuotaRaiseRequest, error) {
+	var request model.QuotaRaiseRequest
+	var rawContactInfo []byte
+	err := row.Scan(
 		&request.ID,
 		&request.OrganizationID,
 		&request.RequestedBy,
@@ -152,9 +213,6 @@ func (s *Store) GetQuotaRaiseRequest(ctx context.Context, requestID string) (mod
 		&request.UpdatedAt,
 		&request.DecidedAt,
 	)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return model.QuotaRaiseRequest{}, ErrNotFound
-	}
 	if err == nil {
 		if err := json.Unmarshal(rawContactInfo, &request.ContactInfo); err != nil {
 			return model.QuotaRaiseRequest{}, err

--- a/internal/store/metrics_integration_test.go
+++ b/internal/store/metrics_integration_test.go
@@ -79,10 +79,11 @@ func TestListAuditEventsReturnsRecordedLifecycleEvents(t *testing.T) {
 		t.Fatalf("expected declined request, got %+v", decision)
 	}
 
-	events, err := env.store.ListAuditEvents(ctx, 10, 0)
+	eventPage, err := env.store.ListAuditEvents(ctx, AuditEventListFilter{Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
+	events := eventPage.Events
 	if len(events) != 3 {
 		t.Fatalf("expected 3 audit events, got %d: %+v", len(events), events)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -71,6 +71,16 @@ type DeviceClaimTokenPage struct {
 	Page   Page
 }
 
+type QuotaRaiseRequestPage struct {
+	Requests []model.QuotaRaiseRequest
+	Page     Page
+}
+
+type AuditEventPage struct {
+	Events []model.AuditEvent
+	Page   Page
+}
+
 type RegisterInput struct {
 	Email                     string
 	PasswordHash              string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -333,6 +333,52 @@ paths:
           $ref: "#/components/responses/Error"
         "409":
           $ref: "#/components/responses/Error"
+  /v1/admin/quota-raise-requests:
+    get:
+      security:
+        - bearerAuth: []
+      summary: List quota-raise requests.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/QuotaRaiseRequestStatus"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Quota-raise request list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuotaRaiseRequestsResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+  /v1/admin/quota-raise-requests/{requestId}:
+    get:
+      security:
+        - bearerAuth: []
+      summary: Get a quota-raise request.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Quota-raise request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuotaRaiseRequestResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
   /v1/admin/quota-raise-requests/{requestId}/approve:
     post:
       security:
@@ -405,6 +451,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EvalTierMetricsResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+  /v1/admin/audit-events:
+    get:
+      security:
+        - bearerAuth: []
+      summary: List audit events.
+      parameters:
+        - name: event_type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: subject_type
+          in: query
+          required: false
+          schema:
+            type: string
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Audit event list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditEventsResponse"
         "401":
           $ref: "#/components/responses/Error"
         "403":
@@ -1648,6 +1723,16 @@ components:
       properties:
         quota_raise_request:
           $ref: "#/components/schemas/QuotaRaiseRequest"
+    QuotaRaiseRequestsResponse:
+      type: object
+      required: [quota_raise_requests, pagination]
+      properties:
+        quota_raise_requests:
+          type: array
+          items:
+            $ref: "#/components/schemas/QuotaRaiseRequest"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
     QuotaRaiseDecisionResponse:
       type: object
       required: [quota_raise_request, organization]
@@ -2056,6 +2141,44 @@ components:
     QuotaRaiseRequestStatus:
       type: string
       enum: [pending, approved, declined]
+    AuditEventsResponse:
+      type: object
+      required: [audit_events, pagination]
+      properties:
+        audit_events:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuditEvent"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+    AuditEvent:
+      type: object
+      required: [id, event_type, subject_type, subject_id, payload, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_type:
+          type: string
+        actor_user_id:
+          type: string
+          format: uuid
+        organization_id:
+          type: string
+          format: uuid
+        subject_type:
+          type: string
+        subject_id:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     DeviceClaimToken:
       type: object
       required: [id, category, video_cloud_devid, activity_id, clip_public_key, metadata, expires_at, created_at, updated_at]


### PR DESCRIPTION
## Summary
- Add platform-admin list/show endpoints for quota-raise requests
- Add platform-admin audit event listing with event_type and subject_type filters
- Add pagination/filter integration tests and OpenAPI contract coverage

Closes #101

## Tests
- `go test ./...`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable' go test ./internal/api ./internal/store`
