### PR TITLE
ci: replace github-script release download

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -50,39 +50,17 @@ jobs:
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Download release bundle
-        uses: actions/github-script@v7
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        with:
-          script: |
-            const fs = require("fs");
-            const path = require("path");
-
-            const version = process.env.VERSION;
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-            const assetName = `rtk_account_manager-${version}.tar.gz`;
-
-            const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag: version });
-            const asset = release.data.assets.find((item) => item.name === assetName);
-            if (!asset) {
-              core.setFailed(`release asset not found: ${assetName}`);
-              return;
-            }
-            const response = await github.request("GET /repos/{owner}/{repo}/releases/assets/{asset_id}", {
-              owner,
-              repo,
-              asset_id: asset.id,
-              headers: { Accept: "application/octet-stream" },
-            });
-            fs.rmSync("dist", { recursive: true, force: true });
-            fs.mkdirSync("dist", { recursive: true });
-            fs.writeFileSync(path.join("dist", assetName), Buffer.from(response.data));
-
-      - name: Extract release bundle
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          rm -rf dist
+          mkdir -p dist
+          gh release download "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "rtk_account_manager-$VERSION.tar.gz" \
+            --dir dist
           test -f "dist/rtk_account_manager-$VERSION.tar.gz"
           tar -C dist -xzf "dist/rtk_account_manager-$VERSION.tar.gz"
 


### PR DESCRIPTION
## Summary
- replace `actions/github-script@v7` in the local deploy workflow with a shell step using `gh release download`
- keep private release asset downloads authenticated with `${{ github.token }}`
- leave `account-manager-cd` as deploy-only and keep CI on the CI runner

Closes #125

## Test Plan
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml`
- `rg -n "actions/github-script|github-script|Node.js 20|node20" .github/workflows || true`
- `gh release download v0.1.0-staging.1 --repo hkt999rtk/rtk_account_manager --pattern 'rtk_account_manager-v0.1.0-staging.1.tar.gz' --dir "$tmp"`
- `TEST_DATABASE_URL= go test ./...`
- `git diff --check`
