### PR TITLE
[codex] Document Keycloak OIDC SSO plan

### DIFF
--- a/docs/KEYCLOAK_OIDC_SSO.md
+++ b/docs/KEYCLOAK_OIDC_SSO.md
@@ -1,0 +1,254 @@
+# Keycloak / OIDC SSO Specification
+
+## Source Of Truth
+
+This document is the detailed planned specification for Keycloak/OIDC SSO in
+account manager. `SPEC.md` remains the top-level product and API specification
+and links here for the OIDC details.
+
+This is specification-only until the matching migrations, OpenAPI, handlers,
+configuration wiring, and tests are implemented.
+
+## Goal
+
+Add Keycloak/OIDC as an authentication option while keeping account manager as
+the owner of local users, organization membership, roles, device authorization,
+refresh tokens, and API JWT issuance.
+
+Keycloak is an external identity provider. It is not embedded in account
+manager and does not own account-manager authorization policy.
+
+## First Implementation Decisions
+
+- OIDC uses an account-manager backend callback flow. The backend redirects the
+  browser to Keycloak, receives the authorization-code callback, validates the
+  OIDC response, and returns the existing account-manager token response shape.
+- Local email/password login remains supported.
+- User provisioning is pre-provision only. OIDC login never creates a local
+  user, organization, or membership.
+- Organization roles are resolved only from account-manager local memberships.
+  Keycloak groups, realm roles, and client roles are not authorization inputs in
+  the first implementation.
+- Successful SSO login issues account-manager access and refresh JWTs. Clients
+  keep using `Authorization: Bearer <account-manager-access-token>` for API
+  calls.
+- The first implementation targets one configured Keycloak/OIDC provider from
+  environment configuration.
+- Multi-provider platform-admin CRUD is planned as an admin-only management
+  surface after the env-configured provider path is implemented.
+
+## Backend Callback Flow
+
+1. `GET /v1/auth/oidc/providers` returns enabled public provider metadata when
+   `OIDC_ENABLED=true`; it returns an empty list or disabled response when OIDC
+   is not enabled.
+2. `GET /v1/auth/oidc/:providerId/login` creates a one-time OIDC state and
+   nonce, stores only their hashes, and redirects the browser to the provider
+   authorization endpoint using the authorization-code flow.
+3. `GET /v1/auth/oidc/:providerId/callback` validates state, exchanges the code,
+   validates the ID token, resolves the local account-manager user, links the
+   identity only under the configured policy, and returns the existing login
+   token response shape.
+
+## User Provisioning And Linking
+
+- Unknown SSO users return `403 user_not_provisioned`.
+- OIDC login never creates users, organizations, or memberships.
+- Disabled local users cannot authenticate through SSO.
+- With the default `OIDC_AUTO_LINK_EMAIL=false`, callback accepts only an
+  existing `user_identities` link for the validated provider subject.
+- If `OIDC_AUTO_LINK_EMAIL=true` is explicitly enabled, callback may link a
+  validated provider subject to an existing pre-provisioned local user whose
+  normalized email exactly matches the verified Keycloak email.
+- The Keycloak email claim must be present and `email_verified=true`.
+
+## Authorization Model
+
+- Account-manager local organization memberships and roles remain the only
+  authorization source.
+- Keycloak groups, realm roles, and client roles are ignored by account-manager
+  authorization in the first implementation.
+- A successful SSO login only proves identity. It does not grant organization or
+  device access without local membership.
+
+## Token Model
+
+- Account manager issues its own access and refresh JWTs after successful SSO.
+- Account-manager refresh-token rotation, logout, revocation, and disabled-user
+  checks remain unchanged.
+- Keycloak access tokens and refresh tokens are not persisted in the first
+  implementation.
+- Keycloak token values must not be logged, stored in reports, or returned by
+  account-manager APIs.
+
+## Security Policy
+
+- Callback validation must require state and nonce validation.
+- ID token validation must require issuer, audience, signature, and expiry
+  checks.
+- The provider issuer must match the configured `OIDC_ISSUER_URL`.
+- The token audience must include the configured `OIDC_CLIENT_ID`.
+- Expired, replayed, or consumed login state must be rejected.
+- Raw `state` and `nonce` values must not be stored.
+- Provider discovery and admin list/show responses must never expose client
+  secrets.
+
+## Data Model
+
+### `identity_providers`
+
+Stores configured external OIDC provider metadata. The first implementation may
+load the single provider from environment variables, but the table is reserved
+for the planned platform-admin management surface.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | UUID | Yes | Primary key. |
+| `provider_id` | Text | Yes | Stable URL-safe provider identifier, unique. |
+| `name` | Text | Yes | Human-readable provider name, for example `Keycloak`. |
+| `type` | Text | Yes | `oidc` for the planned Keycloak integration. |
+| `issuer_url` | Text | Yes | Expected OIDC issuer URL. |
+| `client_id` | Text | Yes | OIDC client id registered in Keycloak. |
+| `client_secret_ref` | Text | No | Optional secret reference for admin-managed providers; raw secrets must not be returned by APIs. |
+| `scopes` | Text array | Yes | Requested scopes, default `openid,email,profile`. |
+| `enabled` | Boolean | Yes | Disabled providers are hidden from public discovery and cannot start login. |
+| `metadata` | JSONB | Yes | Non-secret provider metadata, default `{}`. |
+| `created_at` | Timestamp | Yes | Creation timestamp. |
+| `updated_at` | Timestamp | Yes | Last update timestamp. |
+
+Constraints:
+
+- `provider_id` is unique and must not be blank.
+- `issuer_url` must match the issuer in validated ID tokens.
+- Raw client secrets must not be exposed in list/show API responses or reports.
+
+### `user_identities`
+
+Links local account-manager users to external OIDC identities.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | UUID | Yes | Primary key. |
+| `user_id` | UUID | Yes | References `users.id`. |
+| `provider_id` | UUID | Yes | References `identity_providers.id`. |
+| `issuer_url` | Text | Yes | Issuer observed and validated at link time. |
+| `subject` | Text | Yes | OIDC `sub` claim. |
+| `email` | Text | Yes | Verified email claim used for pre-provision matching. |
+| `email_verified` | Boolean | Yes | Must be true for a successful SSO link/login. |
+| `claims` | JSONB | Yes | Non-secret normalized identity claims, default `{}`. |
+| `linked_at` | Timestamp | Yes | Time the identity was linked. |
+| `last_login_at` | Timestamp | No | Last successful SSO login time. |
+| `created_at` | Timestamp | Yes | Creation timestamp. |
+| `updated_at` | Timestamp | Yes | Last update timestamp. |
+
+Constraints:
+
+- `(provider_id, subject)` is unique.
+- `(user_id, provider_id)` should be unique for the first implementation unless
+  a later policy allows multiple subjects from the same provider.
+- `email` must be normalized lowercase and must match a verified Keycloak email
+  claim at link time.
+- Disabled local users cannot authenticate through linked identities.
+
+### `oidc_login_states`
+
+Stores short-lived OIDC login state for backend callback validation.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | UUID | Yes | Primary key. |
+| `provider_id` | UUID | Yes | References `identity_providers.id`. |
+| `state_hash` | Text | Yes | Hash of the generated OIDC state value. |
+| `nonce_hash` | Text | Yes | Hash of the generated OIDC nonce value. |
+| `redirect_url` | Text | Yes | Callback URL used for this login attempt. |
+| `post_login_redirect_url` | Text | No | Optional allowed application redirect target after token issuance. |
+| `expires_at` | Timestamp | Yes | Short expiry, recommended maximum 10 minutes. |
+| `consumed_at` | Timestamp | No | Set after successful or terminal callback processing. |
+| `created_at` | Timestamp | Yes | Creation timestamp. |
+
+Constraints:
+
+- Raw `state` and `nonce` values must not be stored.
+- `state_hash` is unique while active.
+- Expired or consumed state records must not be accepted.
+- Callback handling must consume state atomically so replayed callbacks fail.
+
+## API Contract
+
+### Public Auth
+
+| Method | Path | Auth | Description |
+| --- | --- | --- | --- |
+| `GET` | `/v1/auth/oidc/providers` | No | List enabled public OIDC provider metadata without secrets. |
+| `GET` | `/v1/auth/oidc/:providerId/login` | No | Start Keycloak/OIDC login and redirect to the provider authorization endpoint. |
+| `GET` | `/v1/auth/oidc/:providerId/callback` | No | Handle backend OIDC callback and return the existing token response shape. |
+
+### Current User
+
+| Method | Path | Auth | Description |
+| --- | --- | --- | --- |
+| `GET` | `/v1/me/identities` | Yes | List current user's linked external identities. |
+| `DELETE` | `/v1/me/identities/:identityId` | Yes | Unlink one of the current user's external identities when policy allows. |
+
+### Platform Admin Provider Management
+
+These endpoints are planned admin-only scope. The first implementation can ship
+the env-configured single provider before this CRUD surface.
+
+| Method | Path | Auth | Role | Description |
+| --- | --- | --- | --- | --- |
+| `POST` | `/v1/admin/identity-providers` | Yes | Platform admin | Create an OIDC identity provider configuration without exposing raw secrets. |
+| `GET` | `/v1/admin/identity-providers` | Yes | Platform admin | List OIDC identity provider configurations without raw secrets. |
+| `GET` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Show one OIDC identity provider configuration without raw secrets. |
+| `PATCH` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Update OIDC identity provider metadata, status, or secret reference. |
+| `DELETE` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Disable or remove an OIDC identity provider when no active policy blocks it. |
+
+## Configuration
+
+| Variable | Description |
+| --- | --- |
+| `OIDC_ENABLED` | Enables the planned OIDC login routes when `true`. |
+| `OIDC_PROVIDER_ID` | Stable provider id used in `/v1/auth/oidc/:providerId/...`, for example `keycloak`. |
+| `OIDC_PROVIDER_NAME` | Display name returned by provider discovery, for example `Keycloak`. |
+| `OIDC_ISSUER_URL` | Expected Keycloak/OIDC issuer URL. |
+| `OIDC_CLIENT_ID` | OIDC client id registered for account manager. |
+| `OIDC_CLIENT_SECRET` | OIDC client secret. Must be provided through runtime secret management and never logged. |
+| `OIDC_REDIRECT_URL` | Exact backend callback URL registered with Keycloak. |
+| `OIDC_SCOPES` | Space-separated scopes, default `openid email profile`. |
+| `OIDC_AUTO_LINK_EMAIL` | Whether callback may link a validated provider subject to an existing pre-provisioned local user by verified email. Default `false`. |
+
+## Future Implementation Tests
+
+Tests must cover:
+
+- Provider discovery when OIDC is disabled and enabled.
+- Login redirect creates hashed state and nonce records.
+- Callback rejects invalid state, replayed state, invalid nonce, invalid issuer,
+  invalid audience, expired token, and unverified email.
+- Callback rejects unknown users with `403 user_not_provisioned`.
+- Callback rejects disabled local users.
+- Successful callback links an identity under the configured policy and returns
+  the existing account-manager token response shape.
+- Local email/password login continues to work after OIDC is enabled.
+- Keycloak groups, realm roles, and client roles do not grant account-manager
+  organization access.
+- Keycloak access tokens and refresh tokens are not persisted.
+
+## Acceptance Criteria
+
+The planned Keycloak/OIDC authentication implementation is acceptable when:
+
+- Existing email/password login, refresh-token rotation, and account-manager JWT
+  behavior remain supported and documented.
+- Keycloak is treated as an external IdP, not as an embedded account-manager SSO
+  server.
+- Account-manager local users, organization memberships, roles, and device
+  authorization remain the source of truth for API access.
+- The backend callback flow validates state, nonce, issuer, audience, signature,
+  expiry, and verified email before issuing account-manager JWTs.
+- Unknown SSO users return `403 user_not_provisioned`.
+- Disabled local users cannot login through SSO.
+- Successful SSO returns the existing token response shape and does not persist
+  Keycloak access or refresh tokens.
+- Automated tests cover the OIDC behavior matrix and prove local login still
+  works.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -50,7 +50,7 @@ Provisioning and account/video event-channel integration are the v2 surface impl
 - Device command dispatch.
 - Device self-registration or provisioning flows in v1.
 - Device certificate management.
-- Third-party/social login.
+- Third-party/social login outside the planned Keycloak/OIDC integration path.
 - Executable batch operations, OTA campaign execution, and firmware rollout policy.
 - Custom RBAC permissions.
 - Multi-region deployment concerns.
@@ -115,6 +115,44 @@ Account-manager-owned video metadata keys:
 - `video_cloud_deactivated_at`
 - `video_cloud_last_error`
 
+## 2.2 Planned Scope: Keycloak / OIDC Authentication
+
+Keycloak/OIDC SSO is the next planned authentication capability. Keycloak is an
+external identity provider; account manager remains the authoritative owner of
+local users, organization memberships, roles, device authorization, refresh
+tokens, and API JWT issuance.
+
+The detailed normative specification for this planned capability is
+[KEYCLOAK_OIDC_SSO.md](KEYCLOAK_OIDC_SSO.md). This section summarizes the
+top-level product decisions so the main SPEC remains readable.
+
+First implementation decisions:
+
+- OIDC uses an account-manager backend callback flow. The backend redirects the
+  browser to Keycloak, receives the authorization-code callback, validates the
+  OIDC response, and returns the existing account-manager token response shape.
+- Local email/password login remains supported.
+- User provisioning is pre-provision only. OIDC login never creates a local
+  user, organization, or membership.
+- Organization roles are resolved only from account-manager local memberships.
+  Keycloak groups, realm roles, and client roles are not authorization inputs in
+  the first implementation.
+- Successful SSO login issues account-manager access and refresh JWTs. Clients
+  keep using `Authorization: Bearer <account-manager-access-token>` for API
+  calls.
+- The first implementation targets one configured Keycloak/OIDC provider from
+  environment configuration. Multi-provider platform-admin CRUD is planned as an
+  admin-only management surface.
+
+This planned scope does not:
+
+- Embed or operate Keycloak inside account manager.
+- Persist Keycloak access tokens or refresh tokens.
+- Treat Keycloak as the source of account-manager organization ownership,
+  membership, role, or device access policy.
+- Auto-link an arbitrary external identity to a local user without the configured
+  account-manager policy allowing that link.
+
 ## 3. Core Concepts
 
 ### Organization
@@ -124,6 +162,18 @@ An organization represents an account boundary. Devices belong to organizations,
 ### User
 
 A user is a human account authenticated by email and password. A user may belong to one or more organizations.
+
+### External Identity Provider
+
+An external identity provider is a configured Keycloak/OIDC issuer that can
+authenticate a human user. It does not own account-manager organization
+membership, roles, or device authorization.
+
+### User Identity
+
+A user identity links an account-manager local user to an external OIDC
+`issuer` and `subject`. This link is used for SSO login after the OIDC callback
+is validated.
 
 ### Organization Member
 
@@ -305,6 +355,18 @@ Stores one-time email verification and password reset tokens.
 Auth tokens must be stored hashed, not in raw form, and are throttled by
 `user_id` and `purpose`.
 
+### Planned Keycloak/OIDC Tables
+
+The planned SSO data model is defined in
+[KEYCLOAK_OIDC_SSO.md](KEYCLOAK_OIDC_SSO.md). It includes:
+
+- `identity_providers` for configured external OIDC provider metadata.
+- `user_identities` for local-user to OIDC issuer/subject links.
+- `oidc_login_states` for short-lived hashed state and nonce validation.
+
+No migration exists for these tables until the Keycloak/OIDC implementation
+issue is started.
+
 ### `quota_raise_requests`
 
 Tracks evaluation-tier quota raise requests and platform-admin decisions.
@@ -463,9 +525,17 @@ Constraints:
   `SMTP_HOST` and `SMTP_FROM` are configured, and otherwise falls back to the
   local log adapter so quota decisions are observable in dev/test until a real
   mail adapter is configured.
-- Third-party/social login is a deferred first-phase lifecycle capability and
-  must not be presented as available API behavior until implemented.
+- Keycloak/OIDC SSO is a planned authentication capability. It must not be
+  presented as available API behavior until migrations, OpenAPI, handlers, and
+  tests are implemented.
 - Expired or revoked refresh tokens may be removed by an explicit maintenance command.
+
+### Keycloak / OIDC Authentication (Planned)
+
+The planned Keycloak integration treats account manager as an OIDC client and
+Keycloak as an external identity provider. Detailed callback, linking, token,
+security, and test requirements are defined in
+[KEYCLOAK_OIDC_SSO.md](KEYCLOAK_OIDC_SSO.md).
 
 ### Self-Service Evaluation Tier
 
@@ -542,10 +612,15 @@ All endpoints are versioned under `/v1`.
 | `POST` | `/v1/auth/resend-verification` | No | Issue a replacement email verification token for an unverified user, with enumeration-safe response semantics. |
 | `POST` | `/v1/auth/forgot-password` | No | Issue a password reset token, with enumeration-safe response semantics. |
 | `POST` | `/v1/auth/reset-password` | No | Consume a password reset token, set a new password, and revoke active refresh tokens. |
+| `GET` | `/v1/auth/oidc/providers` | No | Planned: list enabled public OIDC provider metadata without secrets. |
+| `GET` | `/v1/auth/oidc/:providerId/login` | No | Planned: start Keycloak/OIDC login and redirect to the provider authorization endpoint. |
+| `GET` | `/v1/auth/oidc/:providerId/callback` | No | Planned: handle backend OIDC callback and return the existing token response shape. |
 | `POST` | `/v1/auth/logout` | Yes | Revoke current refresh token/session. |
 | `GET` | `/v1/me` | Yes | Return current user and memberships. |
 | `DELETE` | `/v1/me` | Yes | Disable current user account and revoke refresh tokens. |
 | `PATCH` | `/v1/me/password` | Yes | Change current user password and revoke refresh tokens. |
+| `GET` | `/v1/me/identities` | Yes | Planned: list current user's linked external identities. |
+| `DELETE` | `/v1/me/identities/:identityId` | Yes | Planned: unlink one of the current user's external identities when policy allows. |
 
 ### Organizations and Members
 
@@ -576,6 +651,11 @@ All endpoints are versioned under `/v1`.
 | `POST` | `/v1/admin/device-claim-tokens/:tokenId/revoke` | Yes | Platform admin | Revoke an unused or already claimed Claim Token. |
 | `POST` | `/v1/admin/device-claim-tokens/:tokenId/reclaim` | Yes | Platform admin | Reclaim a claimed token/device after support or factory-reset evidence. |
 | `POST` | `/v1/admin/device-claims/:claimId/transfer` | Yes | Platform admin | Transfer a resolved claim/token/device to another organization after operator evidence. |
+| `POST` | `/v1/admin/identity-providers` | Yes | Platform admin | Planned: create an OIDC identity provider configuration without exposing raw secrets. |
+| `GET` | `/v1/admin/identity-providers` | Yes | Platform admin | Planned: list OIDC identity provider configurations without raw secrets. |
+| `GET` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Planned: show one OIDC identity provider configuration without raw secrets. |
+| `PATCH` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Planned: update OIDC identity provider metadata, status, or secret reference. |
+| `DELETE` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Planned: disable or remove an OIDC identity provider when no active policy blocks it. |
 
 ### Devices
 
@@ -1117,6 +1197,20 @@ V2 cross-service configuration:
 | `AZURE_EVENTHUB_CONNECTION_STRING` | Azure Event Hubs connection string when using Azure. |
 | `AZURE_EVENTHUB_CHECKPOINT_FILE` | Optional durable checkpoint file for the Azure inbox consumer. Defaults to `.state/azure_eventhubs/<stream>__<consumer-group>.json`. |
 
+Planned Keycloak/OIDC configuration:
+
+| Variable | Description |
+| --- | --- |
+| `OIDC_ENABLED` | Enables the planned OIDC login routes when `true`. |
+| `OIDC_PROVIDER_ID` | Stable provider id used in `/v1/auth/oidc/:providerId/...`, for example `keycloak`. |
+| `OIDC_PROVIDER_NAME` | Display name returned by provider discovery, for example `Keycloak`. |
+| `OIDC_ISSUER_URL` | Expected Keycloak/OIDC issuer URL. |
+| `OIDC_CLIENT_ID` | OIDC client id registered for account manager. |
+| `OIDC_CLIENT_SECRET` | OIDC client secret. Must be provided through runtime secret management and never logged. |
+| `OIDC_REDIRECT_URL` | Exact backend callback URL registered with Keycloak. |
+| `OIDC_SCOPES` | Space-separated scopes, default `openid email profile`. |
+| `OIDC_AUTO_LINK_EMAIL` | Whether callback may link a validated provider subject to an existing pre-provisioned local user by verified email. Default `false`. |
+
 ## 10. Testing Expectations
 
 Tests should cover:
@@ -1164,6 +1258,21 @@ Tests should cover:
 - Unknown message types and invalid schema versions are rejected or dead-lettered.
 - The maintained test report maps v2 behavior groups to correctness assertions, not only coverage.
 
+Future Keycloak/OIDC implementation tests must cover:
+
+- Provider discovery when OIDC is disabled and enabled.
+- Login redirect creates hashed state and nonce records.
+- Callback rejects invalid state, replayed state, invalid nonce, invalid issuer,
+  invalid audience, expired token, and unverified email.
+- Callback rejects unknown users with `403 user_not_provisioned`.
+- Callback rejects disabled local users.
+- Successful callback links an identity under the configured policy and returns
+  the existing account-manager token response shape.
+- Local email/password login continues to work after OIDC is enabled.
+- Keycloak groups, realm roles, and client roles do not grant account-manager
+  organization access.
+- Keycloak access tokens and refresh tokens are not persisted.
+
 ## 11. Acceptance Criteria
 
 The v1 backend is acceptable when:
@@ -1191,6 +1300,23 @@ The v2 provisioning/event-channel implementation is acceptable when:
 - Retry and dead-letter state are inspectable in the database.
 - Local development can run without Azure using the `log` broker adapter.
 - Automated tests cover the v2 behavior matrix and report correctness evidence.
+
+The planned Keycloak/OIDC authentication implementation is acceptable when:
+
+- Existing email/password login, refresh-token rotation, and account-manager JWT
+  behavior remain supported and documented.
+- Keycloak is treated as an external IdP, not as an embedded account-manager SSO
+  server.
+- Account-manager local users, organization memberships, roles, and device
+  authorization remain the source of truth for API access.
+- The backend callback flow validates state, nonce, issuer, audience, signature,
+  expiry, and verified email before issuing account-manager JWTs.
+- Unknown SSO users return `403 user_not_provisioned`.
+- Disabled local users cannot login through SSO.
+- Successful SSO returns the existing token response shape and does not persist
+  Keycloak access or refresh tokens.
+- Automated tests cover the OIDC behavior matrix and prove local login still
+  works.
 
 ## 12. Contract Follow-Up Scope
 


### PR DESCRIPTION
## Summary

- Adds a dedicated Keycloak/OIDC SSO planned specification document.
- Keeps docs/SPEC.md as the top-level source spec and links to the detailed SSO document.
- Documents backend callback flow, pre-provision linking policy, local role ownership, token model, data model, API contract, config, security policy, tests, and acceptance criteria.

## Validation

- git diff --check HEAD~1..HEAD
