### PR TITLE
test: harden automated test quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 18 * * *"
 
 jobs:
   test:
@@ -54,6 +57,9 @@ jobs:
       - name: Run tests and generate report
         run: make test-report
 
+      - name: Run repeatability smoke
+        run: make test-repeat
+
       - name: Build packages
         run: go build ./...
 
@@ -65,3 +71,34 @@ jobs:
           path: |
             docs/TEST_REPORT.md
             reports/
+
+  deep-test:
+    runs-on: [self-hosted, account-manager-ci]
+    timeout-minutes: 20
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run race tests
+        run: make test-race
+
+      - name: Run fuzz smoke
+        run: make fuzz-smoke
+
+      - name: Upload deep test artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: deep-test-report
+          path: reports/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: tidy test integration-test test-report readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
+REPORT_DIR ?= reports
+UNIT_TEST_PACKAGES := ./internal/api ./internal/auth ./internal/broker ./internal/channel ./internal/config ./internal/database ./internal/openapi ./internal/readiness ./internal/store ./internal/worker/inbox ./internal/worker/outbox
+RACE_TEST_PACKAGES := ./internal/channel ./internal/broker ./internal/worker/... ./internal/auth ./internal/config ./internal/readiness
+FUZZ_SMOKE_TIME ?= 2s
+
+.PHONY: tidy test integration-test test-report test-race test-repeat fuzz-smoke readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
 
 tidy:
 	go mod tidy
@@ -11,6 +16,19 @@ integration-test:
 
 test-report:
 	./scripts/test-report.sh
+
+test-race:
+	@mkdir -p $(REPORT_DIR)
+	TEST_DATABASE_URL= go test -race $(RACE_TEST_PACKAGES) | tee $(REPORT_DIR)/test-race.txt
+
+test-repeat:
+	@mkdir -p $(REPORT_DIR)
+	TEST_DATABASE_URL= go test -shuffle=on -count=3 $(UNIT_TEST_PACKAGES) | tee $(REPORT_DIR)/test-repeat.txt
+
+fuzz-smoke:
+	@mkdir -p $(REPORT_DIR)
+	TEST_DATABASE_URL= go test ./internal/channel -run=^$$ -fuzz=FuzzEnvelopeStrictJSONAndValidation -fuzztime=$(FUZZ_SMOKE_TIME) | tee $(REPORT_DIR)/fuzz-smoke-channel.txt
+	TEST_DATABASE_URL= go test ./internal/api -run=^$$ -fuzz=FuzzBindStrictRequestShape -fuzztime=$(FUZZ_SMOKE_TIME) | tee $(REPORT_DIR)/fuzz-smoke-api.txt
 
 readiness-smoke:
 	go run ./cmd/readiness-smoke

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,18 +2,26 @@
 
 ## Test Layers
 
-The backend uses three test layers:
+The backend uses these test layers:
 
 | Layer | Command | Purpose |
 | --- | --- | --- |
 | Unit tests | `make test` | Fast package-level checks that do not require Postgres unless `TEST_DATABASE_URL` is set. |
 | Integration tests | `make integration-test` | Runs the API, store, migrations, auth, authorization, and device lifecycle tests against Postgres. |
 | Full report | `make test-report` | Runs formatting, integration-aware tests, coverage, build validation, and writes `docs/TEST_REPORT.md`. |
+| Race tests | `make test-race` | Runs Go's race detector against packages that do not need the shared integration database. |
+| Repeatability smoke | `make test-repeat` | Runs selected unit packages with `-shuffle=on -count=3` to catch order coupling and flakes. |
+| Fuzz smoke | `make fuzz-smoke` | Runs short seeded fuzz checks for strict JSON and contract parser behavior. |
 | Readiness smoke | `make readiness-smoke` | Emits a redacted private-cloud readiness artifact against a running deployment. |
 
 `make integration-test` and `make test-report` expect Postgres to be reachable at `TEST_DATABASE_URL`.
 For the default local setup, start it first with `make db-up`.
 `make test-report` now fails fast with that prerequisite message instead of overwriting `docs/TEST_REPORT.md` with a misleading low-coverage report.
+
+Integration tests share one Postgres database and use an advisory lock through
+`internal/testutil.LockIntegrationDatabase`. Do not make these tests parallel
+unless each test receives an isolated database/schema or the truncation strategy
+is changed first.
 
 ## Coverage Policy
 
@@ -30,6 +38,10 @@ COVERAGE_THRESHOLD=82.0 make test-report
 ```
 
 Coverage scope is `./internal/...` because command entry points under `cmd/*` are validated by `go build ./...`.
+
+The project intentionally keeps the minimum at `80.0%` while adding stronger
+correctness gates. Raising coverage should be a separate baseline change, not a
+side effect of feature work.
 
 ## Required Test Updates
 
@@ -57,6 +69,10 @@ Update tests whenever changing:
 | `reports/gofmt.txt` | Files that need formatting, empty when formatting passes. |
 | `reports/build.txt` | Build output, empty when build passes. |
 | `reports/test-cases.md` | Passing test case list extracted from Go JSON events. |
+| `reports/correctness-gates.md` | Required behavior gates and representative passing tests. |
+| `reports/test-repeat.txt` | `make test-repeat` output when that target runs. |
+| `reports/test-race.txt` | `make test-race` output when that target runs. |
+| `reports/fuzz-smoke-*.txt` | `make fuzz-smoke` output when that target runs. |
 
 `reports/` is ignored by git. Commit `docs/TEST_REPORT.md` when intentionally refreshing the maintained report.
 
@@ -87,7 +103,7 @@ Use `go run ./cmd/readiness-smoke -dry-run` for configuration-only validation.
 
 ## Correctness Versus Coverage
 
-Coverage only proves that statements executed. Correctness comes from assertions that check externally visible behavior and database state. The maintained report includes a correctness validation section that maps tests back to behavior groups from `docs/SPEC.md`.
+Coverage only proves that statements executed. Correctness comes from assertions that check externally visible behavior and database state. The maintained report includes correctness gates and a correctness validation section that map tests back to behavior groups from `docs/SPEC.md`.
 
 When adding a feature, do not rely on line coverage alone. Add assertions for:
 
@@ -97,6 +113,11 @@ When adding a feature, do not rely on line coverage alone. Add assertions for:
 - Token lifecycle behavior.
 - Outbox/inbox idempotency and retry/dead-letter behavior.
 - OpenAPI response compatibility when API payloads change.
+
+`make test-report` fails when a required correctness gate is missing a passing
+representative test. When renaming or replacing a representative test, update
+`scripts/test-report.sh` in the same change so the executable gate and the
+human-readable report stay aligned.
 
 For the current Claim Token and readiness scope, the maintained report must
 name representative tests for Claim Token persistence, Claim Token resolve API
@@ -114,10 +135,12 @@ When implementing the v2 provisioning/event-channel milestone, the maintained re
 | Deactivation API | Creating a deactivation operation writes the correct operation and outbox command. |
 | Authorization | `owner` and `admin` may initiate lifecycle operations; `member` may only read provisioning state. |
 | Device scoping | Cross-organization and missing devices are rejected without leaking resource existence. |
+| Authorization matrix | Owner/admin/member/platform-admin/outsider/disabled-user behavior is checked across device, claim, lifecycle, quota, and audit endpoints. |
 | Disabled devices | Disabled devices cannot be provisioned. |
 | Operation idempotency | Reusing `operation_id` with the same payload returns the existing operation. |
 | Operation conflicts | Reusing `operation_id` with a different payload returns `409 Conflict`. |
 | Message validation | Required envelope fields, supported `schema_version`, message type, stream, and partition key are validated. |
+| Parser fuzz seeds | Strict JSON, envelope, and API bind parser seeds cover malformed JSON, unknown fields, wrong stream/message type, wrong partition key, and multiple JSON values. |
 | Outbox worker | Publish success marks rows `published`; transient failure retries; exhausted failure becomes `dead_lettered`. |
 | Inbox worker | Duplicate `message_id` is ignored safely and does not repeat side effects. |
 | Projection idempotency | Replayed events with the same `operation_id` do not corrupt final state. |
@@ -132,6 +155,7 @@ When implementing the v2 provisioning/event-channel milestone, the maintained re
 | Registry-only readiness | `GET /provisioning` returns account-side readiness with nullable `operation` for enabled and disabled registry-only devices while preserving `404` for missing devices. |
 | Readiness failure attribution | Failed/dead-lettered provisioning and deactivation readiness responses include `readiness.failure` with layer, source state, retryability, error fields, operation id, and occurrence time. |
 | Admin visibility | Platform-admin quota request list/show and audit event list endpoints enforce admin-only access, pagination, and filters. |
+| Database schema invariants | Catalog tests verify critical tables, columns, constraints, indexes, token hashing columns, message dedupe keys, and audit/query filter indexes. |
 | OpenAPI contract validation | Claim resolve, registry-only provisioning-state, provisioned provisioning-state, provisioning, and deactivation responses validate against `openapi.yaml`. |
 | Broker adapters | Local broker tests are deterministic; Azure Event Hubs tests do not run unless explicitly configured. |
 
@@ -139,4 +163,24 @@ The v2 test report must distinguish coverage from correctness by naming represen
 
 ## CI
 
-GitHub Actions runs `make test-report` on pushes to `main` and on pull requests. The workflow starts a Postgres service, runs the report, builds all packages, and uploads the report artifacts.
+GitHub Actions runs `make test-report` and `make test-repeat` on pushes to
+`main` and on pull requests. The workflow starts a Postgres service, runs the
+report, builds all packages, and uploads the report artifacts.
+
+Scheduled/manual CI also runs the heavier `make test-race` and
+`make fuzz-smoke` targets. These are kept out of the normal PR critical path so
+developer feedback stays fast while still giving the project a recurring deeper
+signal.
+
+When CI fails:
+
+- Postgres unreachable: confirm the service health check and `TEST_DATABASE_URL`.
+- Migration or schema failure: inspect the first failing integration test and
+  compare the migration catalog checks with the intended schema.
+- OpenAPI drift: update `openapi.yaml` and the response contract test together.
+- Correctness gate failure: restore the missing representative test or update
+  the gate if the behavior moved to a renamed test.
+- Coverage regression: add meaningful assertions for the changed behavior
+  before considering a threshold override.
+- Race/repeat/fuzz failure: treat it as test isolation or parser correctness
+  evidence; do not paper over it by removing the target.

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -1,6 +1,6 @@
 # Test Report
 
-Generated: 2026-05-07T14:45:28Z
+Generated: 2026-05-07T15:52:31Z
 
 ## Summary
 
@@ -11,12 +11,13 @@ Generated: 2026-05-07T14:45:28Z
 | Tests | PASS |
 | Build | PASS |
 | Coverage threshold | PASS |
+| Correctness gates | PASS |
 
 ## Coverage
 
 | Metric | Value |
 | --- | --- |
-| Total statement coverage | 80.5% |
+| Total statement coverage | 80.6% |
 | Minimum required coverage | 80.0% |
 | Coverage mode | atomic |
 | Coverage scope | ./internal/... |
@@ -26,10 +27,41 @@ Generated: 2026-05-07T14:45:28Z
 | Metric | Value |
 | --- | --- |
 | Go packages | 20 |
-| Test cases started | 264 |
-| JSON pass events | 276 |
+| Test cases started | 308 |
+| JSON pass events | 320 |
 | JSON fail events | 0 |
 | Integration database | Postgres via TEST_DATABASE_URL |
+
+## Correctness Gates
+
+`make test-report` fails when any required behavior group below is missing a passing representative test. These gates protect the maintained report from drifting away from the executable suite.
+
+| Behavior group | Required test | Result |
+| --- | --- | --- |
+| Auth and sessions | `TestIntegrationRegisterLoginRefreshAndLogout` | PASS |
+| Disabled users | `TestIntegrationDisabledUserCannotUseExistingTokens` | PASS |
+| Organization access | `TestIntegrationOwnerCanUpdateOrganization` | PASS |
+| Member management | `TestIntegrationLastOwnerCannotBeRemovedOrDowngraded` | PASS |
+| Device lifecycle | `TestIntegrationRoleAuthorizationDeviceScopeAndSerialUniqueness` | PASS |
+| Authorization and tenancy matrix | `TestIntegrationAuthorizationAndTenancyMatrix` | PASS |
+| Provisioning API | `TestIntegrationProvisioningEndpoints` | PASS |
+| Claim Token persistence | `TestResolveDeviceClaimTokenCreatesDeviceAndClaim` | PASS |
+| Claim Token admin workflow | `TestDeviceClaimTokenAdminLifecycle` | PASS |
+| Claim resolve API | `TestIntegrationClaimResolveEndpoint` | PASS |
+| Deactivation API | `TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata` | PASS |
+| Message validation | `TestValidateRejectsEnvelopeContractMismatches` | PASS |
+| Contract parser fuzz seeds | `FuzzEnvelopeStrictJSONAndValidation` | PASS |
+| Strict API bind fuzz seeds | `FuzzBindStrictRequestShape` | PASS |
+| Outbox worker | `TestRunOnceMarksSuccessfulPublishes` | PASS |
+| Inbox worker | `TestRunOnceSkipsPreviouslyProcessedDuplicates` | PASS |
+| Projection idempotency and metadata merge | `TestApplyProjectionMetadataPreservesExistingFieldsAndClearsNil` | PASS |
+| Account readiness projection | `TestReadinessFromProjectionStates` | PASS |
+| Registry-only readiness | `TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness` | PASS |
+| Admin quota and audit visibility | `TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow` | PASS |
+| Broker adapters | `TestAzureEventHubsPublisherPublishesJSONRecord` | PASS |
+| Database invariants | `TestIntegrationDatabaseSchemaInvariants` | PASS |
+| OpenAPI contract | `TestIntegrationResponsesMatchOpenAPIContract` | PASS |
+| Configuration and maintenance | `TestLoadReadsEnvironmentAndDurations` | PASS |
 
 ## Correctness Validation
 
@@ -42,6 +74,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Organization access | Current-user organization listing, organization create/get/update, cross-organization organization access rejection. |
 | Member management | Owner add/update/remove/disable/enable member flows, admin/member forbidden paths, last-owner downgrade/remove/disable protection. |
 | Device lifecycle | Device create/list/get/update/status update/soft-delete, disabled-device read-only behavior, duplicate serial rejection, same serial in another org allowed. |
+| Authorization and tenancy matrix | `TestIntegrationAuthorizationAndTenancyMatrix` verifies owner/admin/member/platform-admin/outsider/disabled-user behavior across device reads/writes, claim resolve, provisioning, deactivation, quota visibility, audit visibility, and foreign organization access. |
 | Provisioning API | `TestIntegrationProvisioningEndpoints` verifies owner/admin initiation, member read-only access, raw claim-material rejection, transactional `device_operations` plus `device_message_outbox` writes, projected command payload shape, account-side readiness source facts, disabled-device rejection, and idempotent `operation_id` reuse. |
 | Claim Token persistence | `TestResolveDeviceClaimTokenCreatesDeviceAndClaim`, `TestResolveDeviceClaimTokenMatchesExistingDevice`, `TestResolveDeviceClaimTokenRejectsInvalidToken`, `TestResolveDeviceClaimTokenRejectsExpiredToken`, `TestResolveDeviceClaimTokenRejectsAlreadyClaimedToken`, `TestResolveDeviceClaimTokenRejectsCrossOrganizationToken`, and `TestResolveDeviceClaimTokenRejectsUnsupportedCategory` verify account-manager-owned Claim Token storage, raw-token non-persistence, hashed-token lookup, expiry, idempotent ownership matching, category policy, and organization boundaries. |
 | Claim Token admin workflow | `TestDeviceClaimTokenAdminLifecycle` and `TestIntegrationAdminDeviceClaimTokenWorkflow` verify platform-admin token creation/import/list/show/revoke, raw-token non-persistence, generated raw-token one-time return, platform-admin-only access, and revoked-token resolve rejection. |
@@ -53,6 +86,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Operation idempotency | Reusing the same lifecycle `operation_id` returns the existing operation and preserves the original outbox `message_id`, including retries after device disablement or missing live metadata. |
 | Operation conflicts | Reusing a lifecycle `operation_id` with conflicting provision activity data or deactivation reason returns `409 Conflict`. |
 | Message validation | Envelope fields, supported `schema_version`, message-type/stream/service pairing, lifecycle UUIDs, UTC timestamps, and `partition_key` validation for cross-service messages. |
+| Contract parser fuzz seeds | `FuzzEnvelopeStrictJSONAndValidation` and `FuzzBindStrictRequestShape` run seeded malformed JSON, unknown-field, wrong stream/message type, wrong partition key, and strict bind request-shape cases during normal `go test`. |
 | Outbox worker | `TestRunOnceMarksSuccessfulPublishes`, `TestRunOnceSchedulesTransientRetry`, `TestRunOnceDeadLettersExhaustedPublishFailures`, `TestRunOnceIgnoresStaleLeaseTransitionConflict`, and `TestRunOnceIgnoresConflictWhenRetryLosesToPublished` verify publish success, retry, dead-letter, and stale-lease conflict handling when another worker already won the publish race. |
 | Outbox publish race recovery | `TestRecordOutboxPublishTransitionRejectsStaleLease`, `TestRecordOutboxPublishTransitionLetsPublishedOutcomeOverrideLaterFailure`, and `TestRecordOutboxPublishTransitionPreservesInboxCompletedOperation` verify stale workers cannot roll back a published outbox row or overwrite an inbox-completed device operation. |
 | Inbox worker | `TestRunOnceSkipsPreviouslyProcessedDuplicates`, `TestRunOnceDeadLettersInvalidMessages`, and `TestRunOnceRetriesTransientProjectionFailures` verify message-id dedupe, dead-lettering, and transient projection retry behavior. |
@@ -65,12 +99,19 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Registry-only readiness | `TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness` verifies enabled and disabled registry-only devices return `200 OK`, `operation: null`, account-side readiness, `product_state=registered`, and preserve `404 Not Found` for truly missing devices. |
 | Admin quota and audit visibility | `TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow`, `TestIntegrationResponsesMatchOpenAPIContract`, and `TestListAuditEventsReturnsRecordedLifecycleEvents` verify platform-admin-only quota request list/show, audit event filters, pagination metadata, and existing approve/decline behavior. |
 | Broker adapters | `TestNewPublisherCreatesLogPublisherAndRejectsUnsupportedKinds`, `TestNewConsumerCreatesLogConsumerAndRejectsUnsupportedKinds`, `TestLogPublisherWritesEnvelopeJSON`, `TestLogConsumerReadsEnvelopeJSON`, `TestAzureEventHubsPublisherPublishesJSONRecord`, `TestAzureEventHubsConsumerReadsAcrossPartitions`, `TestAzureEventHubsConsumerAcknowledgesAndResumesFromCheckpoint`, and `TestOpenAzurePartitionsUsesStoredCheckpointWhenPresent` cover the deterministic local default adapter plus Azure Event Hubs publish/consume and durable checkpoint resume behavior without requiring live Azure. |
-| Database invariants | Idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, automatic `updated_at` triggers. |
+| Database invariants | `TestIntegrationDatabaseSchemaInvariants` plus existing migration tests verify idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, critical tables/columns/constraints/indexes, and automatic `updated_at` triggers. |
 | OpenAPI contract | `TestIntegrationResponsesMatchOpenAPIContract` plus OpenAPI schema validation cover representative Claim Token resolve/admin, registry-only provisioning-state with nullable `operation`, provisioned/failed provisioning-state, provisioning, deactivation, quota visibility, and audit visibility responses against `openapi.yaml`. |
 | Configuration and maintenance | `.env` loading, TTL parsing/fallbacks, worker-specific broker config defaults, required JWT secrets, and refresh-token cleanup behavior. |
 
 ## Executed Test Cases
 
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape/seed#0`
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape/seed#1`
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape/seed#2`
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape/seed#3`
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape/seed#4`
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape/seed#5`
+- `rtk_account_manager/internal/api`: `FuzzBindStrictRequestShape`
 - `rtk_account_manager/internal/api`: `TestAllowSignupEnforcesCaptchaDisposableAndRateLimit`
 - `rtk_account_manager/internal/api`: `TestAuthRecoveryValidationRejectsBlankTokens/reset_password_blank_token`
 - `rtk_account_manager/internal/api`: `TestAuthRecoveryValidationRejectsBlankTokens/verify_email_blank_token`
@@ -85,6 +126,34 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestHealthRoute`
 - `rtk_account_manager/internal/api`: `TestIntegrationAdminDeviceClaimTokenWorkflow`
 - `rtk_account_manager/internal/api`: `TestIntegrationAdminMetricsReportsEmptySnapshot`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/admin_can_create_device`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/admin_can_list_devices`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/admin_can_resolve_claim`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/admin_can_start_provision`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/disabled_user_cannot_list_own_devices`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/member_can_list_devices`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/member_cannot_create_device`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/member_cannot_list_quota_requests_as_platform_admin`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/member_cannot_resolve_claim`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/member_cannot_start_deactivation`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/member_cannot_start_provision`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/outsider_cannot_create_device_in_foreign_org`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/outsider_cannot_list_org_devices`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/outsider_cannot_resolve_claim_in_foreign_org`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/outsider_cannot_start_deactivation_in_foreign_org`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/outsider_cannot_start_provision_in_foreign_org`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_can_create_device`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_can_list_devices`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_can_resolve_claim`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_can_start_deactivation`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_can_start_provision`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_cannot_list_audit_events`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/owner_cannot_list_claim_tokens_as_platform_admin`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/platform_admin_can_list_audit_events`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/platform_admin_can_list_claim_tokens`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/platform_admin_can_list_quota_requests`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix/platform_admin_can_show_quota_request`
+- `rtk_account_manager/internal/api`: `TestIntegrationAuthorizationAndTenancyMatrix`
 - `rtk_account_manager/internal/api`: `TestIntegrationClaimResolveEndpoint`
 - `rtk_account_manager/internal/api`: `TestIntegrationCleanupRefreshTokensRemovesExpiredAndRevokedRows`
 - `rtk_account_manager/internal/api`: `TestIntegrationCurrentUserCanChangePassword`
@@ -179,6 +248,14 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/broker`: `TestOpenAzurePartitionsUsesStoredCheckpointWhenPresent`
 - `rtk_account_manager/internal/broker`: `TestTransientHelpersExposeWrappedError`
 - `rtk_account_manager/internal/broker`: `TestTransientMarker`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#0`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#1`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#2`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#3`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#4`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#5`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation/seed#6`
+- `rtk_account_manager/internal/channel`: `FuzzEnvelopeStrictJSONAndValidation`
 - `rtk_account_manager/internal/channel`: `TestDecodeStrictJSONRejectsMultipleJSONValues`
 - `rtk_account_manager/internal/channel`: `TestEnvelopeUnmarshalRejectsUnknownFields`
 - `rtk_account_manager/internal/channel`: `TestValidateAcceptsExplicitFalseRetryable/deactivate_failed`
@@ -274,6 +351,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestDeviceMessagePersistenceRejectsInvalidSchemaValues`
 - `rtk_account_manager/internal/store`: `TestEvaluationQuotaUsageUtilizationHandlesZeroAndNonZeroQuotas`
 - `rtk_account_manager/internal/store`: `TestGetOutboxMessageDetailIncludesOperation`
+- `rtk_account_manager/internal/store`: `TestIntegrationDatabaseSchemaInvariants`
 - `rtk_account_manager/internal/store`: `TestJSONHelpers`
 - `rtk_account_manager/internal/store`: `TestListAuditEventsReturnsRecordedLifecycleEvents`
 - `rtk_account_manager/internal/store`: `TestListInboxMessagesByStatusAndShowDetail`
@@ -357,6 +435,7 @@ go build ./...
 | reports/gofmt.txt | Files requiring gofmt, empty when formatting passes. |
 | reports/build.txt | Build output, empty when build passes. |
 | reports/test-cases.md | Markdown list of passing test cases captured from Go JSON events. |
+| reports/correctness-gates.md | Required correctness behavior gates and pass/fail status. |
 
 ## Coverage Gaps To Watch
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -553,6 +553,36 @@ func TestBindStrictRejectsUnknownFields(t *testing.T) {
 	}
 }
 
+func FuzzBindStrictRequestShape(f *testing.F) {
+	gin.SetMode(gin.TestMode)
+
+	type strictRequest struct {
+		Name string `json:"name"`
+	}
+
+	f.Add(`{"name":"camera"}`)
+	f.Add(`{"name":"camera","claim_material":{"serial_number":"CAM-001"}}`)
+	f.Add(`{"name":"camera"} {}`)
+	f.Add(`{"name":"   "}`)
+	f.Add(`not json`)
+	f.Add(`{"name":1}`)
+
+	f.Fuzz(func(t *testing.T, body string) {
+		recorder := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(recorder)
+		context.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+
+		var req strictRequest
+		ok := bindStrict(context, &req)
+		if ok && recorder.Code >= http.StatusBadRequest {
+			t.Fatalf("bindStrict accepted request but wrote error status %d: %s", recorder.Code, recorder.Body.String())
+		}
+		if !ok && recorder.Code < http.StatusBadRequest {
+			t.Fatalf("bindStrict rejected request without error status, code=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+	})
+}
+
 func TestRejectUnsupportedClaimMaterial(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2159,27 +2160,14 @@ func TestIntegrationClaimResolveEndpoint(t *testing.T) {
 	env := newIntegrationEnv(t)
 	ctx := context.Background()
 	claims := store.New(env.db)
+	fixtures := newAPIFixtureBuilder(t, env)
 
-	owner := registerUser(t, env.router, "claim-owner@example.com", "Claim Owner Org")
-	admin := registerUser(t, env.router, "claim-admin@example.com", "Claim Admin Org")
-	member := registerUser(t, env.router, "claim-member@example.com", "Claim Member Org")
-	otherOwner := registerUser(t, env.router, "claim-other@example.com", "Claim Other Org")
-
-	for _, membership := range []struct {
-		email string
-		role  string
-	}{
-		{email: "claim-admin@example.com", role: "admin"},
-		{email: "claim-member@example.com", role: "member"},
-	} {
-		res := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/members", map[string]any{
-			"email": membership.email,
-			"role":  membership.role,
-		}, owner.Tokens.AccessToken)
-		if res.Code != http.StatusCreated {
-			t.Fatalf("expected add member %s 201, got %d: %s", membership.email, res.Code, res.Body.String())
-		}
-	}
+	owner := fixtures.register("claim-owner")
+	admin := fixtures.register("claim-admin")
+	member := fixtures.register("claim-member")
+	otherOwner := fixtures.register("claim-other")
+	fixtures.addMember(owner, admin, "admin")
+	fixtures.addMember(owner, member, "member")
 
 	seedClaimToken := func(rawToken, videoDevid string, expiresAt time.Time, orgID *string, category model.DeviceCategory) {
 		t.Helper()
@@ -2298,6 +2286,117 @@ func TestIntegrationClaimResolveEndpoint(t *testing.T) {
 		"device_name": "Quota Camera",
 	}, owner.Tokens.AccessToken)
 	assertErrorDetails(t, quotaClaimRes, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", false, "request_quota_raise_or_contact_admin")
+}
+
+func TestIntegrationAuthorizationAndTenancyMatrix(t *testing.T) {
+	env := newIntegrationEnv(t)
+	ctx := context.Background()
+	fixtures := newAPIFixtureBuilder(t, env)
+
+	owner := fixtures.register("matrix-owner")
+	admin := fixtures.register("matrix-admin")
+	member := fixtures.register("matrix-member")
+	outsider := fixtures.register("matrix-outsider")
+	platformAdmin := fixtures.register("matrix-platform-admin")
+	disabled := fixtures.register("matrix-disabled")
+	fixtures.addMember(owner, admin, "admin")
+	fixtures.addMember(owner, member, "member")
+	if _, err := env.db.Exec(ctx, `UPDATE users SET platform_admin = true WHERE id = $1`, platformAdmin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, disabled.User.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	quotaRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/quota-raise-requests", map[string]any{
+		"requested_quota": 8,
+		"use_case":        "matrix",
+		"contact_info":    map[string]any{"email": "matrix@example.com"},
+	}, owner.Tokens.AccessToken)
+	if quotaRes.Code != http.StatusCreated {
+		t.Fatalf("fixture quota raise request failed with %d: %s", quotaRes.Code, quotaRes.Body.String())
+	}
+	quotaBody := decodeBody[quotaRaiseRequestBody](t, quotaRes)
+
+	projectedDevice := fixtures.createDevice(owner, "matrix-projected-device", "MATRIX-PROJECTED-001")
+	if _, err := store.New(env.db).ProjectDevice(ctx, owner.Organization.ID, projectedDevice.Device.ID, store.ProvisionSucceededProjection(channel.DeviceProvisionSucceededPayload{
+		OrgID:           owner.Organization.ID,
+		AccountDeviceID: projectedDevice.Device.ID,
+		VideoCloudDevid: "matrix-video-device",
+		ActivityID:      "matrix-activity",
+		ActivatedAt:     time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	type actor struct {
+		name  string
+		token string
+	}
+	actors := map[string]actor{
+		"owner":          {name: "owner", token: owner.Tokens.AccessToken},
+		"admin":          {name: "admin", token: admin.Tokens.AccessToken},
+		"member":         {name: "member", token: member.Tokens.AccessToken},
+		"outsider":       {name: "outsider", token: outsider.Tokens.AccessToken},
+		"platform_admin": {name: "platform_admin", token: platformAdmin.Tokens.AccessToken},
+		"disabled_user":  {name: "disabled_user", token: disabled.Tokens.AccessToken},
+	}
+
+	type matrixCase struct {
+		name       string
+		actor      string
+		method     string
+		path       string
+		body       func(string) any
+		wantStatus int
+	}
+	cases := []matrixCase{
+		{name: "owner can list devices", actor: "owner", method: http.MethodGet, path: "/v1/orgs/" + owner.Organization.ID + "/devices", wantStatus: http.StatusOK},
+		{name: "admin can list devices", actor: "admin", method: http.MethodGet, path: "/v1/orgs/" + owner.Organization.ID + "/devices", wantStatus: http.StatusOK},
+		{name: "member can list devices", actor: "member", method: http.MethodGet, path: "/v1/orgs/" + owner.Organization.ID + "/devices", wantStatus: http.StatusOK},
+		{name: "outsider cannot list org devices", actor: "outsider", method: http.MethodGet, path: "/v1/orgs/" + owner.Organization.ID + "/devices", wantStatus: http.StatusNotFound},
+		{name: "disabled user cannot list own devices", actor: "disabled_user", method: http.MethodGet, path: "/v1/orgs/" + disabled.Organization.ID + "/devices", wantStatus: http.StatusUnauthorized},
+		{name: "owner can create device", actor: "owner", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices", body: func(s string) any { return devicePayload("matrix-owner-device-"+s, "MATRIX-OWNER-"+s) }, wantStatus: http.StatusCreated},
+		{name: "admin can create device", actor: "admin", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices", body: func(s string) any { return devicePayload("matrix-admin-device-"+s, "MATRIX-ADMIN-"+s) }, wantStatus: http.StatusCreated},
+		{name: "member cannot create device", actor: "member", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices", body: func(s string) any { return devicePayload("matrix-member-device-"+s, "MATRIX-MEMBER-"+s) }, wantStatus: http.StatusForbidden},
+		{name: "outsider cannot create device in foreign org", actor: "outsider", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices", body: func(s string) any { return devicePayload("matrix-outsider-device-"+s, "MATRIX-OUTSIDER-"+s) }, wantStatus: http.StatusNotFound},
+		{name: "owner can resolve claim", actor: "owner", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/claim/resolve", body: fixtures.claimResolvePayload(owner.Organization.ID, "owner"), wantStatus: http.StatusCreated},
+		{name: "admin can resolve claim", actor: "admin", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/claim/resolve", body: fixtures.claimResolvePayload(owner.Organization.ID, "admin"), wantStatus: http.StatusCreated},
+		{name: "member cannot resolve claim", actor: "member", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/claim/resolve", body: fixtures.claimResolvePayload(owner.Organization.ID, "member"), wantStatus: http.StatusForbidden},
+		{name: "outsider cannot resolve claim in foreign org", actor: "outsider", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/claim/resolve", body: fixtures.claimResolvePayload(owner.Organization.ID, "outsider"), wantStatus: http.StatusNotFound},
+		{name: "owner can start provision", actor: "owner", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + fixtures.createDevice(owner, "matrix-provision-owner", "MATRIX-PROVISION-OWNER").Device.ID + "/provision", body: lifecycleProvisionPayload("matrix-provision-owner"), wantStatus: http.StatusCreated},
+		{name: "admin can start provision", actor: "admin", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + fixtures.createDevice(owner, "matrix-provision-admin", "MATRIX-PROVISION-ADMIN").Device.ID + "/provision", body: lifecycleProvisionPayload("matrix-provision-admin"), wantStatus: http.StatusCreated},
+		{name: "member cannot start provision", actor: "member", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + fixtures.createDevice(owner, "matrix-provision-member", "MATRIX-PROVISION-MEMBER").Device.ID + "/provision", body: lifecycleProvisionPayload("matrix-provision-member"), wantStatus: http.StatusForbidden},
+		{name: "outsider cannot start provision in foreign org", actor: "outsider", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + fixtures.createDevice(owner, "matrix-provision-outsider", "MATRIX-PROVISION-OUTSIDER").Device.ID + "/provision", body: lifecycleProvisionPayload("matrix-provision-outsider"), wantStatus: http.StatusNotFound},
+		{name: "owner can start deactivation", actor: "owner", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + projectedDevice.Device.ID + "/deactivate", body: lifecycleDeactivatePayload("matrix-deactivate-owner"), wantStatus: http.StatusCreated},
+		{name: "member cannot start deactivation", actor: "member", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + projectedDevice.Device.ID + "/deactivate", body: lifecycleDeactivatePayload("matrix-deactivate-member"), wantStatus: http.StatusForbidden},
+		{name: "outsider cannot start deactivation in foreign org", actor: "outsider", method: http.MethodPost, path: "/v1/orgs/" + owner.Organization.ID + "/devices/" + projectedDevice.Device.ID + "/deactivate", body: lifecycleDeactivatePayload("matrix-deactivate-outsider"), wantStatus: http.StatusNotFound},
+		{name: "platform admin can list claim tokens", actor: "platform_admin", method: http.MethodGet, path: "/v1/admin/device-claim-tokens", wantStatus: http.StatusOK},
+		{name: "owner cannot list claim tokens as platform admin", actor: "owner", method: http.MethodGet, path: "/v1/admin/device-claim-tokens", wantStatus: http.StatusForbidden},
+		{name: "platform admin can list quota requests", actor: "platform_admin", method: http.MethodGet, path: "/v1/admin/quota-raise-requests", wantStatus: http.StatusOK},
+		{name: "member cannot list quota requests as platform admin", actor: "member", method: http.MethodGet, path: "/v1/admin/quota-raise-requests", wantStatus: http.StatusForbidden},
+		{name: "platform admin can show quota request", actor: "platform_admin", method: http.MethodGet, path: "/v1/admin/quota-raise-requests/" + quotaBody.QuotaRaiseRequest.ID, wantStatus: http.StatusOK},
+		{name: "platform admin can list audit events", actor: "platform_admin", method: http.MethodGet, path: "/v1/admin/audit-events", wantStatus: http.StatusOK},
+		{name: "owner cannot list audit events", actor: "owner", method: http.MethodGet, path: "/v1/admin/audit-events", wantStatus: http.StatusForbidden},
+	}
+
+	for i, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			suffix := fmt.Sprintf("%02d", i)
+			var body any
+			if tc.body != nil {
+				body = tc.body(suffix)
+			}
+			res := performJSON(env.router, tc.method, tc.path, body, actors[tc.actor].token)
+			if res.Code != tc.wantStatus {
+				t.Fatalf("%s as %s expected %d, got %d: %s", tc.name, actors[tc.actor].name, tc.wantStatus, res.Code, res.Body.String())
+			}
+			if tc.wantStatus == http.StatusNotFound && bytes.Contains(res.Body.Bytes(), []byte(projectedDevice.Device.ID)) {
+				t.Fatalf("cross-tenant response leaked foreign device id: %s", res.Body.String())
+			}
+		})
+	}
 }
 
 func TestIntegrationAdminDeviceClaimTokenWorkflow(t *testing.T) {
@@ -2616,6 +2715,7 @@ func TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata(t *testing.T) {
 
 type registerBody struct {
 	User struct {
+		Email                     string `json:"email"`
 		ID                        string `json:"id"`
 		EmailVerified             bool   `json:"email_verified"`
 		SignupPendingVerification bool   `json:"signup_pending_verification"`
@@ -2862,6 +2962,84 @@ func registerUser(t *testing.T, router *gin.Engine, email, orgName string) regis
 		t.Fatalf("expected register 201, got %d: %s", res.Code, res.Body.String())
 	}
 	return decodeBody[registerBody](t, res)
+}
+
+type apiFixtureBuilder struct {
+	t   *testing.T
+	env integrationEnv
+}
+
+func newAPIFixtureBuilder(t *testing.T, env integrationEnv) apiFixtureBuilder {
+	t.Helper()
+	return apiFixtureBuilder{t: t, env: env}
+}
+
+func (b apiFixtureBuilder) register(slug string) registerBody {
+	b.t.Helper()
+	return registerUser(b.t, b.env.router, slug+"@example.com", slug+" Org")
+}
+
+func (b apiFixtureBuilder) addMember(owner registerBody, member registerBody, role string) {
+	b.t.Helper()
+	res := performJSON(b.env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/members", map[string]any{
+		"email": member.User.Email,
+		"role":  role,
+	}, owner.Tokens.AccessToken)
+	if res.Code != http.StatusCreated {
+		b.t.Fatalf("fixture add member %s as %s failed with %d: %s", member.User.Email, role, res.Code, res.Body.String())
+	}
+}
+
+func (b apiFixtureBuilder) createDevice(owner registerBody, name, serial string) deviceBody {
+	b.t.Helper()
+	res := performJSON(b.env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices", devicePayload(name, serial), owner.Tokens.AccessToken)
+	if res.Code != http.StatusCreated {
+		b.t.Fatalf("fixture create device %s/%s failed with %d: %s", name, serial, res.Code, res.Body.String())
+	}
+	return decodeBody[deviceBody](b.t, res)
+}
+
+func (b apiFixtureBuilder) claimResolvePayload(orgID, slug string) func(string) any {
+	b.t.Helper()
+	return func(suffix string) any {
+		rawToken := "claim-token-" + slug + "-" + suffix
+		videoDevid := "claim-video-" + slug + "-" + suffix
+		if _, err := store.New(b.env.db).CreateDeviceClaimToken(context.Background(), store.DeviceClaimTokenCreateInput{
+			OrganizationID:  &orgID,
+			TokenHash:       auth.HashToken(rawToken),
+			Category:        model.DeviceCategoryIPCamera,
+			VideoCloudDevid: videoDevid,
+			ActivityID:      "activity-" + videoDevid,
+			ClipPublicKey:   "clip-key-" + videoDevid,
+			ExpiresAt:       time.Now().UTC().Add(time.Hour),
+			Now:             time.Now().UTC(),
+		}); err != nil {
+			b.t.Fatalf("fixture seed claim token %s failed: %v", rawToken, err)
+		}
+		return map[string]any{
+			"claim_token": rawToken,
+			"device_name": "Claim Camera " + slug + " " + suffix,
+		}
+	}
+}
+
+func lifecycleProvisionPayload(slug string) func(string) any {
+	return func(suffix string) any {
+		return map[string]any{
+			"operation_id":      slug + "-op-" + suffix,
+			"video_cloud_devid": slug + "-video-" + suffix,
+			"activity_id":       slug + "-activity-" + suffix,
+			"clip_public_key":   slug + "-clip-key-" + suffix,
+		}
+	}
+}
+
+func lifecycleDeactivatePayload(slug string) func(string) any {
+	return func(suffix string) any {
+		return map[string]any{
+			"operation_id": slug + "-op-" + suffix,
+		}
+	}
 }
 
 func latestAuthToken(t *testing.T, sink *recordingAuthTokenSink, email, purpose string) string {

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -910,6 +910,43 @@ func TestDecodeStrictJSONRejectsMultipleJSONValues(t *testing.T) {
 	}
 }
 
+func FuzzEnvelopeStrictJSONAndValidation(f *testing.F) {
+	valid := validEnvelope(MessageTypeDeviceProvisionRequested, DeviceProvisionRequestedPayload{
+		OrgID:           testOrgID,
+		AccountDeviceID: testDeviceID,
+		VideoCloudDevid: "video-1",
+		ActivityID:      "activity-1",
+		ClipPublicKey:   "clip-key",
+		RequestedBy:     "user-1",
+	})
+	validJSON, err := json.Marshal(valid)
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(string(validJSON), StreamAccountVideoCommands)
+	f.Add(`{"message_id":"msg-1","correlation_id":"corr-1","operation_id":"op-1","source_service":"rtk_account_manager","target_service":"realtek_video_server","message_type":"DeviceProvisionRequested","schema_version":"1.0","partition_key":"22222222-2222-2222-2222-222222222222","occurred_at":"2026-04-28T12:00:00Z","payload":{},"unexpected":"value"}`, StreamAccountVideoCommands)
+	f.Add(string(validJSON)+` {}`, StreamAccountVideoCommands)
+	f.Add(strings.ReplaceAll(string(validJSON), "DeviceProvisionRequested", "UnknownMessage"), StreamAccountVideoCommands)
+	f.Add(strings.ReplaceAll(string(validJSON), StreamAccountVideoCommands, StreamVideoAccountEvents), StreamVideoAccountEvents)
+	f.Add(strings.ReplaceAll(string(validJSON), testDeviceID, "33333333-3333-3333-3333-333333333333"), StreamAccountVideoCommands)
+	f.Add(`not json`, StreamAccountVideoCommands)
+
+	f.Fuzz(func(t *testing.T, data string, stream string) {
+		var envelope Envelope
+		err := json.Unmarshal([]byte(data), &envelope)
+		if err != nil {
+			return
+		}
+		payload, err := envelope.ValidateAndDecode(stream)
+		if err != nil {
+			return
+		}
+		if payload.PartitionKey() == "" {
+			t.Fatalf("validated payload has empty partition key: %+v", payload)
+		}
+	})
+}
+
 func validEnvelope(messageType MessageType, payload any) Envelope {
 	raw, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/store/schema_integration_test.go
+++ b/internal/store/schema_integration_test.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+
+	requiredTables := []string{
+		"auth_tokens",
+		"audit_events",
+		"device_claim_tokens",
+		"device_claims",
+		"device_message_inbox",
+		"device_message_outbox",
+		"device_operations",
+		"quota_raise_requests",
+	}
+	for _, table := range requiredTables {
+		requireTable(t, ctx, env, table)
+	}
+
+	requiredColumns := map[string][]string{
+		"device_claim_tokens":  {"token_hash", "organization_id", "created_by", "revoked_at", "metadata", "notes", "expires_at", "claimed_at"},
+		"device_claims":        {"claim_token_id", "organization_id", "device_id", "claimed_by", "status", "provision_input"},
+		"device_message_inbox": {"message_id", "operation_id", "stream", "message_type", "schema_version", "partition_key", "status", "payload", "attempt_count"},
+		"device_message_outbox": {"message_id", "operation_id", "stream", "message_type", "schema_version", "partition_key", "status", "payload",
+			"attempt_count", "available_at"},
+		"audit_events":         {"event_type", "subject_type", "subject_id", "actor_user_id", "organization_id", "payload"},
+		"quota_raise_requests": {"organization_id", "requested_by", "requested_quota", "status", "contact_info", "decision_reason"},
+		"device_operations":    {"operation_id", "organization_id", "device_id", "operation_type", "status", "request_payload", "result_payload"},
+	}
+	for table, columns := range requiredColumns {
+		for _, column := range columns {
+			requireColumn(t, ctx, env, table, column)
+		}
+	}
+
+	requiredConstraints := []struct {
+		table string
+		name  string
+	}{
+		{table: "organizations", name: "organizations_name_not_blank"},
+		{table: "organizations", name: "organizations_tier_check"},
+		{table: "organizations", name: "organizations_evaluation_device_quota_check"},
+		{table: "users", name: "users_email_normalized"},
+		{table: "devices", name: "devices_name_not_blank"},
+		{table: "devices", name: "devices_category_check"},
+		{table: "devices", name: "devices_status_check"},
+		{table: "devices", name: "devices_org_id_unique"},
+		{table: "organization_members", name: "organization_members_role_check"},
+		{table: "device_operations", name: "device_operations_operation_id_key"},
+		{table: "device_operations", name: "device_operations_operation_type_check"},
+		{table: "device_operations", name: "device_operations_status_check"},
+		{table: "device_operations", name: "device_operations_org_device_fkey"},
+		{table: "device_message_outbox", name: "device_message_outbox_message_id_key"},
+		{table: "device_message_outbox", name: "device_message_outbox_stream_check"},
+		{table: "device_message_outbox", name: "device_message_outbox_message_type_check"},
+		{table: "device_message_inbox", name: "device_message_inbox_message_id_key"},
+		{table: "device_message_inbox", name: "device_message_inbox_stream_check"},
+		{table: "device_message_inbox", name: "device_message_inbox_message_type_check"},
+		{table: "device_claim_tokens", name: "device_claim_tokens_token_hash_key"},
+		{table: "device_claims", name: "device_claims_claim_token_id_key"},
+		{table: "device_claims", name: "device_claims_status_check"},
+		{table: "quota_raise_requests", name: "quota_raise_requests_requested_quota_check"},
+		{table: "quota_raise_requests", name: "quota_raise_requests_status_check"},
+	}
+	for _, constraint := range requiredConstraints {
+		requireConstraint(t, ctx, env, constraint.table, constraint.name)
+	}
+
+	requiredIndexes := []string{
+		"audit_events_event_type_idx",
+		"audit_events_subject_idx",
+		"device_claim_tokens_active_idx",
+		"device_claim_tokens_created_by_idx",
+		"device_claim_tokens_org_idx",
+		"device_claims_device_idx",
+		"device_claims_org_created_idx",
+		"device_message_inbox_operation_idx",
+		"device_message_inbox_status_received_idx",
+		"device_message_outbox_operation_idx",
+		"device_message_outbox_status_available_idx",
+		"device_operations_org_device_created_idx",
+		"device_operations_status_created_idx",
+		"devices_org_serial_unique",
+		"quota_raise_requests_org_status_idx",
+	}
+	for _, index := range requiredIndexes {
+		requireIndex(t, ctx, env, index)
+	}
+}
+
+func requireTable(t *testing.T, ctx context.Context, env storeIntegrationEnv, table string) {
+	t.Helper()
+	var exists bool
+	if err := env.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public' AND table_name = $1
+		)
+	`, table).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatalf("missing required table %s", table)
+	}
+}
+
+func requireColumn(t *testing.T, ctx context.Context, env storeIntegrationEnv, table, column string) {
+	t.Helper()
+	var exists bool
+	if err := env.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2
+		)
+	`, table, column).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatalf("missing required column %s.%s", table, column)
+	}
+}
+
+func requireConstraint(t *testing.T, ctx context.Context, env storeIntegrationEnv, table, constraint string) {
+	t.Helper()
+	var exists bool
+	if err := env.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_constraint c
+			JOIN pg_class t ON t.oid = c.conrelid
+			JOIN pg_namespace n ON n.oid = t.relnamespace
+			WHERE n.nspname = 'public' AND t.relname = $1 AND c.conname = $2
+		)
+	`, table, constraint).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatalf("missing required constraint %s on table %s", constraint, table)
+	}
+}
+
+func requireIndex(t *testing.T, ctx context.Context, env storeIntegrationEnv, index string) {
+	t.Helper()
+	var exists bool
+	if err := env.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_indexes
+			WHERE schemaname = 'public' AND indexname = $1
+		)
+	`, index).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatalf("missing required index %s", index)
+	}
+}

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -47,6 +47,7 @@ format_status=0
 test_status=0
 build_status=0
 coverage_status=0
+correctness_status=0
 
 require_postgres
 
@@ -78,11 +79,6 @@ if ! awk -v actual="$coverage_number" -v minimum="$COVERAGE_THRESHOLD" 'BEGIN { 
 	coverage_status=1
 fi
 
-overall_status="PASS"
-if [ "$format_status" -ne 0 ] || [ "$test_status" -ne 0 ] || [ "$build_status" -ne 0 ] || [ "$coverage_status" -ne 0 ]; then
-	overall_status="FAIL"
-fi
-
 package_count="$(go list ./... | wc -l | tr -d ' ')"
 test_count="$(grep -c '"Action":"run"' "$TEST_EVENTS" 2>/dev/null || true)"
 pass_count="$(grep -c '"Action":"pass"' "$TEST_EVENTS" 2>/dev/null || true)"
@@ -91,6 +87,55 @@ fail_count="$(grep -c '"Action":"fail"' "$TEST_EVENTS" 2>/dev/null || true)"
 grep '"Action":"pass".*"Test":' "$TEST_EVENTS" 2>/dev/null \
 	| sed -E 's/.*"Package":"([^"]+)","Test":"([^"]+)".*/- `\1`: `\2`/' \
 	| sort -u >"$TEST_CASES_MD" || true
+
+CORRECTNESS_GATES="$REPORT_DIR/correctness-gates.md"
+cat >"$CORRECTNESS_GATES" <<'EOF'
+| Behavior group | Required test | Result |
+| --- | --- | --- |
+EOF
+
+require_passed_test() {
+	local group test_name
+	group="$1"
+	test_name="$2"
+
+	if grep -Eq '"Action":"pass".*"Test":"'"$test_name"'("|/)' "$TEST_EVENTS" 2>/dev/null; then
+		printf '| %s | `%s` | PASS |\n' "$group" "$test_name" >>"$CORRECTNESS_GATES"
+	else
+		printf '| %s | `%s` | FAIL |\n' "$group" "$test_name" >>"$CORRECTNESS_GATES"
+		correctness_status=1
+	fi
+}
+
+require_passed_test "Auth and sessions" "TestIntegrationRegisterLoginRefreshAndLogout"
+require_passed_test "Disabled users" "TestIntegrationDisabledUserCannotUseExistingTokens"
+require_passed_test "Organization access" "TestIntegrationOwnerCanUpdateOrganization"
+require_passed_test "Member management" "TestIntegrationLastOwnerCannotBeRemovedOrDowngraded"
+require_passed_test "Device lifecycle" "TestIntegrationRoleAuthorizationDeviceScopeAndSerialUniqueness"
+require_passed_test "Authorization and tenancy matrix" "TestIntegrationAuthorizationAndTenancyMatrix"
+require_passed_test "Provisioning API" "TestIntegrationProvisioningEndpoints"
+require_passed_test "Claim Token persistence" "TestResolveDeviceClaimTokenCreatesDeviceAndClaim"
+require_passed_test "Claim Token admin workflow" "TestDeviceClaimTokenAdminLifecycle"
+require_passed_test "Claim resolve API" "TestIntegrationClaimResolveEndpoint"
+require_passed_test "Deactivation API" "TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata"
+require_passed_test "Message validation" "TestValidateRejectsEnvelopeContractMismatches"
+require_passed_test "Contract parser fuzz seeds" "FuzzEnvelopeStrictJSONAndValidation"
+require_passed_test "Strict API bind fuzz seeds" "FuzzBindStrictRequestShape"
+require_passed_test "Outbox worker" "TestRunOnceMarksSuccessfulPublishes"
+require_passed_test "Inbox worker" "TestRunOnceSkipsPreviouslyProcessedDuplicates"
+require_passed_test "Projection idempotency and metadata merge" "TestApplyProjectionMetadataPreservesExistingFieldsAndClearsNil"
+require_passed_test "Account readiness projection" "TestReadinessFromProjectionStates"
+require_passed_test "Registry-only readiness" "TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness"
+require_passed_test "Admin quota and audit visibility" "TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow"
+require_passed_test "Broker adapters" "TestAzureEventHubsPublisherPublishesJSONRecord"
+require_passed_test "Database invariants" "TestIntegrationDatabaseSchemaInvariants"
+require_passed_test "OpenAPI contract" "TestIntegrationResponsesMatchOpenAPIContract"
+require_passed_test "Configuration and maintenance" "TestLoadReadsEnvironmentAndDurations"
+
+overall_status="PASS"
+if [ "$format_status" -ne 0 ] || [ "$test_status" -ne 0 ] || [ "$build_status" -ne 0 ] || [ "$coverage_status" -ne 0 ] || [ "$correctness_status" -ne 0 ]; then
+	overall_status="FAIL"
+fi
 
 cat >"$REPORT_FILE" <<EOF
 # Test Report
@@ -106,6 +151,7 @@ Generated: $started_at
 | Tests | $(if [ "$test_status" -eq 0 ]; then echo PASS; else echo FAIL; fi) |
 | Build | $(if [ "$build_status" -eq 0 ]; then echo PASS; else echo FAIL; fi) |
 | Coverage threshold | $(if [ "$coverage_status" -eq 0 ]; then echo PASS; else echo FAIL; fi) |
+| Correctness gates | $(if [ "$correctness_status" -eq 0 ]; then echo PASS; else echo FAIL; fi) |
 
 ## Coverage
 
@@ -126,6 +172,12 @@ Generated: $started_at
 | JSON fail events | $fail_count |
 | Integration database | Postgres via TEST_DATABASE_URL |
 
+## Correctness Gates
+
+\`make test-report\` fails when any required behavior group below is missing a passing representative test. These gates protect the maintained report from drifting away from the executable suite.
+
+$(cat "$CORRECTNESS_GATES")
+
 ## Correctness Validation
 
 Coverage is only a signal that code executed. Correctness is validated by assertions in the automated tests. This report confirms the following behavior groups were exercised:
@@ -137,6 +189,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Organization access | Current-user organization listing, organization create/get/update, cross-organization organization access rejection. |
 | Member management | Owner add/update/remove/disable/enable member flows, admin/member forbidden paths, last-owner downgrade/remove/disable protection. |
 | Device lifecycle | Device create/list/get/update/status update/soft-delete, disabled-device read-only behavior, duplicate serial rejection, same serial in another org allowed. |
+| Authorization and tenancy matrix | \`TestIntegrationAuthorizationAndTenancyMatrix\` verifies owner/admin/member/platform-admin/outsider/disabled-user behavior across device reads/writes, claim resolve, provisioning, deactivation, quota visibility, audit visibility, and foreign organization access. |
 | Provisioning API | \`TestIntegrationProvisioningEndpoints\` verifies owner/admin initiation, member read-only access, raw claim-material rejection, transactional \`device_operations\` plus \`device_message_outbox\` writes, projected command payload shape, account-side readiness source facts, disabled-device rejection, and idempotent \`operation_id\` reuse. |
 | Claim Token persistence | \`TestResolveDeviceClaimTokenCreatesDeviceAndClaim\`, \`TestResolveDeviceClaimTokenMatchesExistingDevice\`, \`TestResolveDeviceClaimTokenRejectsInvalidToken\`, \`TestResolveDeviceClaimTokenRejectsExpiredToken\`, \`TestResolveDeviceClaimTokenRejectsAlreadyClaimedToken\`, \`TestResolveDeviceClaimTokenRejectsCrossOrganizationToken\`, and \`TestResolveDeviceClaimTokenRejectsUnsupportedCategory\` verify account-manager-owned Claim Token storage, raw-token non-persistence, hashed-token lookup, expiry, idempotent ownership matching, category policy, and organization boundaries. |
 | Claim Token admin workflow | \`TestDeviceClaimTokenAdminLifecycle\` and \`TestIntegrationAdminDeviceClaimTokenWorkflow\` verify platform-admin token creation/import/list/show/revoke, raw-token non-persistence, generated raw-token one-time return, platform-admin-only access, and revoked-token resolve rejection. |
@@ -148,6 +201,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Operation idempotency | Reusing the same lifecycle \`operation_id\` returns the existing operation and preserves the original outbox \`message_id\`, including retries after device disablement or missing live metadata. |
 | Operation conflicts | Reusing a lifecycle \`operation_id\` with conflicting provision activity data or deactivation reason returns \`409 Conflict\`. |
 | Message validation | Envelope fields, supported \`schema_version\`, message-type/stream/service pairing, lifecycle UUIDs, UTC timestamps, and \`partition_key\` validation for cross-service messages. |
+| Contract parser fuzz seeds | \`FuzzEnvelopeStrictJSONAndValidation\` and \`FuzzBindStrictRequestShape\` run seeded malformed JSON, unknown-field, wrong stream/message type, wrong partition key, and strict bind request-shape cases during normal \`go test\`. |
 | Outbox worker | \`TestRunOnceMarksSuccessfulPublishes\`, \`TestRunOnceSchedulesTransientRetry\`, \`TestRunOnceDeadLettersExhaustedPublishFailures\`, \`TestRunOnceIgnoresStaleLeaseTransitionConflict\`, and \`TestRunOnceIgnoresConflictWhenRetryLosesToPublished\` verify publish success, retry, dead-letter, and stale-lease conflict handling when another worker already won the publish race. |
 | Outbox publish race recovery | \`TestRecordOutboxPublishTransitionRejectsStaleLease\`, \`TestRecordOutboxPublishTransitionLetsPublishedOutcomeOverrideLaterFailure\`, and \`TestRecordOutboxPublishTransitionPreservesInboxCompletedOperation\` verify stale workers cannot roll back a published outbox row or overwrite an inbox-completed device operation. |
 | Inbox worker | \`TestRunOnceSkipsPreviouslyProcessedDuplicates\`, \`TestRunOnceDeadLettersInvalidMessages\`, and \`TestRunOnceRetriesTransientProjectionFailures\` verify message-id dedupe, dead-lettering, and transient projection retry behavior. |
@@ -160,7 +214,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Registry-only readiness | \`TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness\` verifies enabled and disabled registry-only devices return \`200 OK\`, \`operation: null\`, account-side readiness, \`product_state=registered\`, and preserve \`404 Not Found\` for truly missing devices. |
 | Admin quota and audit visibility | \`TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow\`, \`TestIntegrationResponsesMatchOpenAPIContract\`, and \`TestListAuditEventsReturnsRecordedLifecycleEvents\` verify platform-admin-only quota request list/show, audit event filters, pagination metadata, and existing approve/decline behavior. |
 | Broker adapters | \`TestNewPublisherCreatesLogPublisherAndRejectsUnsupportedKinds\`, \`TestNewConsumerCreatesLogConsumerAndRejectsUnsupportedKinds\`, \`TestLogPublisherWritesEnvelopeJSON\`, \`TestLogConsumerReadsEnvelopeJSON\`, \`TestAzureEventHubsPublisherPublishesJSONRecord\`, \`TestAzureEventHubsConsumerReadsAcrossPartitions\`, \`TestAzureEventHubsConsumerAcknowledgesAndResumesFromCheckpoint\`, and \`TestOpenAzurePartitionsUsesStoredCheckpointWhenPresent\` cover the deterministic local default adapter plus Azure Event Hubs publish/consume and durable checkpoint resume behavior without requiring live Azure. |
-| Database invariants | Idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, automatic \`updated_at\` triggers. |
+| Database invariants | \`TestIntegrationDatabaseSchemaInvariants\` plus existing migration tests verify idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, critical tables/columns/constraints/indexes, and automatic \`updated_at\` triggers. |
 | OpenAPI contract | \`TestIntegrationResponsesMatchOpenAPIContract\` plus OpenAPI schema validation cover representative Claim Token resolve/admin, registry-only provisioning-state with nullable \`operation\`, provisioned/failed provisioning-state, provisioning, deactivation, quota visibility, and audit visibility responses against \`openapi.yaml\`. |
 | Configuration and maintenance | \`.env\` loading, TTL parsing/fallbacks, worker-specific broker config defaults, required JWT secrets, and refresh-token cleanup behavior. |
 
@@ -189,6 +243,7 @@ go build ./...
 | $FORMAT_OUT | Files requiring gofmt, empty when formatting passes. |
 | $BUILD_OUT | Build output, empty when build passes. |
 | $TEST_CASES_MD | Markdown list of passing test cases captured from Go JSON events. |
+| $CORRECTNESS_GATES | Required correctness behavior gates and pass/fail status. |
 
 ## Coverage Gaps To Watch
 


### PR DESCRIPTION
## Summary
- add deterministic API fixture helpers and an authorization/tenancy matrix covering devices, claim resolve, lifecycle, quota, audit, platform-admin, outsider, and disabled-user cases
- add schema invariant integration tests and seeded fuzz/property tests for strict JSON and channel/API parser behavior
- add `test-race`, `test-repeat`, and `fuzz-smoke` targets, PR repeatability CI, scheduled/manual deep-test CI, and executable correctness gates in `make test-report`
- update `docs/TESTING.md` and refresh `docs/TEST_REPORT.md`

Closes #110
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116

## Tests
- `go test ./internal/api ./internal/channel ./internal/store`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable' go test ./internal/store -run TestIntegrationDatabaseSchemaInvariants -count=1`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:5432/rtk_account_manager?sslmode=disable' go test ./internal/api -run TestIntegrationAuthorizationAndTenancyMatrix -count=1`
- `make test-repeat`
- `make fuzz-smoke FUZZ_SMOKE_TIME=1s`
- `make test-report`
- `make test-race`
- `git diff --check`
