### PR TITLE
CI/CD report candidate import workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,27 @@ jobs:
         run: test -z "$(gofmt -l .)"
 
       - name: Run tests and generate report
-        run: make test-report
+        run: |
+          REPORT_FILE=.artifacts/report-candidates/docs/TEST_REPORT.md \
+            REPORT_GENERATED_AT=ci-candidate \
+            REPORT_CANONICAL=true \
+            make test-report
+          ./scripts/validate-report-candidate.sh \
+            docs/TEST_REPORT.md \
+            .artifacts/report-candidates/docs/TEST_REPORT.md
+
+      - name: Check committed test report drift
+        run: |
+          if ! diff -u docs/TEST_REPORT.md .artifacts/report-candidates/docs/TEST_REPORT.md; then
+            cat >&2 <<'MSG'
+          docs/TEST_REPORT.md is stale.
+
+          Import the generated test-report-candidate artifact into the PR branch
+          with the "Import Report Candidate" workflow, or regenerate and commit the
+          same candidate locally.
+          MSG
+            exit 1
+          fi
 
       - name: Run repeatability smoke
         run: make test-repeat
@@ -66,14 +86,24 @@ jobs:
       - name: Check release bundle
         run: VERSION="ci-${GITHUB_SHA::12}" make release
 
-      - name: Upload test report artifacts
+      - name: Check report candidate scripts
+        run: make check-report-candidates
+
+      - name: Upload raw test artifacts
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-report
+          name: test-report-raw
           path: |
-            docs/TEST_REPORT.md
             reports/
+
+      - name: Upload test report candidate
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-report-candidate
+          path: .artifacts/report-candidates/docs/TEST_REPORT.md
+          if-no-files-found: error
 
   deep-test:
     runs-on: [self-hosted, account-manager-ci]

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -192,10 +192,12 @@ jobs:
         shell: bash
         env:
           ACCOUNT_MANAGER_DEPLOY_ETC_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_ETC_DIR }}
+          ACCOUNT_MANAGER_DEPLOY_STATE_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_STATE_DIR }}
           VERSION: ${{ steps.version.outputs.version }}
           RESTART_UNITS: ${{ inputs.restart_units }}
         run: |
           etc_dir="${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}"
+          state_dir="${ACCOUNT_MANAGER_DEPLOY_STATE_DIR:-/var/lib/rtk-account-manager}"
           rm -rf deployment-evidence
           mkdir -p deployment-evidence
           {
@@ -203,16 +205,44 @@ jobs:
             echo "restart_units=$RESTART_UNITS"
             echo "collected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } > deployment-evidence/summary.txt
+          marker="$state_dir/last-db-backup-ok"
+          if sudo -n test -s "$marker"; then
+            echo "present" > deployment-evidence/backup-marker-status.txt
+          else
+            echo "missing" > deployment-evidence/backup-marker-status.txt
+          fi
           sudo -n systemctl status rtk-account-manager.service --no-pager > deployment-evidence/api-status.txt 2>&1 || true
           sudo -n systemctl status rtk-account-manager-cleanup-tokens.timer --no-pager > deployment-evidence/cleanup-timer-status.txt 2>&1 || true
           sudo -n systemctl status rtk-account-manager-migrate.service --no-pager > deployment-evidence/migrate-status.txt 2>&1 || true
           sudo -n sh -c "grep -E '^[A-Za-z_][A-Za-z0-9_]*=' \"$etc_dir/account-manager.env\" | sed -E 's/=.*/=<redacted>/'" \
             > deployment-evidence/redacted-env-keys.txt 2>&1 || true
 
+      - name: Generate readiness test report candidate
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          VERIFY_RESULT: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          OUTPUT=.artifacts/report-candidates/docs/READINESS_TEST_REPORT.md \
+            EVIDENCE_DIR=deployment-evidence \
+            ./scripts/generate-readiness-report-candidate.sh
+
       - name: Upload deployment evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: account-manager-deployment-evidence-${{ steps.version.outputs.version }}
-          path: deployment-evidence/*
+          path: |
+            deployment-evidence/*
+            .artifacts/report-candidates/docs/READINESS_TEST_REPORT.md
           if-no-files-found: warn
+
+      - name: Upload readiness test report candidate
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: readiness-test-report-candidate-${{ steps.version.outputs.version }}
+          path: .artifacts/report-candidates/docs/READINESS_TEST_REPORT.md
+          if-no-files-found: error

--- a/.github/workflows/import-report-candidate.yml
+++ b/.github/workflows/import-report-candidate.yml
@@ -1,0 +1,95 @@
+name: Import Report Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        description: "Workflow run ID that produced the report candidate artifact."
+        required: true
+        type: string
+      artifact_name:
+        description: "Artifact name to import, for example test-report-candidate."
+        required: true
+        type: string
+      target_report:
+        description: "Canonical report file to replace."
+        required: true
+        type: choice
+        options:
+          - docs/TEST_REPORT.md
+          - docs/RELEASE_TEST_REPORT.md
+          - docs/READINESS_TEST_REPORT.md
+      pr_branch:
+        description: "Pull request branch to update."
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  import:
+    name: Import selected report candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch input
+        shell: bash
+        env:
+          PR_BRANCH: ${{ inputs.pr_branch }}
+        run: |
+          case "$PR_BRANCH" in
+            "" | -* | *..* | */. | ./* | *" "* | *"~"* | *"^"* | *":"* | *"?"* | *"["* | *"\\"* )
+              echo "invalid branch name: $PR_BRANCH" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Check out pull request branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.pr_branch }}
+          fetch-depth: 0
+
+      - name: Download selected artifact
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        run: |
+          rm -rf .artifacts/imported
+          mkdir -p .artifacts/imported
+          gh run download "$ARTIFACT_RUN_ID" \
+            --name "$ARTIFACT_NAME" \
+            --dir .artifacts/imported
+
+      - name: Import report candidate
+        shell: bash
+        env:
+          TARGET_REPORT: ${{ inputs.target_report }}
+          IMPORT_DIR: .artifacts/imported
+        run: ./scripts/import-report-candidate.sh
+
+      - name: Commit selected report
+        shell: bash
+        env:
+          TARGET_REPORT: ${{ inputs.target_report }}
+          PR_BRANCH: ${{ inputs.pr_branch }}
+        run: |
+          changed="$(git diff --name-only)"
+          if [ -z "$changed" ]; then
+            echo "no report changes to commit"
+            exit 0
+          fi
+          if [ "$changed" != "$TARGET_REPORT" ]; then
+            echo "import changed unexpected files:" >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$TARGET_REPORT"
+          git commit -m "docs: import $(basename "$TARGET_REPORT") candidate"
+          git push origin "HEAD:$PR_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,19 @@ jobs:
       - name: Build release bundle
         run: VERSION="${{ steps.version.outputs.version }}" make release
 
+      - name: Generate release test report candidate
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          RELEASE_ASSET: dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          contracts_commit="$(git ls-tree HEAD contracts 2>/dev/null | awk '{print $3}' || true)"
+          OUTPUT=.artifacts/report-candidates/docs/RELEASE_TEST_REPORT.md \
+            CONTRACTS_COMMIT="$contracts_commit" \
+            ./scripts/generate-release-report-candidate.sh
+
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -59,6 +72,13 @@ jobs:
           path: |
             dist/rtk_account_manager-${{ steps.version.outputs.version }}
             dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
+          if-no-files-found: error
+
+      - name: Upload release test report candidate
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-test-report-candidate-${{ steps.version.outputs.version }}
+          path: .artifacts/report-candidates/docs/RELEASE_TEST_REPORT.md
           if-no-files-found: error
 
       - name: Publish GitHub release

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 dist/
 tmp/
 reports/
+.artifacts/
 coverage.out
 .DS_Store
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UNIT_TEST_PACKAGES := ./internal/api ./internal/auth ./internal/broker ./interna
 RACE_TEST_PACKAGES := ./internal/channel ./internal/broker ./internal/worker/... ./internal/auth ./internal/config ./internal/readiness
 FUZZ_SMOKE_TIME ?= 2s
 
-.PHONY: tidy test integration-test test-report test-race test-repeat fuzz-smoke build release check-release readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
+.PHONY: tidy test integration-test test-report check-report-candidates test-race test-repeat fuzz-smoke build release check-release readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
 
 tidy:
 	go mod tidy
@@ -17,6 +17,9 @@ integration-test:
 
 test-report:
 	./scripts/test-report.sh
+
+check-report-candidates:
+	./scripts/report-candidate-tests.sh
 
 test-race:
 	@mkdir -p $(REPORT_DIR)

--- a/docs/READINESS_TEST_REPORT.md
+++ b/docs/READINESS_TEST_REPORT.md
@@ -1,0 +1,7 @@
+# Readiness Test Report
+
+Generated: not imported
+
+## Summary
+
+No readiness test report candidate has been imported yet. Generate a deployment candidate from the Deploy Local Staging workflow and import it through the manual Import Report Candidate workflow after reviewing the sanitized artifact.

--- a/docs/RELEASE_TEST_REPORT.md
+++ b/docs/RELEASE_TEST_REPORT.md
@@ -1,0 +1,7 @@
+# Release Test Report
+
+Generated: not imported
+
+## Summary
+
+No release test report candidate has been imported yet. Generate a release candidate from the Release Bundle workflow and import it through the manual Import Report Candidate workflow when a canonical report is needed.

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -1,6 +1,6 @@
 # Test Report
 
-Generated: 2026-05-07T15:52:31Z
+Generated: ci-candidate
 
 ## Summary
 
@@ -17,7 +17,7 @@ Generated: 2026-05-07T15:52:31Z
 
 | Metric | Value |
 | --- | --- |
-| Total statement coverage | 80.6% |
+| Total statement coverage | recorded in reports/coverage.txt |
 | Minimum required coverage | 80.0% |
 | Coverage mode | atomic |
 | Coverage scope | ./internal/... |
@@ -27,9 +27,9 @@ Generated: 2026-05-07T15:52:31Z
 | Metric | Value |
 | --- | --- |
 | Go packages | 20 |
-| Test cases started | 308 |
-| JSON pass events | 320 |
-| JSON fail events | 0 |
+| Test cases started | recorded in reports/test-events.json |
+| JSON pass events | recorded in reports/test-events.json |
+| JSON fail events | recorded in reports/test-events.json |
 | Integration database | Postgres via TEST_DATABASE_URL |
 
 ## Correctness Gates

--- a/scripts/generate-readiness-report-candidate.sh
+++ b/scripts/generate-readiness-report-candidate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT="${OUTPUT:-.artifacts/report-candidates/docs/READINESS_TEST_REPORT.md}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-deployment-evidence}"
+VERSION="${VERSION:-}"
+VERIFY_RESULT="${VERIFY_RESULT:-unknown}"
+RUN_URL="${RUN_URL:-}"
+GENERATED_AT="${REPORT_GENERATED_AT:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+
+if [ -z "$RUN_URL" ] && [ -n "${GITHUB_SERVER_URL:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ]; then
+	RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+fi
+if [ -z "$RUN_URL" ]; then
+	RUN_URL="not available"
+fi
+
+if [ -z "$VERSION" ] && [ -f "$EVIDENCE_DIR/summary.txt" ]; then
+	VERSION="$(awk -F= '$1 == "version" { print $2; exit }' "$EVIDENCE_DIR/summary.txt")"
+fi
+if [ -z "$VERSION" ]; then
+	VERSION="unknown"
+fi
+
+extract_active_line() {
+	local file=$1
+	if [ -f "$file" ]; then
+		grep -m1 'Active:' "$file" | sed -E 's/^[[:space:]]+//' || true
+	fi
+}
+
+backup_marker_status="unknown"
+if [ -f "$EVIDENCE_DIR/backup-marker-status.txt" ]; then
+	backup_marker_status="$(tr '\n' ' ' <"$EVIDENCE_DIR/backup-marker-status.txt" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+fi
+
+api_status="$(extract_active_line "$EVIDENCE_DIR/api-status.txt")"
+cleanup_status="$(extract_active_line "$EVIDENCE_DIR/cleanup-timer-status.txt")"
+migrate_status="$(extract_active_line "$EVIDENCE_DIR/migrate-status.txt")"
+api_status="${api_status:-not collected}"
+cleanup_status="${cleanup_status:-not collected}"
+migrate_status="${migrate_status:-not collected}"
+
+mkdir -p "$(dirname "$OUTPUT")"
+cat >"$OUTPUT" <<EOF
+# Readiness Test Report
+
+Generated: $GENERATED_AT
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Deployed version | \`$VERSION\` |
+| Verify result | \`$VERIFY_RESULT\` |
+| Backup marker status | \`$backup_marker_status\` |
+| Workflow run | $RUN_URL |
+
+## Service Status Summary
+
+| Unit | Summary |
+| --- | --- |
+| rtk-account-manager.service | \`$api_status\` |
+| rtk-account-manager-cleanup-tokens.timer | \`$cleanup_status\` |
+| rtk-account-manager-migrate.service | \`$migrate_status\` |
+
+## Redacted Environment Keys
+
+EOF
+
+if [ -s "$EVIDENCE_DIR/redacted-env-keys.txt" ]; then
+	sed -E 's/=.*/=<redacted>/' "$EVIDENCE_DIR/redacted-env-keys.txt" \
+		| awk '/^[A-Za-z_][A-Za-z0-9_]*=<redacted>$/ { printf "- `%s`\n", $0 }' >>"$OUTPUT"
+else
+	echo "No redacted environment key inventory was collected." >>"$OUTPUT"
+fi
+
+cat >>"$OUTPUT" <<'EOF'
+
+## Candidate Policy
+
+This sanitized readiness report contains only concise deployment evidence. Full systemd output, readiness JSON, logs, and diagnostics remain artifact-only.
+EOF
+
+"$(dirname "$0")/validate-report-candidate.sh" docs/READINESS_TEST_REPORT.md "$OUTPUT" >/dev/null
+echo "generated readiness report candidate: $OUTPUT"

--- a/scripts/generate-release-report-candidate.sh
+++ b/scripts/generate-release-report-candidate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT="${OUTPUT:-.artifacts/report-candidates/docs/RELEASE_TEST_REPORT.md}"
+VERSION="${VERSION:-}"
+SOURCE_COMMIT="${SOURCE_COMMIT:-${GITHUB_SHA:-}}"
+RELEASE_ASSET="${RELEASE_ASSET:-}"
+RUN_URL="${RUN_URL:-}"
+CONTRACTS_COMMIT="${CONTRACTS_COMMIT:-}"
+GENERATED_AT="${REPORT_GENERATED_AT:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+
+if [ -z "$VERSION" ]; then
+	echo "VERSION is required" >&2
+	exit 2
+fi
+
+if [ -z "$SOURCE_COMMIT" ]; then
+	SOURCE_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+fi
+
+if [ -z "$RELEASE_ASSET" ] || [ ! -f "$RELEASE_ASSET" ]; then
+	echo "RELEASE_ASSET must point to an existing release tarball" >&2
+	exit 2
+fi
+
+if [ -z "$RUN_URL" ] && [ -n "${GITHUB_SERVER_URL:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ]; then
+	RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+fi
+if [ -z "$RUN_URL" ]; then
+	RUN_URL="not available"
+fi
+
+if [ -z "$CONTRACTS_COMMIT" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	CONTRACTS_COMMIT="$(git ls-tree HEAD contracts 2>/dev/null | awk '{print $3}' || true)"
+fi
+if [ -z "$CONTRACTS_COMMIT" ]; then
+	CONTRACTS_COMMIT="not present"
+fi
+
+asset_name="$(basename "$RELEASE_ASSET")"
+if command -v sha256sum >/dev/null 2>&1; then
+	asset_sha256="$(sha256sum "$RELEASE_ASSET" | awk '{print $1}')"
+else
+	asset_sha256="$(shasum -a 256 "$RELEASE_ASSET" | awk '{print $1}')"
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+cat >"$OUTPUT" <<EOF
+# Release Test Report
+
+Generated: $GENERATED_AT
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Release version | \`$VERSION\` |
+| Source commit | \`$SOURCE_COMMIT\` |
+| Release asset | \`$asset_name\` |
+| Release asset SHA256 | \`$asset_sha256\` |
+| Contracts commit | \`$CONTRACTS_COMMIT\` |
+| Workflow run | $RUN_URL |
+
+## Candidate Policy
+
+This sanitized release report is generated as a workflow artifact. It is not committed automatically. Import it into a pull request branch only through the report import workflow after reviewing the artifact.
+EOF
+
+"$(dirname "$0")/validate-report-candidate.sh" docs/RELEASE_TEST_REPORT.md "$OUTPUT" >/dev/null
+echo "generated release report candidate: $OUTPUT"

--- a/scripts/import-report-candidate.sh
+++ b/scripts/import-report-candidate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_REPORT="${TARGET_REPORT:-${1:-}}"
+IMPORT_DIR="${IMPORT_DIR:-.artifacts/imported}"
+
+case "$TARGET_REPORT" in
+	docs/TEST_REPORT.md | docs/RELEASE_TEST_REPORT.md | docs/READINESS_TEST_REPORT.md)
+		;;
+	*)
+		echo "unsupported target report: $TARGET_REPORT" >&2
+		exit 2
+		;;
+esac
+
+if [ ! -d "$IMPORT_DIR" ]; then
+	echo "import directory not found: $IMPORT_DIR" >&2
+	exit 2
+fi
+
+candidate="$(find "$IMPORT_DIR" -type f -path "*/$TARGET_REPORT" | head -n 1)"
+if [ -z "$candidate" ]; then
+	echo "candidate for $TARGET_REPORT not found under $IMPORT_DIR" >&2
+	exit 2
+fi
+
+"$(dirname "$0")/validate-report-candidate.sh" "$TARGET_REPORT" "$candidate"
+mkdir -p "$(dirname "$TARGET_REPORT")"
+cp "$candidate" "$TARGET_REPORT"
+echo "imported $candidate to $TARGET_REPORT"

--- a/scripts/report-candidate-tests.sh
+++ b/scripts/report-candidate-tests.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_contains() {
+	local file=$1
+	local pattern=$2
+	if ! grep -F -- "$pattern" "$file" >/dev/null; then
+		echo "expected $file to contain: $pattern" >&2
+		exit 1
+	fi
+}
+
+assert_rejects() {
+	local description=$1
+	shift
+	if "$@" >/dev/null 2>&1; then
+		echo "expected rejection: $description" >&2
+		exit 1
+	fi
+}
+
+valid_report="$tmp_dir/docs/TEST_REPORT.md"
+mkdir -p "$(dirname "$valid_report")"
+cat >"$valid_report" <<'EOF'
+# Test Report
+
+Generated: test
+EOF
+"$repo_root/scripts/validate-report-candidate.sh" docs/TEST_REPORT.md "$valid_report" >/dev/null
+
+assert_rejects "invalid target path" "$repo_root/scripts/validate-report-candidate.sh" docs/UNKNOWN.md "$valid_report"
+
+dsn_report="$tmp_dir/dsn.md"
+cat >"$dsn_report" <<'EOF'
+# Test Report
+
+DATABASE_URL=postgres://user:password@localhost/db
+EOF
+assert_rejects "raw DSN with credentials" "$repo_root/scripts/validate-report-candidate.sh" docs/TEST_REPORT.md "$dsn_report"
+
+secret_report="$tmp_dir/secret.md"
+cat >"$secret_report" <<'EOF'
+# Test Report
+
+JWT_ACCESS_SECRET=not-redacted
+EOF
+assert_rejects "secret env assignment" "$repo_root/scripts/validate-report-candidate.sh" docs/TEST_REPORT.md "$secret_report"
+
+jwt_report="$tmp_dir/jwt.md"
+cat >"$jwt_report" <<'EOF'
+# Test Report
+
+token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature
+EOF
+assert_rejects "JWT-looking value" "$repo_root/scripts/validate-report-candidate.sh" docs/TEST_REPORT.md "$jwt_report"
+
+key_report="$tmp_dir/key.md"
+cat >"$key_report" <<'EOF'
+# Test Report
+
+-----BEGIN PRIVATE KEY-----
+EOF
+assert_rejects "private key material" "$repo_root/scripts/validate-report-candidate.sh" docs/TEST_REPORT.md "$key_report"
+
+asset="$tmp_dir/rtk_account_manager-vtest.tar.gz"
+printf 'release-bundle' >"$asset"
+release_output="$tmp_dir/candidates/docs/RELEASE_TEST_REPORT.md"
+OUTPUT="$release_output" \
+	VERSION="vtest" \
+	SOURCE_COMMIT="abc123" \
+	RELEASE_ASSET="$asset" \
+	CONTRACTS_COMMIT="def456" \
+	RUN_URL="https://github.example/run/1" \
+	REPORT_GENERATED_AT="test" \
+	"$repo_root/scripts/generate-release-report-candidate.sh" >/dev/null
+assert_contains "$release_output" "# Release Test Report"
+assert_contains "$release_output" "| Release version | \`vtest\` |"
+assert_contains "$release_output" "| Source commit | \`abc123\` |"
+assert_contains "$release_output" "| Contracts commit | \`def456\` |"
+assert_contains "$release_output" "| Release asset SHA256 |"
+
+evidence="$tmp_dir/deployment-evidence"
+mkdir -p "$evidence"
+cat >"$evidence/summary.txt" <<'EOF'
+version=vready
+EOF
+cat >"$evidence/backup-marker-status.txt" <<'EOF'
+present
+EOF
+cat >"$evidence/api-status.txt" <<'EOF'
+     Active: active (running) since today
+EOF
+cat >"$evidence/cleanup-timer-status.txt" <<'EOF'
+     Active: active (waiting) since today
+EOF
+cat >"$evidence/migrate-status.txt" <<'EOF'
+     Active: inactive (dead) since today
+EOF
+cat >"$evidence/redacted-env-keys.txt" <<'EOF'
+DATABASE_URL=<redacted>
+JWT_ACCESS_SECRET=<redacted>
+EOF
+readiness_output="$tmp_dir/candidates/docs/READINESS_TEST_REPORT.md"
+OUTPUT="$readiness_output" \
+	EVIDENCE_DIR="$evidence" \
+	VERIFY_RESULT="success" \
+	RUN_URL="https://github.example/run/2" \
+	REPORT_GENERATED_AT="test" \
+	"$repo_root/scripts/generate-readiness-report-candidate.sh" >/dev/null
+assert_contains "$readiness_output" "# Readiness Test Report"
+assert_contains "$readiness_output" "| Deployed version | \`vready\` |"
+assert_contains "$readiness_output" "| Verify result | \`success\` |"
+assert_contains "$readiness_output" "- \`JWT_ACCESS_SECRET=<redacted>\`"
+
+import_root="$tmp_dir/imported/artifact/docs"
+mkdir -p "$import_root"
+cp "$release_output" "$import_root/RELEASE_TEST_REPORT.md"
+(
+	cd "$tmp_dir"
+	assert_rejects "invalid import target" "$repo_root/scripts/import-report-candidate.sh" docs/NOT_ALLOWED.md
+	TARGET_REPORT=docs/RELEASE_TEST_REPORT.md IMPORT_DIR="$tmp_dir/imported" "$repo_root/scripts/import-report-candidate.sh" >/dev/null
+	test -f docs/RELEASE_TEST_REPORT.md
+)
+
+echo "report candidate script tests passed"

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -17,7 +17,7 @@ FORMAT_OUT="$REPORT_DIR/gofmt.txt"
 BUILD_OUT="$REPORT_DIR/build.txt"
 TEST_CASES_MD="$REPORT_DIR/test-cases.md"
 
-started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+started_at="${REPORT_GENERATED_AT:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
 
 require_postgres() {
 	local authority host port
@@ -83,6 +83,17 @@ package_count="$(go list ./... | wc -l | tr -d ' ')"
 test_count="$(grep -c '"Action":"run"' "$TEST_EVENTS" 2>/dev/null || true)"
 pass_count="$(grep -c '"Action":"pass"' "$TEST_EVENTS" 2>/dev/null || true)"
 fail_count="$(grep -c '"Action":"fail"' "$TEST_EVENTS" 2>/dev/null || true)"
+
+coverage_total_display="$coverage_total"
+test_count_display="$test_count"
+pass_count_display="$pass_count"
+fail_count_display="$fail_count"
+if [ "${REPORT_CANONICAL:-false}" = "true" ]; then
+	coverage_total_display="recorded in $COVERAGE_FUNC"
+	test_count_display="recorded in $TEST_EVENTS"
+	pass_count_display="recorded in $TEST_EVENTS"
+	fail_count_display="recorded in $TEST_EVENTS"
+fi
 
 grep '"Action":"pass".*"Test":' "$TEST_EVENTS" 2>/dev/null \
 	| sed -E 's/.*"Package":"([^"]+)","Test":"([^"]+)".*/- `\1`: `\2`/' \
@@ -157,7 +168,7 @@ Generated: $started_at
 
 | Metric | Value |
 | --- | --- |
-| Total statement coverage | $coverage_total |
+| Total statement coverage | $coverage_total_display |
 | Minimum required coverage | ${COVERAGE_THRESHOLD}% |
 | Coverage mode | atomic |
 | Coverage scope | ./internal/... |
@@ -167,9 +178,9 @@ Generated: $started_at
 | Metric | Value |
 | --- | --- |
 | Go packages | $package_count |
-| Test cases started | $test_count |
-| JSON pass events | $pass_count |
-| JSON fail events | $fail_count |
+| Test cases started | $test_count_display |
+| JSON pass events | $pass_count_display |
+| JSON fail events | $fail_count_display |
 | Integration database | Postgres via TEST_DATABASE_URL |
 
 ## Correctness Gates

--- a/scripts/validate-report-candidate.sh
+++ b/scripts/validate-report-candidate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target=${1:-}
+candidate=${2:-}
+
+case "$target" in
+  docs/TEST_REPORT.md)
+    expected_heading="# Test Report"
+    ;;
+  docs/RELEASE_TEST_REPORT.md)
+    expected_heading="# Release Test Report"
+    ;;
+  docs/READINESS_TEST_REPORT.md)
+    expected_heading="# Readiness Test Report"
+    ;;
+  *)
+    echo "unsupported target report: $target" >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "$candidate" ] || [ ! -f "$candidate" ]; then
+  echo "candidate report not found: $candidate" >&2
+  exit 2
+fi
+
+first_line=$(sed -n '1p' "$candidate")
+if [ "$first_line" != "$expected_heading" ]; then
+  echo "invalid report heading: expected '$expected_heading', got '$first_line'" >&2
+  exit 1
+fi
+
+if grep -E -- '-----BEGIN [A-Z ]*PRIVATE KEY-----' "$candidate" >/dev/null; then
+  echo "candidate contains private key material" >&2
+  exit 1
+fi
+
+if grep -E 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+' "$candidate" >/dev/null; then
+  echo "candidate contains JWT-looking token material" >&2
+  exit 1
+fi
+
+if grep -E '[a-z][a-z0-9+.-]*://[^[:space:]/:@]+:[^[:space:]@]+@' "$candidate" \
+  | grep -Ev '<redacted>|%5Bredacted%5D|\\[redacted\\]' >/dev/null; then
+  echo "candidate contains unredacted credential-bearing URL" >&2
+  exit 1
+fi
+
+if awk '
+  BEGIN { bad = 0 }
+  /^[A-Za-z_][A-Za-z0-9_]*(SECRET|TOKEN|PASSWORD)[A-Za-z0-9_]*=/ {
+    if ($0 !~ /=<redacted>$/ && $0 !~ /=$/) {
+      print $0
+      bad = 1
+    }
+  }
+  END { exit bad }
+' "$candidate" >/dev/null; then
+  :
+else
+  echo "candidate contains unredacted secret-like environment assignment" >&2
+  exit 1
+fi
+
+echo "report candidate is valid for $target: $candidate"


### PR DESCRIPTION
## Summary
- generate sanitized test, release, and readiness report candidates as workflow artifacts
- add validation/import scripts plus a manual workflow that updates exactly one canonical report file
- add CI drift checking for docs/TEST_REPORT.md and keep raw diagnostics artifact-only

Closes #128

## Validation
- TEST_DATABASE_URL=postgres://rtk:***@localhost:5432/rtk_account_manager?sslmode=disable REPORT_FILE=docs/TEST_REPORT.md REPORT_GENERATED_AT=ci-candidate make test-report
- REPORT_FILE=.artifacts/report-candidates/docs/TEST_REPORT.md REPORT_GENERATED_AT=ci-candidate make test-report && validate && diff
- VERSION=ci-local make release && generate release report candidate
- make check-report-candidates
- bash -n scripts/*.sh
- ruby YAML parse for .github/workflows/*.yml
- git diff --check