### PR TITLE
chore: harden deploy readiness evidence

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -17,6 +17,34 @@ on:
         required: true
         default: true
         type: boolean
+      run_readiness_smoke:
+        description: "Run login/org/device/provisioning smoke when smoke secrets are configured."
+        required: true
+        default: false
+        type: boolean
+      restore_drill_reference:
+        description: "Restore-drill evidence reference, or SKIP:<reason>."
+        required: false
+        default: "SKIP:not-provided"
+        type: string
+      smtp_mode:
+        description: "SMTP evidence mode."
+        required: true
+        default: "SKIP"
+        type: choice
+        options:
+          - configured
+          - log-only
+          - SKIP
+      broker_mode:
+        description: "Cross-service broker evidence mode."
+        required: true
+        default: "SKIP"
+        type: choice
+        options:
+          - enabled
+          - disabled
+          - SKIP
 
 permissions:
   contents: read
@@ -75,11 +103,15 @@ jobs:
           ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR }}
           ACCOUNT_MANAGER_DEPLOY_STATE_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_STATE_DIR }}
           RESTART_UNITS: ${{ inputs.restart_units }}
+          RESTORE_DRILL_REFERENCE: ${{ inputs.restore_drill_reference }}
         run: |
           valid_path='^/[A-Za-z0-9._/-]+$'
           valid_units='^[A-Za-z0-9_.@ -]+$'
+          valid_evidence='^[A-Za-z0-9._:/@# -]+$'
           test -n "$RESTART_UNITS"
+          test -n "$RESTORE_DRILL_REFERENCE"
           [[ "$RESTART_UNITS" =~ $valid_units ]]
+          [[ "$RESTORE_DRILL_REFERENCE" =~ $valid_evidence ]]
           [[ "${ACCOUNT_MANAGER_DEPLOY_PREFIX:-/opt/rtk-account-manager}" =~ $valid_path ]]
           [[ "${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}" =~ $valid_path ]]
           [[ "${ACCOUNT_MANAGER_DEPLOY_SYSTEMD_DIR:-/etc/systemd/system}" =~ $valid_path ]]
@@ -193,11 +225,21 @@ jobs:
         env:
           ACCOUNT_MANAGER_DEPLOY_ETC_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_ETC_DIR }}
           ACCOUNT_MANAGER_DEPLOY_STATE_DIR: ${{ vars.ACCOUNT_MANAGER_DEPLOY_STATE_DIR }}
+          ACCOUNT_MANAGER_SMOKE_BASE_URL: ${{ vars.ACCOUNT_MANAGER_SMOKE_BASE_URL }}
+          ACCOUNT_MANAGER_SMOKE_EMAIL: ${{ secrets.ACCOUNT_MANAGER_SMOKE_EMAIL }}
+          ACCOUNT_MANAGER_SMOKE_PASSWORD: ${{ secrets.ACCOUNT_MANAGER_SMOKE_PASSWORD }}
+          ACCOUNT_MANAGER_SMOKE_ORG_ID: ${{ secrets.ACCOUNT_MANAGER_SMOKE_ORG_ID }}
+          ACCOUNT_MANAGER_SMOKE_DEVICE_ID: ${{ secrets.ACCOUNT_MANAGER_SMOKE_DEVICE_ID }}
           VERSION: ${{ steps.version.outputs.version }}
           RESTART_UNITS: ${{ inputs.restart_units }}
+          RESTORE_DRILL_REFERENCE: ${{ inputs.restore_drill_reference }}
+          SMTP_MODE: ${{ inputs.smtp_mode }}
+          BROKER_MODE: ${{ inputs.broker_mode }}
+          RUN_READINESS_SMOKE: ${{ inputs.run_readiness_smoke }}
         run: |
           etc_dir="${ACCOUNT_MANAGER_DEPLOY_ETC_DIR:-/etc/rtk-account-manager}"
           state_dir="${ACCOUNT_MANAGER_DEPLOY_STATE_DIR:-/var/lib/rtk-account-manager}"
+          base_url="${ACCOUNT_MANAGER_SMOKE_BASE_URL:-http://127.0.0.1:18081}"
           rm -rf deployment-evidence
           mkdir -p deployment-evidence
           {
@@ -205,11 +247,81 @@ jobs:
             echo "restart_units=$RESTART_UNITS"
             echo "collected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } > deployment-evidence/summary.txt
+          {
+            echo "restore_drill_reference=$RESTORE_DRILL_REFERENCE"
+            echo "smtp_mode=$SMTP_MODE"
+            echo "broker_mode=$BROKER_MODE"
+          } > deployment-evidence/production-evidence.txt
           marker="$state_dir/last-db-backup-ok"
           if sudo -n test -s "$marker"; then
-            echo "present" > deployment-evidence/backup-marker-status.txt
+            marker_text=$(sudo -n cat "$marker" 2>/dev/null | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+            echo "present ${marker_text:-timestamp-unavailable}" > deployment-evidence/backup-marker-status.txt
           else
             echo "missing" > deployment-evidence/backup-marker-status.txt
+          fi
+          if curl -fsS "$base_url/v1/health" >/dev/null 2>&1; then
+            echo "health=PASS" > deployment-evidence/smoke-results.txt
+          else
+            echo "health=FAIL" > deployment-evidence/smoke-results.txt
+          fi
+          if [ "$RUN_READINESS_SMOKE" != "true" ]; then
+            {
+              echo "login=SKIP:disabled"
+              echo "organization_read=SKIP:disabled"
+              echo "device_read=SKIP:disabled"
+              echo "provisioning_readiness=SKIP:disabled"
+            } >> deployment-evidence/smoke-results.txt
+          elif [ -z "$ACCOUNT_MANAGER_SMOKE_EMAIL" ] || [ -z "$ACCOUNT_MANAGER_SMOKE_PASSWORD" ] || [ -z "$ACCOUNT_MANAGER_SMOKE_ORG_ID" ] || [ -z "$ACCOUNT_MANAGER_SMOKE_DEVICE_ID" ]; then
+            {
+              echo "login=SKIP:missing-smoke-secret"
+              echo "organization_read=SKIP:missing-smoke-secret"
+              echo "device_read=SKIP:missing-smoke-secret"
+              echo "provisioning_readiness=SKIP:missing-smoke-secret"
+            } >> deployment-evidence/smoke-results.txt
+          else
+            login_file=$(mktemp)
+            trap 'rm -f "$login_file"' EXIT
+            if curl -fsS -X POST "$base_url/v1/auth/login" \
+              -H 'Content-Type: application/json' \
+              -d "{\"email\":\"$ACCOUNT_MANAGER_SMOKE_EMAIL\",\"password\":\"$ACCOUNT_MANAGER_SMOKE_PASSWORD\"}" \
+              > "$login_file"; then
+              echo "login=PASS" >> deployment-evidence/smoke-results.txt
+              if command -v jq >/dev/null 2>&1; then
+                access_token=$(jq -r '.tokens.access_token // empty' "$login_file")
+              else
+                echo "json_parser=SKIP:jq-missing" >> deployment-evidence/smoke-results.txt
+                access_token=""
+              fi
+            else
+              echo "login=FAIL" >> deployment-evidence/smoke-results.txt
+              access_token=""
+            fi
+            if [ -z "$access_token" ]; then
+              if command -v jq >/dev/null 2>&1; then
+                skip_reason="no-access-token"
+              else
+                skip_reason="jq-missing"
+              fi
+              echo "organization_read=SKIP:$skip_reason" >> deployment-evidence/smoke-results.txt
+              echo "device_read=SKIP:$skip_reason" >> deployment-evidence/smoke-results.txt
+              echo "provisioning_readiness=SKIP:$skip_reason" >> deployment-evidence/smoke-results.txt
+            else
+              if curl -fsS "$base_url/v1/orgs/$ACCOUNT_MANAGER_SMOKE_ORG_ID" -H "Authorization: Bearer $access_token" >/dev/null 2>&1; then
+                echo "organization_read=PASS" >> deployment-evidence/smoke-results.txt
+              else
+                echo "organization_read=FAIL" >> deployment-evidence/smoke-results.txt
+              fi
+              if curl -fsS "$base_url/v1/orgs/$ACCOUNT_MANAGER_SMOKE_ORG_ID/devices/$ACCOUNT_MANAGER_SMOKE_DEVICE_ID" -H "Authorization: Bearer $access_token" >/dev/null 2>&1; then
+                echo "device_read=PASS" >> deployment-evidence/smoke-results.txt
+              else
+                echo "device_read=FAIL" >> deployment-evidence/smoke-results.txt
+              fi
+              if curl -fsS "$base_url/v1/orgs/$ACCOUNT_MANAGER_SMOKE_ORG_ID/devices/$ACCOUNT_MANAGER_SMOKE_DEVICE_ID/provisioning" -H "Authorization: Bearer $access_token" >/dev/null 2>&1; then
+                echo "provisioning_readiness=PASS" >> deployment-evidence/smoke-results.txt
+              else
+                echo "provisioning_readiness=SKIP:not-readable-or-not-selected" >> deployment-evidence/smoke-results.txt
+              fi
+            fi
           fi
           sudo -n systemctl status rtk-account-manager.service --no-pager > deployment-evidence/api-status.txt 2>&1 || true
           sudo -n systemctl status rtk-account-manager-cleanup-tokens.timer --no-pager > deployment-evidence/cleanup-timer-status.txt 2>&1 || true

--- a/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
+++ b/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
@@ -167,6 +167,28 @@ the staging environment with:
 | `ACCOUNT_MANAGER_DEPLOY_PREFIX` variable | Optional override; defaults to `/opt/rtk-account-manager`. |
 | `ACCOUNT_MANAGER_DEPLOY_ETC_DIR` variable | Optional override; defaults to `/etc/rtk-account-manager`. |
 | `ACCOUNT_MANAGER_DEPLOY_STATE_DIR` variable | Optional override; defaults to `/var/lib/rtk-account-manager`. |
+| `ACCOUNT_MANAGER_SMOKE_BASE_URL` variable | Optional smoke base URL; defaults to `http://127.0.0.1:18081`. |
+| `ACCOUNT_MANAGER_SMOKE_EMAIL` secret | Existing smoke user email for optional readiness smoke. |
+| `ACCOUNT_MANAGER_SMOKE_PASSWORD` secret | Existing smoke user password for optional readiness smoke. |
+| `ACCOUNT_MANAGER_SMOKE_ORG_ID` secret | Existing organization ID readable by the smoke user. |
+| `ACCOUNT_MANAGER_SMOKE_DEVICE_ID` secret | Existing device ID readable by the smoke user. |
+
+Manual deploy inputs:
+
+| Input | Purpose |
+| --- | --- |
+| `version` | Existing GitHub Release tag to deploy. |
+| `restart_units` | Space-separated account-manager units to restart after migration. |
+| `verify` | Run package verification after restart. |
+| `run_readiness_smoke` | Run login, organization read, device read, and provisioning/readiness smoke when smoke secrets are configured. |
+| `restore_drill_reference` | Operator reference for the latest restore drill, or `SKIP:<reason>`. |
+| `smtp_mode` | `configured`, `log-only`, or `SKIP`. |
+| `broker_mode` | `enabled`, `disabled`, or `SKIP`. |
+
+`SKIP:<reason>` values are acceptable only when the omission is deliberate and
+reviewable, for example `SKIP:evaluation-no-broker` or
+`SKIP:restore-drill-not-required-for-demo`. Do not use `SKIP` to hide a failed
+backup, failed smoke check, or missing production-like dependency.
 
 Before running a deployment that can apply migrations, confirm a fresh database
 backup and create the deploy gate marker:
@@ -188,7 +210,15 @@ Deploy sequence:
 6. Run `rtk-account-manager-migrate.service`.
 7. Restart selected runtime units.
 8. Run `/opt/rtk-account-manager/verify.sh`.
-9. Upload deployment evidence with service status and redacted env keys.
+9. Collect deployment evidence:
+   - backup marker freshness from `/var/lib/rtk-account-manager/last-db-backup-ok`
+   - restore-drill reference from the manual deploy input
+   - `/v1/health` smoke result
+   - optional login, organization, device, and provisioning/readiness smoke result
+   - SMTP mode and cross-service broker mode
+   - concise systemd status summaries
+   - redacted runtime env-key inventory
+10. Upload concise readiness evidence plus raw diagnostics artifacts.
 
 Default restart units are:
 
@@ -346,6 +376,17 @@ Expected response:
 
 ## Smoke Checks
 
+The deploy workflow always records `/v1/health`. Set
+`run_readiness_smoke=true` and configure the smoke secrets to also record
+login, organization read, device read, and provisioning/readiness checks.
+
+If `run_readiness_smoke=false`, the readiness report records those checks as
+`SKIP:disabled`. If any smoke secret is missing, it records
+`SKIP:missing-smoke-secret`. If `jq` is unavailable on the deploy runner, the
+workflow records `SKIP:jq-missing` for token-dependent checks. These explicit
+SKIP values are intended to make evidence gaps visible without committing raw
+responses, JWTs, passwords, or customer payloads.
+
 Use an existing smoke user and existing organization/device in production-like
 deployments. Do not create customer data solely for smoke checks unless that is
 part of an evaluation environment.
@@ -490,7 +531,7 @@ Attach redacted evidence to deployment sign-off:
 - auth/login smoke result
 - organization/device read smoke result
 - provisioning/readiness smoke result or explicit `SKIP`
-- SMTP mode: configured or log-only `SKIP`
+- SMTP mode: `configured`, `log-only`, or `SKIP`
 - cross-service channel mode: enabled, disabled, or `SKIP`
 - backup timestamp and restore-drill reference
 - worker service status when lifecycle channel is enabled

--- a/scripts/generate-readiness-report-candidate.sh
+++ b/scripts/generate-readiness-report-candidate.sh
@@ -34,6 +34,22 @@ if [ -f "$EVIDENCE_DIR/backup-marker-status.txt" ]; then
 	backup_marker_status="$(tr '\n' ' ' <"$EVIDENCE_DIR/backup-marker-status.txt" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
 fi
 
+read_evidence_value() {
+	local file=$1
+	local key=$2
+	if [ -f "$file" ]; then
+		awk -F= -v key="$key" '$1 == key { print substr($0, length(key) + 2); exit }' "$file"
+	fi
+}
+
+production_evidence="$EVIDENCE_DIR/production-evidence.txt"
+restore_drill_reference="$(read_evidence_value "$production_evidence" restore_drill_reference)"
+smtp_mode="$(read_evidence_value "$production_evidence" smtp_mode)"
+broker_mode="$(read_evidence_value "$production_evidence" broker_mode)"
+restore_drill_reference="${restore_drill_reference:-unknown}"
+smtp_mode="${smtp_mode:-unknown}"
+broker_mode="${broker_mode:-unknown}"
+
 api_status="$(extract_active_line "$EVIDENCE_DIR/api-status.txt")"
 cleanup_status="$(extract_active_line "$EVIDENCE_DIR/cleanup-timer-status.txt")"
 migrate_status="$(extract_active_line "$EVIDENCE_DIR/migrate-status.txt")"
@@ -54,6 +70,9 @@ Generated: $GENERATED_AT
 | Deployed version | \`$VERSION\` |
 | Verify result | \`$VERIFY_RESULT\` |
 | Backup marker status | \`$backup_marker_status\` |
+| Restore drill reference | \`$restore_drill_reference\` |
+| SMTP mode | \`$smtp_mode\` |
+| Cross-service broker mode | \`$broker_mode\` |
 | Workflow run | $RUN_URL |
 
 ## Service Status Summary
@@ -63,6 +82,31 @@ Generated: $GENERATED_AT
 | rtk-account-manager.service | \`$api_status\` |
 | rtk-account-manager-cleanup-tokens.timer | \`$cleanup_status\` |
 | rtk-account-manager-migrate.service | \`$migrate_status\` |
+
+## Smoke Summary
+
+EOF
+
+if [ -s "$EVIDENCE_DIR/smoke-results.txt" ]; then
+	awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/ { printf "| `%s` | `%s` |\n", $1, substr($0, length($1) + 2) }' "$EVIDENCE_DIR/smoke-results.txt" \
+		| {
+			echo "| Check | Result |"
+			echo "| --- | --- |"
+			cat
+		} >>"$OUTPUT"
+else
+	cat >>"$OUTPUT" <<'EOF'
+| Check | Result |
+| --- | --- |
+| `health` | `unknown` |
+| `login` | `SKIP:not-collected` |
+| `organization_read` | `SKIP:not-collected` |
+| `device_read` | `SKIP:not-collected` |
+| `provisioning_readiness` | `SKIP:not-collected` |
+EOF
+fi
+
+cat >>"$OUTPUT" <<'EOF'
 
 ## Redacted Environment Keys
 

--- a/scripts/report-candidate-tests.sh
+++ b/scripts/report-candidate-tests.sh
@@ -89,7 +89,19 @@ cat >"$evidence/summary.txt" <<'EOF'
 version=vready
 EOF
 cat >"$evidence/backup-marker-status.txt" <<'EOF'
-present
+present 2026-05-13T00:00:00Z
+EOF
+cat >"$evidence/production-evidence.txt" <<'EOF'
+restore_drill_reference=runbook-restore-2026-05-13
+smtp_mode=log-only
+broker_mode=disabled
+EOF
+cat >"$evidence/smoke-results.txt" <<'EOF'
+health=PASS
+login=PASS
+organization_read=PASS
+device_read=PASS
+provisioning_readiness=SKIP:not-readable-or-not-selected
 EOF
 cat >"$evidence/api-status.txt" <<'EOF'
      Active: active (running) since today
@@ -114,6 +126,13 @@ OUTPUT="$readiness_output" \
 assert_contains "$readiness_output" "# Readiness Test Report"
 assert_contains "$readiness_output" "| Deployed version | \`vready\` |"
 assert_contains "$readiness_output" "| Verify result | \`success\` |"
+assert_contains "$readiness_output" "| Backup marker status | \`present 2026-05-13T00:00:00Z\` |"
+assert_contains "$readiness_output" "| Restore drill reference | \`runbook-restore-2026-05-13\` |"
+assert_contains "$readiness_output" "| SMTP mode | \`log-only\` |"
+assert_contains "$readiness_output" "| Cross-service broker mode | \`disabled\` |"
+assert_contains "$readiness_output" "| \`health\` | \`PASS\` |"
+assert_contains "$readiness_output" "| \`login\` | \`PASS\` |"
+assert_contains "$readiness_output" "| \`provisioning_readiness\` | \`SKIP:not-readable-or-not-selected\` |"
 assert_contains "$readiness_output" "- \`JWT_ACCESS_SECRET=<redacted>\`"
 
 import_root="$tmp_dir/imported/artifact/docs"


### PR DESCRIPTION
Closes #134\n\n## Summary\n- add deploy inputs and evidence capture for restore drill, SMTP, broker, backup marker freshness, and smoke results\n- include sanitized production evidence and smoke summaries in readiness report candidates\n- document operator inputs, SKIP semantics, and deployment evidence expectations\n\n## Tests\n- bash -n scripts/*.sh\n- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml\n- make check-report-candidates\n- make test-report\n- git diff --check