### PR TITLE
ci: add account manager local CD workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Build packages
         run: go build ./...
 
+      - name: Check release bundle
+        run: VERSION="ci-${GITHUB_SHA::12}" make release
+
       - name: Upload test report artifacts
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -1,0 +1,240 @@
+name: Deploy Local Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing GitHub Release version to deploy, for example v1.2.3."
+        required: true
+        type: string
+      restart_units:
+        description: "Space-separated systemd units to restart after migration."
+        required: false
+        default: "rtk-account-manager.service rtk-account-manager-cleanup-tokens.timer"
+        type: string
+      run_verify:
+        description: "Run installed verify.sh after restart."
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: account-manager-deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy release on video-cloud-cd.local
+    runs-on: [self-hosted, Linux, X64, account-manager-cd]
+    environment: staging
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="$INPUT_VERSION"
+          case "$version" in
+            *[!A-Za-z0-9._-]* | "" | .* | *..*)
+              echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+              exit 1
+              ;;
+          esac
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Download release bundle
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const version = process.env.VERSION;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+            const assetName = `rtk_account_manager-${version}.tar.gz`;
+
+            const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag: version });
+            const asset = release.data.assets.find((item) => item.name === assetName);
+            if (!asset) {
+              core.setFailed(`release asset not found: ${assetName}`);
+              return;
+            }
+            const response = await github.request("GET /repos/{owner}/{repo}/releases/assets/{asset_id}", {
+              owner,
+              repo,
+              asset_id: asset.id,
+              headers: { Accept: "application/octet-stream" },
+            });
+            fs.rmSync("dist", { recursive: true, force: true });
+            fs.mkdirSync("dist", { recursive: true });
+            fs.writeFileSync(path.join("dist", assetName), Buffer.from(response.data));
+
+      - name: Extract release bundle
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          test -f "dist/rtk_account_manager-$VERSION.tar.gz"
+          tar -C dist -xzf "dist/rtk_account_manager-$VERSION.tar.gz"
+
+      - name: Verify release bundle
+        run: ./deploy/check-release.sh "dist/rtk_account_manager-${{ steps.version.outputs.version }}"
+
+      - name: Validate deployment inputs
+        shell: bash
+        env:
+          ACCOUNT_MANAGER_DEPLOY_PREFIX: ${{ vars.ACCOUNT_MANAGER_DEPLOY_PREFIX }}
+          ACCOUNT_MANAGER_DEPLOY_ETC_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_ETC_DIR }}
+          ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR }}
+          ACCOUNT_MANAGER_DEPLOY_STATE_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_STATE_DIR }}
+          RESTART_UNITS: ${{ inputs.restart_units }}
+        run: |
+          valid_path='^/[A-Za-z0-9._/-]+$'
+          valid_units='^[A-Za-z0-9_.@ -]+$'
+          test -n "$RESTART_UNITS"
+          [[ "$RESTART_UNITS" =~ $valid_units ]]
+          [[ "${ACCOUNT_MANAGER_DEPLOY_PREFIX:-/opt/rtk-account-manager}" =~ $valid_path ]]
+          [[ "${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}" =~ $valid_path ]]
+          [[ "${ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR:-/etc/systemd/system}" =~ $valid_path ]]
+          [[ "${ACCOUNT_MANAGER_DEPLOY_STATE_DIR:-/var/lib/rtk-account-manager}" =~ $valid_path ]]
+
+      - name: Check passwordless sudo
+        shell: bash
+        run: |
+          if ! sudo -n true 2>/dev/null; then
+            cat >&2 <<'MSG'
+          self-hosted staging deploy requires non-interactive sudo.
+
+          Configure passwordless sudo for the account-manager-cd runner user on
+          video-cloud-cd.local. Do not put sudo passwords in GitHub secrets.
+          MSG
+            exit 1
+          fi
+
+      - name: Install locally
+        shell: bash
+        env:
+          ACCOUNT_MANAGER_DEPLOY_PREFIX: ${{ vars.ACCOUNT_MANAGER_DEPLOY_PREFIX }}
+          ACCOUNT_MANAGER_DEPLOY_ETC_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_ETC_DIR }}
+          ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR }}
+          ACCOUNT_MANAGER_DEPLOY_STATE_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_STATE_DIR }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          release_dir="dist/rtk_account_manager-$VERSION"
+          sudo -n \
+            PREFIX="${ACCOUNT_MANAGER_DEPLOY_PREFIX:-/opt/rtk-account-manager}" \
+            ETC_DIR="${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}" \
+            SYSTEMD_DIR="${ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR:-/etc/systemd/system}" \
+            STATE_DIR="${ACCOUNT_MANAGER_DEPLOY_STATE_DIR:-/var/lib/rtk-account-manager}" \
+            "$release_dir/deploy/install.sh"
+          sudo -n systemctl daemon-reload
+
+      - name: Configure runtime environment
+        shell: bash
+        env:
+          ACCOUNT_MANAGER_DEPLOY_ETC_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_ETC_DIR }}
+          ACCOUNT_MANAGER_RUNTIME_ENV: ${{ secrets.ACCOUNT_MANAGER_RUNTIME_ENV }}
+        run: |
+          etc_dir="${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}"
+          env_file="$etc_dir/account-manager.env"
+          if [ -n "$ACCOUNT_MANAGER_RUNTIME_ENV" ]; then
+            tmp_file=$(mktemp)
+            trap 'rm -f "$tmp_file"' EXIT
+            chmod 0600 "$tmp_file"
+            printf '%s\n' "$ACCOUNT_MANAGER_RUNTIME_ENV" > "$tmp_file"
+            sudo -n install -m 0600 -o root -g root "$tmp_file" "$env_file"
+          elif ! sudo -n test -f "$env_file"; then
+            echo "missing $env_file and ACCOUNT_MANAGER_RUNTIME_ENV is not configured" >&2
+            exit 1
+          fi
+
+      - name: Check database backup marker
+        shell: bash
+        env:
+          ACCOUNT_MANAGER_DEPLOY_STATE_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_STATE_DIR }}
+        run: |
+          marker="${ACCOUNT_MANAGER_DEPLOY_STATE_DIR:-/var/lib/rtk-account-manager}/last-db-backup-ok"
+          if ! sudo -n test -s "$marker"; then
+            cat >&2 <<MSG
+          missing database backup marker: $marker
+
+          Create this marker after confirming an account-manager database backup
+          exists. This keeps migration as a deliberate deployment gate.
+          MSG
+            exit 1
+          fi
+
+      - name: Run migrations
+        shell: bash
+        run: |
+          sudo -n systemctl start rtk-account-manager-migrate.service
+          sudo -n systemctl is-active --quiet rtk-account-manager-migrate.service || true
+          sudo -n systemctl show rtk-account-manager-migrate.service \
+            --property=Result --property=ExecMainStatus --property=ExecMainCode
+          result=$(sudo -n systemctl show rtk-account-manager-migrate.service --property=Result --value)
+          status=$(sudo -n systemctl show rtk-account-manager-migrate.service --property=ExecMainStatus --value)
+          if [ "$result" != "success" ] || [ "$status" != "0" ]; then
+            sudo -n journalctl -u rtk-account-manager-migrate.service -n 120 --no-pager
+            exit 1
+          fi
+
+      - name: Restart and verify locally
+        shell: bash
+        env:
+          ACCOUNT_MANAGER_DEPLOY_PREFIX: ${{ vars.ACCOUNT_MANAGER_DEPLOY_PREFIX }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RESTART_UNITS: ${{ inputs.restart_units }}
+          RUN_VERIFY: ${{ inputs.run_verify }}
+        run: |
+          prefix="${ACCOUNT_MANAGER_DEPLOY_PREFIX:-/opt/rtk-account-manager}"
+          previous_version=$(sudo -n sh -c "cat \"$prefix/current-version\" 2>/dev/null || true")
+          for unit in $RESTART_UNITS; do
+            sudo -n systemctl enable "$unit"
+            sudo -n systemctl restart "$unit"
+          done
+          if [ "$RUN_VERIFY" = "true" ]; then
+            sudo -n "$prefix/verify.sh"
+          fi
+          if [ -n "$previous_version" ]; then
+            printf '%s\n' "$previous_version" | sudo -n tee "$prefix/previous-version" >/dev/null
+          fi
+          printf '%s\n' "$VERSION" | sudo -n tee "$prefix/current-version" >/dev/null
+
+      - name: Collect deployment evidence
+        if: always()
+        shell: bash
+        env:
+          ACCOUNT_MANAGER_DEPLOY_ETC_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_ETC_DIR }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RESTART_UNITS: ${{ inputs.restart_units }}
+        run: |
+          etc_dir="${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}"
+          rm -rf deployment-evidence
+          mkdir -p deployment-evidence
+          {
+            echo "version=$VERSION"
+            echo "restart_units=$RESTART_UNITS"
+            echo "collected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > deployment-evidence/summary.txt
+          sudo -n systemctl status rtk-account-manager.service --no-pager > deployment-evidence/api-status.txt 2>&1 || true
+          sudo -n systemctl status rtk-account-manager-cleanup-tokens.timer --no-pager > deployment-evidence/cleanup-timer-status.txt 2>&1 || true
+          sudo -n systemctl status rtk-account-manager-migrate.service --no-pager > deployment-evidence/migrate-status.txt 2>&1 || true
+          sudo -n sh -c "grep -E '^[A-Za-z_][A-Za-z0-9_]*=' \"$etc_dir/account-manager.env\" | sed -E 's/=.*/=<redacted>/'" \
+            > deployment-evidence/redacted-env-keys.txt 2>&1 || true
+
+      - name: Upload deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: account-manager-deployment-evidence-${{ steps.version.outputs.version }}
+          path: deployment-evidence/*
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release Bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version. Defaults to the git ref name or short SHA."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Package release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Select version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            version="${GITHUB_SHA::12}"
+          fi
+          case "$version" in
+            *[!A-Za-z0-9._-]* | "" | .* | *..*)
+              echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+              exit 1
+              ;;
+          esac
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build release bundle
+        run: VERSION="${{ steps.version.outputs.version }}" make release
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: rtk_account_manager-${{ steps.version.outputs.version }}
+          path: |
+            dist/rtk_account_manager-${{ steps.version.outputs.version }}
+            dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" \
+              "dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz" \
+              --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              "dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz" \
+              --generate-notes \
+              --title "$GITHUB_REF_NAME"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 REPORT_DIR ?= reports
+VERSION ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo dev)
 UNIT_TEST_PACKAGES := ./internal/api ./internal/auth ./internal/broker ./internal/channel ./internal/config ./internal/database ./internal/openapi ./internal/readiness ./internal/store ./internal/worker/inbox ./internal/worker/outbox
 RACE_TEST_PACKAGES := ./internal/channel ./internal/broker ./internal/worker/... ./internal/auth ./internal/config ./internal/readiness
 FUZZ_SMOKE_TIME ?= 2s
 
-.PHONY: tidy test integration-test test-report test-race test-repeat fuzz-smoke readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
+.PHONY: tidy test integration-test test-report test-race test-repeat fuzz-smoke build release check-release readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
 
 tidy:
 	go mod tidy
@@ -29,6 +30,37 @@ fuzz-smoke:
 	@mkdir -p $(REPORT_DIR)
 	TEST_DATABASE_URL= go test ./internal/channel -run=^$$ -fuzz=FuzzEnvelopeStrictJSONAndValidation -fuzztime=$(FUZZ_SMOKE_TIME) | tee $(REPORT_DIR)/fuzz-smoke-channel.txt
 	TEST_DATABASE_URL= go test ./internal/api -run=^$$ -fuzz=FuzzBindStrictRequestShape -fuzztime=$(FUZZ_SMOKE_TIME) | tee $(REPORT_DIR)/fuzz-smoke-api.txt
+
+build:
+	@mkdir -p dist
+	go build -trimpath -o dist/rtk-account-manager ./cmd/server
+	go build -trimpath -o dist/rtk-account-manager-migrate ./cmd/migrate
+	go build -trimpath -o dist/rtk-account-manager-outbox-worker ./cmd/outbox-worker
+	go build -trimpath -o dist/rtk-account-manager-inbox-worker ./cmd/inbox-worker
+	go build -trimpath -o dist/rtk-account-manager-cleanup-tokens ./cmd/cleanup-tokens
+
+release:
+	@rm -rf "dist/rtk_account_manager-$(VERSION)" "dist/rtk_account_manager-$(VERSION).tar.gz"
+	@mkdir -p "dist/rtk_account_manager-$(VERSION)/bin" "dist/rtk_account_manager-$(VERSION)/deploy"
+	go build -trimpath -o "dist/rtk_account_manager-$(VERSION)/bin/rtk-account-manager" ./cmd/server
+	go build -trimpath -o "dist/rtk_account_manager-$(VERSION)/bin/rtk-account-manager-migrate" ./cmd/migrate
+	go build -trimpath -o "dist/rtk_account_manager-$(VERSION)/bin/rtk-account-manager-outbox-worker" ./cmd/outbox-worker
+	go build -trimpath -o "dist/rtk_account_manager-$(VERSION)/bin/rtk-account-manager-inbox-worker" ./cmd/inbox-worker
+	go build -trimpath -o "dist/rtk_account_manager-$(VERSION)/bin/rtk-account-manager-cleanup-tokens" ./cmd/cleanup-tokens
+	cp -R migrations "dist/rtk_account_manager-$(VERSION)/migrations"
+	cp -R deploy/systemd "dist/rtk_account_manager-$(VERSION)/deploy/systemd"
+	cp deploy/account-manager.env.example "dist/rtk_account_manager-$(VERSION)/deploy/account-manager.env.example"
+	cp deploy/install.sh deploy/verify.sh "dist/rtk_account_manager-$(VERSION)/deploy/"
+	{ \
+		echo "version=$(VERSION)"; \
+		echo "git_sha=$$(git rev-parse HEAD 2>/dev/null || echo unknown)"; \
+		echo "built_at=$$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+		echo "module=$$(go list -m)"; \
+	} > "dist/rtk_account_manager-$(VERSION)/release-manifest.txt"
+	./deploy/check-release.sh "dist/rtk_account_manager-$(VERSION)"
+	tar -C dist -czf "dist/rtk_account_manager-$(VERSION).tar.gz" "rtk_account_manager-$(VERSION)"
+
+check-release: release
 
 readiness-smoke:
 	go run ./cmd/readiness-smoke

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,6 +7,9 @@ manager installs.
 | --- | --- |
 | `account-manager.env.example` | Operator-facing environment key inventory with placeholders only. |
 | `systemd/` | Native Linux unit templates for API, migrations, workers, and cleanup. |
+| `install.sh` | Root-owned native install script used by local CD. |
+| `verify.sh` | Installed staging health/systemd verification script. |
+| `check-release.sh` | Release bundle guard used by `make release` and CD. |
 
 These files are examples, not a secret store. Copy the env file to an
 operator-owned location such as `/etc/rtk-account-manager/account-manager.env`,
@@ -14,3 +17,8 @@ fill values from a secret manager, and set file mode `0600`.
 
 The full operations runbook is in
 [`docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md`](../docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md).
+
+Staging CD deploys immutable release tarballs to `video-cloud-cd.local` using
+the `account-manager-cd` self-hosted runner label. Runtime secrets must stay in
+`/etc/rtk-account-manager/account-manager.env` or the GitHub staging
+environment secret `ACCOUNT_MANAGER_RUNTIME_ENV`.

--- a/deploy/account-manager.env.example
+++ b/deploy/account-manager.env.example
@@ -6,7 +6,8 @@ DATABASE_URL=postgres://<user>:<password>@<host>:5432/<database>?sslmode=require
 JWT_ACCESS_SECRET=<secret-from-secret-manager>
 JWT_REFRESH_SECRET=<secret-from-secret-manager>
 
-PORT=8080
+# Staging on video-cloud-cd.local uses 18081 to avoid video_cloud API on 18080.
+PORT=18081
 ACCESS_TOKEN_TTL=15m
 REFRESH_TOKEN_TTL=720h
 

--- a/deploy/check-release.sh
+++ b/deploy/check-release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_dir=${1:-}
+if [ -z "$release_dir" ]; then
+  echo "usage: $0 <release-dir>" >&2
+  exit 2
+fi
+
+if [ ! -d "$release_dir" ]; then
+  echo "release directory not found: $release_dir" >&2
+  exit 1
+fi
+
+required_executables=(
+  bin/rtk-account-manager
+  bin/rtk-account-manager-migrate
+  bin/rtk-account-manager-outbox-worker
+  bin/rtk-account-manager-inbox-worker
+  bin/rtk-account-manager-cleanup-tokens
+  deploy/install.sh
+  deploy/verify.sh
+)
+
+for path in "${required_executables[@]}"; do
+  if [ ! -x "$release_dir/$path" ]; then
+    echo "missing executable: $path" >&2
+    exit 1
+  fi
+done
+
+required_files=(
+  deploy/account-manager.env.example
+  deploy/systemd/rtk-account-manager.service
+  deploy/systemd/rtk-account-manager-migrate.service
+  deploy/systemd/rtk-account-manager-outbox-worker.service
+  deploy/systemd/rtk-account-manager-inbox-worker.service
+  deploy/systemd/rtk-account-manager-cleanup-tokens.service
+  deploy/systemd/rtk-account-manager-cleanup-tokens.timer
+  release-manifest.txt
+)
+
+for path in "${required_files[@]}"; do
+  if [ ! -f "$release_dir/$path" ]; then
+    echo "missing release file: $path" >&2
+    exit 1
+  fi
+done
+
+if ! find "$release_dir/migrations" -maxdepth 1 -type f -name '*.sql' | grep -q .; then
+  echo "release has no SQL migrations" >&2
+  exit 1
+fi
+
+if grep -R '<secret-from-secret-manager>\|<user>:<password>' "$release_dir" \
+  --exclude='account-manager.env.example' >/dev/null; then
+  echo "placeholder secret text leaked outside env example" >&2
+  exit 1
+fi
+
+echo "release bundle is valid: $release_dir"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prefix=${PREFIX:-/opt/rtk-account-manager}
+etc_dir=${ETC_DIR:-/etc/rtk-account-manager}
+systemd_dir=${SYSTEMD_DIR:-/etc/systemd/system}
+state_dir=${STATE_DIR:-/var/lib/rtk-account-manager}
+service_user=${SERVICE_USER:-rtk-account-manager}
+service_group=${SERVICE_GROUP:-$service_user}
+
+release_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "install.sh must run as root" >&2
+  exit 1
+fi
+
+if ! getent group "$service_group" >/dev/null; then
+  groupadd --system "$service_group"
+fi
+
+if ! id -u "$service_user" >/dev/null 2>&1; then
+  useradd --system \
+    --gid "$service_group" \
+    --home-dir "$state_dir" \
+    --shell /usr/sbin/nologin \
+    "$service_user"
+fi
+
+install -d -o root -g root -m 0755 "$prefix" "$prefix/bin" "$systemd_dir"
+install -d -o "$service_user" -g "$service_group" -m 0755 "$state_dir"
+install -d -o root -g root -m 0750 "$etc_dir"
+
+install -m 0755 "$release_dir/bin/rtk-account-manager" "$prefix/bin/rtk-account-manager"
+install -m 0755 "$release_dir/bin/rtk-account-manager-migrate" "$prefix/bin/rtk-account-manager-migrate"
+install -m 0755 "$release_dir/bin/rtk-account-manager-outbox-worker" "$prefix/bin/rtk-account-manager-outbox-worker"
+install -m 0755 "$release_dir/bin/rtk-account-manager-inbox-worker" "$prefix/bin/rtk-account-manager-inbox-worker"
+install -m 0755 "$release_dir/bin/rtk-account-manager-cleanup-tokens" "$prefix/bin/rtk-account-manager-cleanup-tokens"
+install -m 0755 "$release_dir/deploy/verify.sh" "$prefix/verify.sh"
+
+rm -rf "$prefix/migrations"
+mkdir -p "$prefix/migrations"
+cp -R "$release_dir/migrations/." "$prefix/migrations/"
+chown -R root:root "$prefix/migrations"
+chmod -R go-w "$prefix/migrations"
+
+install -m 0644 "$release_dir"/deploy/systemd/*.service "$systemd_dir/"
+install -m 0644 "$release_dir"/deploy/systemd/*.timer "$systemd_dir/"
+install -m 0644 "$release_dir/deploy/account-manager.env.example" "$etc_dir/account-manager.env.example"
+
+install -m 0644 "$release_dir/release-manifest.txt" "$prefix/release-manifest.txt"
+
+echo "installed RTK Account Manager release into $prefix"

--- a/deploy/verify.sh
+++ b/deploy/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prefix=${PREFIX:-/opt/rtk-account-manager}
+env_file=${ENV_FILE:-/etc/rtk-account-manager/account-manager.env}
+base_url=${ACCOUNT_MANAGER_BASE_URL:-http://127.0.0.1:${PORT:-18081}}
+
+if [ -f "$env_file" ]; then
+  env_base_url=$(grep -E '^ACCOUNT_MANAGER_BASE_URL=' "$env_file" | tail -1 | cut -d= -f2- || true)
+  env_port=$(grep -E '^PORT=' "$env_file" | tail -1 | cut -d= -f2- || true)
+  if [ -n "$env_base_url" ]; then
+    base_url=$env_base_url
+  else
+    base_url=${ACCOUNT_MANAGER_BASE_URL:-http://127.0.0.1:${env_port:-${PORT:-18081}}}
+  fi
+fi
+
+echo "Verifying RTK Account Manager at $base_url"
+
+for binary in \
+  rtk-account-manager \
+  rtk-account-manager-migrate \
+  rtk-account-manager-outbox-worker \
+  rtk-account-manager-inbox-worker \
+  rtk-account-manager-cleanup-tokens; do
+  test -x "$prefix/bin/$binary"
+done
+
+curl -fsS "$base_url/v1/health" >/dev/null
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl is-active --quiet rtk-account-manager.service
+  systemctl is-enabled --quiet rtk-account-manager-cleanup-tokens.timer
+fi
+
+echo "RTK Account Manager verification passed"

--- a/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
+++ b/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
@@ -24,12 +24,17 @@ Source inputs:
 Use this profile for demos, engineering validation, and private-cloud
 workshops. It optimizes for fast setup over high availability.
 
+The current staging recommendation is to deploy account manager on
+`video-cloud-cd.local`, the same private-cloud host used by `rtk_video_cloud`.
+This keeps account/video provisioning and readiness checks in one environment
+while preserving service and database isolation.
+
 Recommended placement:
 
 | Component | Evaluation placement |
 | --- | --- |
-| Account Manager API | One `systemd` service or one container on the same host as Postgres. |
-| Postgres | Local Postgres instance or Docker Compose Postgres. |
+| Account Manager API | `systemd` service on `video-cloud-cd.local`, bound to `127.0.0.1:18081`. |
+| Postgres | Shared local PostgreSQL cluster, separate `rtk_account_manager` database and role. |
 | Outbox worker | Optional separate process when provisioning lifecycle commands are enabled. |
 | Inbox worker | Optional separate process when video-side events are consumed locally. |
 | Cleanup tokens | `systemd` timer or scheduled job. |
@@ -101,6 +106,100 @@ For native installs, place binaries under `/opt/rtk-account-manager/bin/` and
 copy the environment file to `/etc/rtk-account-manager/account-manager.env`.
 The environment file must be readable only by the service user and root.
 
+Build an immutable release bundle with:
+
+```sh
+VERSION=v0.1.0 make release
+```
+
+This writes `dist/rtk_account_manager-$VERSION.tar.gz`. GitHub Actions
+publishes the same tarball through `.github/workflows/release.yml`.
+
+## Staging CD On `video-cloud-cd.local`
+
+Use `video-cloud-cd.local` as the staging deploy target for account manager.
+Do not use it for heavy CI. The deployment runner should only run manual deploy
+jobs and short smoke checks.
+
+Runner requirements:
+
+| Setting | Value |
+| --- | --- |
+| Repository | `hkt999rtk/rtk_account_manager` |
+| Runner label | `account-manager-cd` |
+| Host | `video-cloud-cd.local` |
+| Sudo | Passwordless sudo for installing under `/opt`, `/etc`, `/var/lib`, and restarting account-manager units. |
+
+Staging placement:
+
+| Resource | Value |
+| --- | --- |
+| Install prefix | `/opt/rtk-account-manager` |
+| Config dir | `/etc/rtk-account-manager` |
+| State dir | `/var/lib/rtk-account-manager` |
+| Service user/group | `rtk-account-manager` |
+| API port | `18081` |
+| Database | `rtk_account_manager` |
+| Database role | `rtk_account_manager` |
+
+Create the database and role outside the deploy workflow:
+
+```sql
+CREATE ROLE rtk_account_manager LOGIN PASSWORD '<operator-owned-secret>';
+CREATE DATABASE rtk_account_manager OWNER rtk_account_manager;
+```
+
+The runtime DSN must point at the account-manager database, never the
+`video_cloud` database:
+
+```sh
+DATABASE_URL='postgres://rtk_account_manager:<secret>@127.0.0.1:5432/rtk_account_manager?sslmode=disable'
+PORT=18081
+```
+
+The deploy workflow is `.github/workflows/deploy-local.yml`. It is manual
+(`workflow_dispatch`) and deploys an existing GitHub Release version. Configure
+the staging environment with:
+
+| GitHub setting | Purpose |
+| --- | --- |
+| `ACCOUNT_MANAGER_RUNTIME_ENV` secret | Full `/etc/rtk-account-manager/account-manager.env` content. |
+| `ACCOUNT_MANAGER_DEPLOY_PREFIX` variable | Optional override; defaults to `/opt/rtk-account-manager`. |
+| `ACCOUNT_MANAGER_DEPLOY_ETC_DIR` variable | Optional override; defaults to `/etc/rtk-account-manager`. |
+| `ACCOUNT_MANAGER_DEPLOY_STATE_DIR` variable | Optional override; defaults to `/var/lib/rtk-account-manager`. |
+
+Before running a deployment that can apply migrations, confirm a fresh database
+backup and create the deploy gate marker:
+
+```sh
+sudo install -d -o rtk-account-manager -g rtk-account-manager /var/lib/rtk-account-manager
+printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" | \
+  sudo tee /var/lib/rtk-account-manager/last-db-backup-ok >/dev/null
+```
+
+Deploy sequence:
+
+1. Download the release tarball.
+2. Validate the release bundle with `deploy/check-release.sh`.
+3. Install binaries, migrations, systemd units, and env examples with
+   `deploy/install.sh`.
+4. Preserve or install `/etc/rtk-account-manager/account-manager.env`.
+5. Require the backup marker before migrations.
+6. Run `rtk-account-manager-migrate.service`.
+7. Restart selected runtime units.
+8. Run `/opt/rtk-account-manager/verify.sh`.
+9. Upload deployment evidence with service status and redacted env keys.
+
+Default restart units are:
+
+```text
+rtk-account-manager.service rtk-account-manager-cleanup-tokens.timer
+```
+
+Enable `rtk-account-manager-outbox-worker.service` and
+`rtk-account-manager-inbox-worker.service` in `restart_units` only when the
+cross-service lifecycle channel is deliberately enabled for the environment.
+
 ## Environment Variables
 
 Use `deploy/account-manager.env.example` as the operator-facing key inventory.
@@ -118,7 +217,7 @@ It intentionally contains placeholders only.
 
 | Variable | Purpose | Default / notes |
 | --- | --- | --- |
-| `PORT` | API bind port. | `8080` |
+| `PORT` | API bind port. | `8080` by code default; staging deploy uses `18081` to avoid `rtk_video_cloud` on `18080`. |
 | `ACCESS_TOKEN_TTL` | Access token lifetime. | `15m` |
 | `REFRESH_TOKEN_TTL` | Refresh token lifetime. | `720h` |
 | `AUTH_TOKEN_DELIVERY` | Verification/reset token delivery adapter. | `log` is currently supported by the server entrypoint. |
@@ -236,7 +335,7 @@ sudo systemctl enable --now rtk-account-manager-cleanup-tokens.timer
 Health check:
 
 ```sh
-curl -fsS http://127.0.0.1:8080/v1/health
+curl -fsS http://127.0.0.1:18081/v1/health
 ```
 
 Expected response:


### PR DESCRIPTION
## Summary
- add immutable release bundle packaging and release publication workflow
- add manual local staging deploy workflow for `video-cloud-cd.local` using the `account-manager-cd` runner label
- add install/verify/check-release scripts and document DB/service/runner isolation for shared staging

## Infrastructure
- registered `account-manager-cd` repo-scoped runner on `video-cloud-cd.local`
- runner service is enabled and online: `actions.runner.hkt999rtk-rtk_account_manager.account-manager-cd.service`

## Test Plan
- `VERSION=ci-local make release`
- `bash -n deploy/check-release.sh deploy/install.sh deploy/verify.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/deploy-local.yml`
- `TEST_DATABASE_URL= go test ./...`
- `git diff --check`
