### PR TITLE
Align provisioning docs with video device credentials

### DIFF
--- a/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
+++ b/docs/PROVISIONING_AND_EVENT_CHANNEL_PLAN.md
@@ -289,6 +289,13 @@ Rules:
 - Device must exist in the organization.
 - Disabled devices cannot be provisioned.
 - Accepting provisioning immediately exposes pending `video_cloud_devid`, `video_cloud_activity_id`, `video_cloud_clip_public_key`, and `video_cloud_activation_status=pending` in projected device metadata.
+- Account-manager device categories such as `ip_camera`, `mqtt_device`, and
+  `generic` are product registry categories, not video-cloud credential scope
+  names.
+- Any category that maps to `video_cloud_devid` follows the shared video-cloud
+  device-bound credential contract. Account manager initiates lifecycle
+  operations and projects metadata; it does not issue or renew video-cloud
+  device tokens or certificates.
 - Duplicate `operation_id` with the same payload returns the existing operation.
 - Duplicate `operation_id` with a conflicting payload returns `409 Conflict`.
 - The API must not directly call Realtek video server.
@@ -443,8 +450,8 @@ Contract rules:
   projected `video_cloud_*` metadata, and projected account-side
   `online|offline` status.
 - Realtek video server or the video-side integration layer owns token issuance,
-  video-side bootstrap prerequisites, and transport/session readiness inputs
-  that do not live in account-manager state.
+  video-side bootstrap prerequisites, device-bound credentials, and
+  transport/session readiness inputs that do not live in account-manager state.
 - `GET /provisioning` is the account-side lifecycle and readiness projection
   surface; it is not a unified product-readiness endpoint.
 - Its `readiness.sources` object identifies the local source facts behind the
@@ -477,8 +484,8 @@ Failure handling:
 
 - Activation failure must stay visible through operation error fields and
   projected metadata.
-- Missing token/bootstrap prerequisites after activation must surface as
-  post-activation readiness gaps, not as fake activation success.
+- Missing device-bound token/bootstrap prerequisites after activation must
+  surface as post-activation readiness gaps, not as fake activation success.
 - `status=online` alone does not prove full provisioning readiness.
 
 ## Phase 10: Testing And Reporting

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -30,6 +30,9 @@ Provisioning and account/video event-channel integration are the v2 surface impl
   - `ip_camera`
   - `mqtt_device`
   - `generic`
+  These are account-manager product registry categories, not video-cloud
+  credential scope names. Any category that maps to `video_cloud_devid` follows
+  the shared video-cloud device credential contract.
 - Device CRUD operations.
 - Device status management.
 - OpenAPI YAML as the API contract source of truth.
@@ -628,6 +631,12 @@ owned by that organization; submitted video lifecycle material is stored as
 provisioning request payload and projected video metadata, not as a replacement
 for account-manager ownership.
 
+Account-manager device `category` values are not video-cloud credential scopes.
+For any category that has a `video_cloud_devid` mapping, successful video-side
+activation may lead to video-cloud device-bound credentials owned by the
+video-side runtime or integration service. Account manager does not issue,
+renew, or validate video-cloud device tokens or certificates.
+
 The shared contracts define the first implemented app-facing Claim Token
 resolution surface:
 
@@ -669,8 +678,8 @@ Accepted claim material in the current API:
 | Device category | Current account-manager claim material | Notes |
 | --- | --- | --- |
 | `ip_camera` | `video_cloud_devid`, `activity_id`, `clip_public_key` | Supported by `POST .../provision` for the account/video lifecycle flow. `video_cloud_devid` maps the account registry device to the Realtek video identity; `activity_id` and `clip_public_key` are passed to the video-side lifecycle worker. |
-| `mqtt_device` | None beyond an existing registry device id | Category-specific MQTT claim material, broker credentials, and factory identity are out of scope for the current account-manager API. |
-| `generic` | None beyond an existing registry device id | Serial-number, QR-code, activation-code, MAC-address, and future factory-identity claim flows are out of scope for the current account-manager API unless a later endpoint explicitly accepts them. |
+| `mqtt_device` | Existing registry device id plus `video_cloud_devid` when this device participates in video-cloud lifecycle | Category-specific MQTT claim material, broker credentials, and factory identity are out of scope for the current account-manager API. A mapped `video_cloud_devid` still uses video-cloud device-bound credentials outside account manager. |
+| `generic` | Existing registry device id plus `video_cloud_devid` when this device participates in video-cloud lifecycle | Serial-number, QR-code, activation-code, MAC-address, and future factory-identity claim flows are out of scope for the current account-manager API unless a later endpoint explicitly accepts them. A mapped `video_cloud_devid` still uses video-cloud device-bound credentials outside account manager. |
 
 Ownership consequences:
 
@@ -843,7 +852,7 @@ Current readiness inputs:
 | Account registry record exists and is enabled | `rtk_account_manager` device APIs | The organization-scoped device record exists and is not soft-disabled. |
 | Provisioning operation accepted | `POST /provision`, `GET /provisioning` | Account side persisted the lifecycle operation and outbox command. |
 | Video activation result projected | `GET /provisioning`, device `video_cloud_*` metadata | Realtek video activation succeeded or failed for the mapped device identity. |
-| Subject-bound token issuance completed | Video-side or integration-service auth surface | The device or app has the credentials required for product use. |
+| Subject-bound token issuance completed | Video-side or integration-service auth surface | The device or app has the video-cloud credentials required for product use; account-manager categories are not credential scopes. |
 | Video-side bootstrap prerequisites completed when required | Video-side APIs | Device info/config setup or equivalent downstream bootstrap state is available. |
 | Owner transport connected | Account-manager device `status`, projected from `DeviceOnlineChanged` | The device has actually come online through its supported owner transport. |
 
@@ -861,7 +870,7 @@ Account-side readiness projection rules:
   latest provisioning operation status, projected video activation status,
   latest deactivation operation status, and projected video last-error data.
 - Compose the final readiness view from this account-manager projection plus
-  the required video-side credential and bootstrap signals.
+  the required video-side device-bound credential and bootstrap signals.
 
 `readiness.product_state` maps account-side facts into the cross-service
 vocabulary as follows:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1135,7 +1135,10 @@ paths:
         Realtek video claim material only; raw QR, serial-number,
         activation-code, transfer, and factory-reset reclaim flows are out of
         scope. Registry ownership remains scoped to the addressed organization
-        and account-manager device id.
+        and account-manager device id. Device categories are registry
+        categories, not video-cloud credential scopes; any category mapped to
+        `video_cloud_devid` uses video-cloud device-bound credentials outside
+        account manager.
       parameters:
         - $ref: "#/components/parameters/OrgId"
         - $ref: "#/components/parameters/DeviceId"
@@ -1519,7 +1522,8 @@ components:
         accept standalone `claim_material`, SDK-normalized `qr_payload`,
         serial number, activation code, MAC address, or factory identity fields;
         those claim/bind flows require a future dedicated endpoint or owner
-        service.
+        service. Account manager stores lifecycle input and projections only; it
+        does not issue or renew video-cloud device tokens or certificates.
       required: [video_cloud_devid, activity_id, clip_public_key]
       additionalProperties: false
       properties:
@@ -2283,6 +2287,7 @@ components:
       enum: [owner, admin, member]
     DeviceCategory:
       type: string
+      description: Product registry category, not a video-cloud credential scope.
       enum: [ip_camera, mqtt_device, generic]
     DeviceStatus:
       type: string


### PR DESCRIPTION
## Summary
- Clarify account-manager device categories are product registry categories, not video-cloud credential scopes
- Document that mapped `video_cloud_devid` devices use video-cloud device-bound credentials outside account-manager
- Align provisioning/readiness docs and OpenAPI descriptions with the shared device credential contract

## Issue
Closes #118

## Tests
- `make test`
- `go test ./internal/openapi`
