### PR TITLE
[codex] Add OIDC identity persistence

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -359,6 +359,8 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestDeviceMessagePersistenceRejectsInvalidSchemaValues`
 - `rtk_account_manager/internal/store`: `TestEvaluationQuotaUsageUtilizationHandlesZeroAndNonZeroQuotas`
 - `rtk_account_manager/internal/store`: `TestGetOutboxMessageDetailIncludesOperation`
+- `rtk_account_manager/internal/store`: `TestIdentityProviderRejectsRawClientSecretRef`
+- `rtk_account_manager/internal/store`: `TestIdentityProviderStoreCRUDAndEnabledInvariant`
 - `rtk_account_manager/internal/store`: `TestIntegrationDatabaseSchemaInvariants`
 - `rtk_account_manager/internal/store`: `TestJSONHelpers`
 - `rtk_account_manager/internal/store`: `TestLifecycleMetricsAggregatesQueueAndOperationHealth`
@@ -367,6 +369,8 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestListOutboxMessagesByStatusFiltersLifecycleRows`
 - `rtk_account_manager/internal/store`: `TestMergeDeviceMetadataPreservesUnrelatedFields`
 - `rtk_account_manager/internal/store`: `TestMetadataChangedProjectionFiltersNonVideoCloudKeys`
+- `rtk_account_manager/internal/store`: `TestOIDCLoginStateRejectsExpiredState`
+- `rtk_account_manager/internal/store`: `TestOIDCLoginStateStoresHashesAndRejectsReplay`
 - `rtk_account_manager/internal/store`: `TestOnlineChangedProjectionSetsStatusAndLastSeenAt`
 - `rtk_account_manager/internal/store`: `TestOutboxMessagePersistenceAndReadyList`
 - `rtk_account_manager/internal/store`: `TestProjectDeviceProvisioningAndOnlineRules`
@@ -389,6 +393,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestStartDeviceDeactivationOperationRejectsMissingProjectedMetadata`
 - `rtk_account_manager/internal/store`: `TestStartDeviceDeactivationOperationUsesProjectedMetadata`
 - `rtk_account_manager/internal/store`: `TestStartDeviceLifecycleOperationPersistsPendingProvisionMetadata`
+- `rtk_account_manager/internal/store`: `TestUserIdentityStoreEnforcesUniquenessAndListsByUser`
 - `rtk_account_manager/internal/store`: `TestValidatePartitionKeyMatchesOperationSkipsBlankValues`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceDeadLettersInvalidMessages`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceDeadLettersInvalidPartitionKeysAfterPersistingInboxRow/blank_partition_key_is_normalized_for_storage_and_dead-lettered`

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -37,6 +37,55 @@ type AuditEvent struct {
 	UpdatedAt      time.Time      `json:"updated_at"`
 }
 
+type IdentityProviderType string
+
+const (
+	IdentityProviderTypeOIDC IdentityProviderType = "oidc"
+)
+
+type IdentityProvider struct {
+	ID              string               `json:"id"`
+	ProviderID      string               `json:"provider_id"`
+	Name            string               `json:"name"`
+	Type            IdentityProviderType `json:"type"`
+	IssuerURL       string               `json:"issuer_url"`
+	ClientID        string               `json:"client_id"`
+	ClientSecretRef *string              `json:"client_secret_ref,omitempty"`
+	Scopes          []string             `json:"scopes"`
+	Enabled         bool                 `json:"enabled"`
+	Metadata        map[string]any       `json:"metadata"`
+	CreatedAt       time.Time            `json:"created_at"`
+	UpdatedAt       time.Time            `json:"updated_at"`
+}
+
+type UserIdentity struct {
+	ID            string         `json:"id"`
+	UserID        string         `json:"user_id"`
+	ProviderID    string         `json:"provider_id"`
+	ProviderKey   string         `json:"provider_key"`
+	IssuerURL     string         `json:"issuer_url"`
+	Subject       string         `json:"subject"`
+	Email         string         `json:"email"`
+	EmailVerified bool           `json:"email_verified"`
+	Claims        map[string]any `json:"claims"`
+	LinkedAt      time.Time      `json:"linked_at"`
+	LastLoginAt   *time.Time     `json:"last_login_at,omitempty"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+}
+
+type OIDCLoginState struct {
+	ID                   string     `json:"id"`
+	ProviderID           string     `json:"provider_id"`
+	StateHash            string     `json:"state_hash"`
+	NonceHash            string     `json:"nonce_hash"`
+	RedirectURL          string     `json:"redirect_url"`
+	PostLoginRedirectURL *string    `json:"post_login_redirect_url,omitempty"`
+	ExpiresAt            time.Time  `json:"expires_at"`
+	ConsumedAt           *time.Time `json:"consumed_at,omitempty"`
+	CreatedAt            time.Time  `json:"created_at"`
+}
+
 type DeviceClaimToken struct {
 	ID              string         `json:"id"`
 	OrganizationID  *string        `json:"organization_id,omitempty"`

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -43,7 +43,7 @@ func newStoreIntegrationEnv(t *testing.T) storeIntegrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-			TRUNCATE device_claims, device_claim_tokens, device_message_inbox, device_message_outbox, device_operations, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
+			TRUNCATE oidc_login_states, user_identities, identity_providers, device_claims, device_claim_tokens, device_message_inbox, device_message_outbox, device_operations, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
 			RESTART IDENTITY CASCADE
 		`); err != nil {
 		t.Fatal(err)

--- a/internal/store/oidc.go
+++ b/internal/store/oidc.go
@@ -1,0 +1,441 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"rtk_account_manager/internal/model"
+)
+
+type IdentityProviderCreateInput struct {
+	ProviderID      string
+	Name            string
+	Type            model.IdentityProviderType
+	IssuerURL       string
+	ClientID        string
+	ClientSecretRef *string
+	Scopes          []string
+	Enabled         bool
+	Metadata        map[string]any
+	Now             time.Time
+}
+
+type IdentityProviderUpdateInput struct {
+	ProviderID      string
+	Name            *string
+	IssuerURL       *string
+	ClientID        *string
+	ClientSecretRef *string
+	Scopes          []string
+	Enabled         *bool
+	Metadata        map[string]any
+	Now             time.Time
+}
+
+type IdentityProviderListFilter struct {
+	Limit  int
+	Offset int
+}
+
+type UserIdentityCreateInput struct {
+	UserID        string
+	ProviderID    string
+	IssuerURL     string
+	Subject       string
+	Email         string
+	EmailVerified bool
+	Claims        map[string]any
+	Now           time.Time
+}
+
+type OIDCLoginStateCreateInput struct {
+	ProviderID           string
+	StateHash            string
+	NonceHash            string
+	RedirectURL          string
+	PostLoginRedirectURL *string
+	ExpiresAt            time.Time
+	Now                  time.Time
+}
+
+func (s *Store) CreateIdentityProvider(ctx context.Context, in IdentityProviderCreateInput) (model.IdentityProvider, error) {
+	metadata, err := json.Marshal(defaultMetadata(in.Metadata))
+	if err != nil {
+		return model.IdentityProvider{}, err
+	}
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	scopes := in.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "email", "profile"}
+	}
+	providerType := in.Type
+	if providerType == "" {
+		providerType = model.IdentityProviderTypeOIDC
+	}
+	return scanIdentityProvider(s.db.QueryRow(ctx, `
+		INSERT INTO identity_providers (
+			provider_id,
+			name,
+			type,
+			issuer_url,
+			client_id,
+			client_secret_ref,
+			scopes,
+			enabled,
+			metadata,
+			created_at,
+			updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+		RETURNING id::text, provider_id, name, type, issuer_url, client_id, client_secret_ref, scopes, enabled, metadata, created_at, updated_at
+	`, strings.TrimSpace(in.ProviderID), strings.TrimSpace(in.Name), providerType, strings.TrimSpace(in.IssuerURL), strings.TrimSpace(in.ClientID), in.ClientSecretRef, scopes, in.Enabled, metadata, now))
+}
+
+func (s *Store) ListIdentityProviders(ctx context.Context, in IdentityProviderListFilter) (IdentityProviderPage, error) {
+	var total int
+	if err := s.db.QueryRow(ctx, `SELECT count(*)::int FROM identity_providers`).Scan(&total); err != nil {
+		return IdentityProviderPage{}, err
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT id::text, provider_id, name, type, issuer_url, client_id, client_secret_ref, scopes, enabled, metadata, created_at, updated_at
+		FROM identity_providers
+		ORDER BY created_at DESC
+		LIMIT $1 OFFSET $2
+	`, in.Limit, in.Offset)
+	if err != nil {
+		return IdentityProviderPage{}, err
+	}
+	defer rows.Close()
+
+	providers := []model.IdentityProvider{}
+	for rows.Next() {
+		provider, err := scanIdentityProvider(rows)
+		if err != nil {
+			return IdentityProviderPage{}, err
+		}
+		providers = append(providers, provider)
+	}
+	if err := rows.Err(); err != nil {
+		return IdentityProviderPage{}, err
+	}
+	return IdentityProviderPage{Providers: providers, Page: Page{Limit: in.Limit, Offset: in.Offset, Total: total}}, nil
+}
+
+func (s *Store) GetIdentityProviderByProviderID(ctx context.Context, providerID string) (model.IdentityProvider, error) {
+	provider, err := scanIdentityProvider(s.db.QueryRow(ctx, `
+		SELECT id::text, provider_id, name, type, issuer_url, client_id, client_secret_ref, scopes, enabled, metadata, created_at, updated_at
+		FROM identity_providers
+		WHERE provider_id = $1
+	`, providerID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.IdentityProvider{}, ErrNotFound
+	}
+	return provider, err
+}
+
+func (s *Store) GetEnabledIdentityProvider(ctx context.Context) (model.IdentityProvider, error) {
+	provider, err := scanIdentityProvider(s.db.QueryRow(ctx, `
+		SELECT id::text, provider_id, name, type, issuer_url, client_id, client_secret_ref, scopes, enabled, metadata, created_at, updated_at
+		FROM identity_providers
+		WHERE enabled IS TRUE
+		LIMIT 1
+	`))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.IdentityProvider{}, ErrNotFound
+	}
+	return provider, err
+}
+
+func (s *Store) UpdateIdentityProvider(ctx context.Context, in IdentityProviderUpdateInput) (model.IdentityProvider, error) {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	var metadata []byte
+	var err error
+	if in.Metadata != nil {
+		metadata, err = json.Marshal(defaultMetadata(in.Metadata))
+		if err != nil {
+			return model.IdentityProvider{}, err
+		}
+	}
+	var scopes any
+	if in.Scopes != nil {
+		scopes = in.Scopes
+	}
+	provider, err := scanIdentityProvider(s.db.QueryRow(ctx, `
+		UPDATE identity_providers
+		SET
+			name = COALESCE($2, name),
+			issuer_url = COALESCE($3, issuer_url),
+			client_id = COALESCE($4, client_id),
+			client_secret_ref = COALESCE($5, client_secret_ref),
+			scopes = COALESCE($6, scopes),
+			enabled = COALESCE($7, enabled),
+			metadata = COALESCE($8, metadata),
+			updated_at = $9
+		WHERE provider_id = $1
+		RETURNING id::text, provider_id, name, type, issuer_url, client_id, client_secret_ref, scopes, enabled, metadata, created_at, updated_at
+	`, in.ProviderID, in.Name, in.IssuerURL, in.ClientID, in.ClientSecretRef, scopes, in.Enabled, metadata, now))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.IdentityProvider{}, ErrNotFound
+	}
+	return provider, err
+}
+
+func (s *Store) DisableIdentityProvider(ctx context.Context, providerID string, now time.Time) (model.IdentityProvider, error) {
+	enabled := false
+	return s.UpdateIdentityProvider(ctx, IdentityProviderUpdateInput{
+		ProviderID: providerID,
+		Enabled:    &enabled,
+		Now:        now,
+	})
+}
+
+func (s *Store) CreateUserIdentity(ctx context.Context, in UserIdentityCreateInput) (model.UserIdentity, error) {
+	claims, err := json.Marshal(defaultMetadata(in.Claims))
+	if err != nil {
+		return model.UserIdentity{}, err
+	}
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return scanUserIdentity(s.db.QueryRow(ctx, `
+		WITH inserted AS (
+			INSERT INTO user_identities (
+			user_id,
+			provider_id,
+			issuer_url,
+			subject,
+			email,
+			email_verified,
+			claims,
+			linked_at,
+			created_at,
+			updated_at
+			)
+			VALUES ($1, $2, $3, $4, lower(btrim($5)), $6, $7, $8, $8, $8)
+			RETURNING *
+		)
+		SELECT inserted.id::text, inserted.user_id::text, inserted.provider_id::text, identity_providers.provider_id, inserted.issuer_url, inserted.subject, inserted.email, inserted.email_verified, inserted.claims, inserted.linked_at, inserted.last_login_at, inserted.created_at, inserted.updated_at
+		FROM inserted
+		JOIN identity_providers ON identity_providers.id = inserted.provider_id
+	`, in.UserID, in.ProviderID, strings.TrimSpace(in.IssuerURL), strings.TrimSpace(in.Subject), in.Email, in.EmailVerified, claims, now))
+}
+
+func (s *Store) ListUserIdentities(ctx context.Context, userID string) ([]model.UserIdentity, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT user_identities.id::text, user_identities.user_id::text, user_identities.provider_id::text, identity_providers.provider_id, user_identities.issuer_url, user_identities.subject, user_identities.email, user_identities.email_verified, user_identities.claims, user_identities.linked_at, user_identities.last_login_at, user_identities.created_at, user_identities.updated_at
+		FROM user_identities
+		JOIN identity_providers ON identity_providers.id = user_identities.provider_id
+		WHERE user_identities.user_id = $1
+		ORDER BY user_identities.linked_at DESC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	identities := []model.UserIdentity{}
+	for rows.Next() {
+		identity, err := scanUserIdentity(rows)
+		if err != nil {
+			return nil, err
+		}
+		identities = append(identities, identity)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return identities, nil
+}
+
+func (s *Store) GetUserIdentityByProviderSubject(ctx context.Context, providerID, subject string) (model.UserIdentity, error) {
+	identity, err := scanUserIdentity(s.db.QueryRow(ctx, `
+		SELECT user_identities.id::text, user_identities.user_id::text, user_identities.provider_id::text, identity_providers.provider_id, user_identities.issuer_url, user_identities.subject, user_identities.email, user_identities.email_verified, user_identities.claims, user_identities.linked_at, user_identities.last_login_at, user_identities.created_at, user_identities.updated_at
+		FROM user_identities
+		JOIN identity_providers ON identity_providers.id = user_identities.provider_id
+		WHERE user_identities.provider_id = $1 AND user_identities.subject = $2
+	`, providerID, subject))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.UserIdentity{}, ErrNotFound
+	}
+	return identity, err
+}
+
+func (s *Store) UpdateUserIdentityLastLogin(ctx context.Context, identityID string, lastLoginAt time.Time) (model.UserIdentity, error) {
+	identity, err := scanUserIdentity(s.db.QueryRow(ctx, `
+		WITH updated AS (
+			UPDATE user_identities
+			SET last_login_at = $2, updated_at = $2
+			WHERE id = $1
+			RETURNING *
+		)
+		SELECT updated.id::text, updated.user_id::text, updated.provider_id::text, identity_providers.provider_id, updated.issuer_url, updated.subject, updated.email, updated.email_verified, updated.claims, updated.linked_at, updated.last_login_at, updated.created_at, updated.updated_at
+		FROM updated
+		JOIN identity_providers ON identity_providers.id = updated.provider_id
+	`, identityID, lastLoginAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.UserIdentity{}, ErrNotFound
+	}
+	return identity, err
+}
+
+func (s *Store) DeleteUserIdentity(ctx context.Context, userID, identityID string) error {
+	tag, err := s.db.Exec(ctx, `
+		DELETE FROM user_identities
+		WHERE user_id = $1 AND id = $2
+	`, userID, identityID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) CreateOIDCLoginState(ctx context.Context, in OIDCLoginStateCreateInput) (model.OIDCLoginState, error) {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return scanOIDCLoginState(s.db.QueryRow(ctx, `
+		INSERT INTO oidc_login_states (
+			provider_id,
+			state_hash,
+			nonce_hash,
+			redirect_url,
+			post_login_redirect_url,
+			expires_at,
+			created_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id::text, provider_id::text, state_hash, nonce_hash, redirect_url, post_login_redirect_url, expires_at, consumed_at, created_at
+	`, in.ProviderID, in.StateHash, in.NonceHash, in.RedirectURL, in.PostLoginRedirectURL, in.ExpiresAt, now))
+}
+
+func (s *Store) ConsumeOIDCLoginState(ctx context.Context, stateHash string, now time.Time) (model.OIDCLoginState, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.OIDCLoginState{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	state, err := scanOIDCLoginState(tx.QueryRow(ctx, `
+		SELECT id::text, provider_id::text, state_hash, nonce_hash, redirect_url, post_login_redirect_url, expires_at, consumed_at, created_at
+		FROM oidc_login_states
+		WHERE state_hash = $1
+		FOR UPDATE
+	`, stateHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.OIDCLoginState{}, ErrOIDCStateInvalid
+	}
+	if err != nil {
+		return model.OIDCLoginState{}, err
+	}
+	if state.ConsumedAt != nil {
+		return model.OIDCLoginState{}, ErrOIDCStateInvalid
+	}
+	if !state.ExpiresAt.After(now) {
+		return model.OIDCLoginState{}, ErrOIDCStateExpired
+	}
+	consumed, err := scanOIDCLoginState(tx.QueryRow(ctx, `
+		UPDATE oidc_login_states
+		SET consumed_at = $2
+		WHERE id = $1
+		RETURNING id::text, provider_id::text, state_hash, nonce_hash, redirect_url, post_login_redirect_url, expires_at, consumed_at, created_at
+	`, state.ID, now))
+	if err != nil {
+		return model.OIDCLoginState{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.OIDCLoginState{}, err
+	}
+	return consumed, nil
+}
+
+func scanIdentityProvider(row rowScanner) (model.IdentityProvider, error) {
+	var provider model.IdentityProvider
+	var metadata []byte
+	err := row.Scan(
+		&provider.ID,
+		&provider.ProviderID,
+		&provider.Name,
+		&provider.Type,
+		&provider.IssuerURL,
+		&provider.ClientID,
+		&provider.ClientSecretRef,
+		&provider.Scopes,
+		&provider.Enabled,
+		&metadata,
+		&provider.CreatedAt,
+		&provider.UpdatedAt,
+	)
+	if err != nil {
+		return model.IdentityProvider{}, err
+	}
+	provider.Metadata, err = unmarshalJSONMap(metadata)
+	if err != nil {
+		return model.IdentityProvider{}, err
+	}
+	return provider, nil
+}
+
+func scanUserIdentity(row rowScanner) (model.UserIdentity, error) {
+	var identity model.UserIdentity
+	var claims []byte
+	err := row.Scan(
+		&identity.ID,
+		&identity.UserID,
+		&identity.ProviderID,
+		&identity.ProviderKey,
+		&identity.IssuerURL,
+		&identity.Subject,
+		&identity.Email,
+		&identity.EmailVerified,
+		&claims,
+		&identity.LinkedAt,
+		&identity.LastLoginAt,
+		&identity.CreatedAt,
+		&identity.UpdatedAt,
+	)
+	if err != nil {
+		return model.UserIdentity{}, err
+	}
+	identity.Claims, err = unmarshalJSONMap(claims)
+	if err != nil {
+		return model.UserIdentity{}, err
+	}
+	return identity, nil
+}
+
+func scanOIDCLoginState(row rowScanner) (model.OIDCLoginState, error) {
+	var state model.OIDCLoginState
+	err := row.Scan(
+		&state.ID,
+		&state.ProviderID,
+		&state.StateHash,
+		&state.NonceHash,
+		&state.RedirectURL,
+		&state.PostLoginRedirectURL,
+		&state.ExpiresAt,
+		&state.ConsumedAt,
+		&state.CreatedAt,
+	)
+	if err != nil {
+		return model.OIDCLoginState{}, err
+	}
+	return state, nil
+}

--- a/internal/store/oidc_integration_test.go
+++ b/internal/store/oidc_integration_test.go
@@ -1,0 +1,294 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"rtk_account_manager/internal/model"
+)
+
+func TestIdentityProviderStoreCRUDAndEnabledInvariant(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	secretRef := "env:OIDC_CLIENT_SECRET"
+
+	provider, err := env.store.CreateIdentityProvider(ctx, IdentityProviderCreateInput{
+		ProviderID:      "keycloak",
+		Name:            "Keycloak",
+		Type:            model.IdentityProviderTypeOIDC,
+		IssuerURL:       "https://keycloak.example.test/realms/account",
+		ClientID:        "account-manager",
+		ClientSecretRef: &secretRef,
+		Scopes:          []string{"openid", "email", "profile"},
+		Enabled:         true,
+		Metadata:        map[string]any{"realm": "account"},
+		Now:             now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.ProviderID != "keycloak" || provider.Type != model.IdentityProviderTypeOIDC || !provider.Enabled {
+		t.Fatalf("unexpected provider: %+v", provider)
+	}
+	if provider.ClientSecretRef == nil || *provider.ClientSecretRef != secretRef {
+		t.Fatalf("expected secret ref only, got %+v", provider)
+	}
+	if got := provider.Metadata["realm"]; got != "account" {
+		t.Fatalf("expected metadata to round trip, got %+v", provider.Metadata)
+	}
+
+	fetched, err := env.store.GetIdentityProviderByProviderID(ctx, "keycloak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != provider.ID {
+		t.Fatalf("expected provider %s, got %+v", provider.ID, fetched)
+	}
+
+	listed, err := env.store.ListIdentityProviders(ctx, IdentityProviderListFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listed.Page.Total != 1 || len(listed.Providers) != 1 || listed.Providers[0].ID != provider.ID {
+		t.Fatalf("expected provider in list, got %+v", listed)
+	}
+
+	updatedName := "Keycloak Updated"
+	disabled, err := env.store.UpdateIdentityProvider(ctx, IdentityProviderUpdateInput{
+		ProviderID: "keycloak",
+		Name:       &updatedName,
+		Enabled:    boolPtr(false),
+		Metadata:   map[string]any{"realm": "updated"},
+		Now:        now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled.Name != updatedName || disabled.Enabled {
+		t.Fatalf("expected disabled updated provider, got %+v", disabled)
+	}
+
+	enabled, err := env.store.UpdateIdentityProvider(ctx, IdentityProviderUpdateInput{
+		ProviderID: "keycloak",
+		Enabled:    boolPtr(true),
+		Now:        now.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled.Enabled {
+		t.Fatalf("expected enabled provider, got %+v", enabled)
+	}
+
+	_, err = env.store.CreateIdentityProvider(ctx, IdentityProviderCreateInput{
+		ProviderID:      "second",
+		Name:            "Second",
+		Type:            model.IdentityProviderTypeOIDC,
+		IssuerURL:       "https://second.example.test/realms/account",
+		ClientID:        "account-manager",
+		ClientSecretRef: &secretRef,
+		Scopes:          []string{"openid"},
+		Enabled:         true,
+		Now:             now,
+	})
+	if err == nil {
+		t.Fatal("expected second enabled provider to be rejected")
+	}
+
+	var rawSecretCount int
+	if err := env.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM identity_providers
+		WHERE client_secret_ref = 'raw-client-secret' OR metadata::text LIKE '%raw-client-secret%'
+	`).Scan(&rawSecretCount); err != nil {
+		t.Fatal(err)
+	}
+	if rawSecretCount != 0 {
+		t.Fatal("raw OIDC client secret was persisted")
+	}
+}
+
+func TestIdentityProviderRejectsRawClientSecretRef(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	rawSecret := "raw-client-secret"
+
+	_, err := env.store.CreateIdentityProvider(ctx, IdentityProviderCreateInput{
+		ProviderID:      "bad-secret",
+		Name:            "Bad Secret",
+		Type:            model.IdentityProviderTypeOIDC,
+		IssuerURL:       "https://keycloak.example.test/realms/account",
+		ClientID:        "account-manager",
+		ClientSecretRef: &rawSecret,
+		Scopes:          []string{"openid"},
+	})
+	if err == nil {
+		t.Fatal("expected raw client secret ref to be rejected")
+	}
+}
+
+func TestUserIdentityStoreEnforcesUniquenessAndListsByUser(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "oidc-user@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "OIDC User Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := createOIDCTestProvider(t, env, "keycloak", false)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	identity, err := env.store.CreateUserIdentity(ctx, UserIdentityCreateInput{
+		UserID:        registered.User.ID,
+		ProviderID:    provider.ID,
+		IssuerURL:     provider.IssuerURL,
+		Subject:       "subject-1",
+		Email:         "oidc-user@example.com",
+		EmailVerified: true,
+		Claims:        map[string]any{"preferred_username": "oidc-user"},
+		Now:           now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.ProviderKey != "keycloak" || identity.Email != "oidc-user@example.com" || !identity.EmailVerified {
+		t.Fatalf("unexpected identity: %+v", identity)
+	}
+
+	listed, err := env.store.ListUserIdentities(ctx, registered.User.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || listed[0].ID != identity.ID {
+		t.Fatalf("expected identity in user list, got %+v", listed)
+	}
+
+	_, err = env.store.GetUserIdentityByProviderSubject(ctx, provider.ID, "subject-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = env.store.CreateUserIdentity(ctx, UserIdentityCreateInput{
+		UserID:        registered.User.ID,
+		ProviderID:    provider.ID,
+		IssuerURL:     provider.IssuerURL,
+		Subject:       "subject-1",
+		Email:         "oidc-user@example.com",
+		EmailVerified: true,
+	})
+	if err == nil {
+		t.Fatal("expected duplicate provider subject to be rejected")
+	}
+
+	lastLoginAt := now.Add(time.Minute)
+	updated, err := env.store.UpdateUserIdentityLastLogin(ctx, identity.ID, lastLoginAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.LastLoginAt == nil || !updated.LastLoginAt.Equal(lastLoginAt) {
+		t.Fatalf("expected last login update, got %+v", updated)
+	}
+
+	if err := env.store.DeleteUserIdentity(ctx, registered.User.ID, identity.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.store.GetUserIdentityByProviderSubject(ctx, provider.ID, "subject-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected identity to be deleted, got %v", err)
+	}
+}
+
+func TestOIDCLoginStateStoresHashesAndRejectsReplay(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	provider := createOIDCTestProvider(t, env, "keycloak", false)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	postLogin := "https://app.example.test/done"
+
+	state, err := env.store.CreateOIDCLoginState(ctx, OIDCLoginStateCreateInput{
+		ProviderID:           provider.ID,
+		StateHash:            "hashed-state",
+		NonceHash:            "hashed-nonce",
+		RedirectURL:          "https://api.example.test/v1/auth/oidc/keycloak/callback",
+		PostLoginRedirectURL: &postLogin,
+		ExpiresAt:            now.Add(10 * time.Minute),
+		Now:                  now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.StateHash != "hashed-state" || state.NonceHash != "hashed-nonce" {
+		t.Fatalf("expected hashes to round trip, got %+v", state)
+	}
+
+	var rawCount int
+	if err := env.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM oidc_login_states
+		WHERE state_hash = 'raw-state' OR nonce_hash = 'raw-nonce'
+	`).Scan(&rawCount); err != nil {
+		t.Fatal(err)
+	}
+	if rawCount != 0 {
+		t.Fatal("raw OIDC state or nonce was persisted")
+	}
+
+	consumed, err := env.store.ConsumeOIDCLoginState(ctx, "hashed-state", now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if consumed.ConsumedAt == nil {
+		t.Fatalf("expected consumed_at, got %+v", consumed)
+	}
+	if _, err := env.store.ConsumeOIDCLoginState(ctx, "hashed-state", now.Add(2*time.Minute)); !errors.Is(err, ErrOIDCStateInvalid) {
+		t.Fatalf("expected replay to be rejected, got %v", err)
+	}
+	if _, err := env.store.ConsumeOIDCLoginState(ctx, "missing-state", now); !errors.Is(err, ErrOIDCStateInvalid) {
+		t.Fatalf("expected missing state to be rejected, got %v", err)
+	}
+}
+
+func TestOIDCLoginStateRejectsExpiredState(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+	provider := createOIDCTestProvider(t, env, "keycloak", false)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := env.store.CreateOIDCLoginState(ctx, OIDCLoginStateCreateInput{
+		ProviderID:  provider.ID,
+		StateHash:   "expired-state",
+		NonceHash:   "expired-nonce",
+		RedirectURL: "https://api.example.test/callback",
+		ExpiresAt:   now.Add(-time.Minute),
+		Now:         now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.store.ConsumeOIDCLoginState(ctx, "expired-state", now); !errors.Is(err, ErrOIDCStateExpired) {
+		t.Fatalf("expected expired state to be rejected, got %v", err)
+	}
+}
+
+func createOIDCTestProvider(t *testing.T, env storeIntegrationEnv, providerID string, enabled bool) model.IdentityProvider {
+	t.Helper()
+	secretRef := "env:OIDC_CLIENT_SECRET"
+	provider, err := env.store.CreateIdentityProvider(context.Background(), IdentityProviderCreateInput{
+		ProviderID:      providerID,
+		Name:            "Keycloak",
+		Type:            model.IdentityProviderTypeOIDC,
+		IssuerURL:       "https://keycloak.example.test/realms/account",
+		ClientID:        "account-manager",
+		ClientSecretRef: &secretRef,
+		Scopes:          []string{"openid", "email", "profile"},
+		Enabled:         enabled,
+		Metadata:        map[string]any{"realm": "account"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return provider
+}

--- a/internal/store/schema_integration_test.go
+++ b/internal/store/schema_integration_test.go
@@ -17,7 +17,10 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 		"device_message_inbox",
 		"device_message_outbox",
 		"device_operations",
+		"identity_providers",
+		"oidc_login_states",
 		"quota_raise_requests",
+		"user_identities",
 	}
 	for _, table := range requiredTables {
 		requireTable(t, ctx, env, table)
@@ -29,9 +32,13 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 		"device_message_inbox": {"message_id", "operation_id", "stream", "message_type", "schema_version", "partition_key", "status", "payload", "attempt_count"},
 		"device_message_outbox": {"message_id", "operation_id", "stream", "message_type", "schema_version", "partition_key", "status", "payload",
 			"attempt_count", "available_at"},
-		"audit_events":         {"event_type", "subject_type", "subject_id", "actor_user_id", "organization_id", "payload"},
-		"quota_raise_requests": {"organization_id", "requested_by", "requested_quota", "status", "contact_info", "decision_reason"},
-		"device_operations":    {"operation_id", "organization_id", "device_id", "operation_type", "status", "request_payload", "result_payload"},
+		"audit_events":       {"event_type", "subject_type", "subject_id", "actor_user_id", "organization_id", "payload"},
+		"identity_providers": {"provider_id", "name", "type", "issuer_url", "client_id", "client_secret_ref", "scopes", "enabled", "metadata"},
+		"oidc_login_states":  {"provider_id", "state_hash", "nonce_hash", "redirect_url", "post_login_redirect_url", "expires_at", "consumed_at"},
+		"quota_raise_requests": {"organization_id", "requested_by", "requested_quota", "status", "contact_info",
+			"decision_reason"},
+		"user_identities":   {"user_id", "provider_id", "issuer_url", "subject", "email", "email_verified", "claims", "linked_at", "last_login_at"},
+		"device_operations": {"operation_id", "organization_id", "device_id", "operation_type", "status", "request_payload", "result_payload"},
 	}
 	for table, columns := range requiredColumns {
 		for _, column := range columns {
@@ -65,8 +72,17 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 		{table: "device_claim_tokens", name: "device_claim_tokens_token_hash_key"},
 		{table: "device_claims", name: "device_claims_claim_token_id_key"},
 		{table: "device_claims", name: "device_claims_status_check"},
+		{table: "identity_providers", name: "identity_providers_provider_id_key"},
+		{table: "identity_providers", name: "identity_providers_provider_id_not_blank"},
+		{table: "identity_providers", name: "identity_providers_type_check"},
+		{table: "identity_providers", name: "identity_providers_client_secret_ref_check"},
+		{table: "oidc_login_states", name: "oidc_login_states_state_hash_key"},
 		{table: "quota_raise_requests", name: "quota_raise_requests_requested_quota_check"},
 		{table: "quota_raise_requests", name: "quota_raise_requests_status_check"},
+		{table: "user_identities", name: "user_identities_provider_subject_key"},
+		{table: "user_identities", name: "user_identities_user_provider_key"},
+		{table: "user_identities", name: "user_identities_email_normalized"},
+		{table: "user_identities", name: "user_identities_email_verified_check"},
 	}
 	for _, constraint := range requiredConstraints {
 		requireConstraint(t, ctx, env, constraint.table, constraint.name)
@@ -88,7 +104,11 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 		"device_operations_org_device_created_idx",
 		"device_operations_status_created_idx",
 		"devices_org_serial_unique",
+		"identity_providers_enabled_unique_idx",
+		"oidc_login_states_provider_created_idx",
+		"oidc_login_states_active_idx",
 		"quota_raise_requests_org_status_idx",
+		"user_identities_user_idx",
 	}
 	for _, index := range requiredIndexes {
 		requireIndex(t, ctx, env, index)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -27,6 +27,8 @@ var (
 	ErrClaimUnsupportedCategory = errors.New("claim token category is unsupported")
 	ErrClaimInvalidState        = errors.New("claim token state does not allow this operation")
 	ErrClaimEvidenceRequired    = errors.New("claim override requires operator evidence")
+	ErrOIDCStateInvalid         = errors.New("oidc login state is invalid")
+	ErrOIDCStateExpired         = errors.New("oidc login state is expired")
 )
 
 type Store struct {
@@ -81,6 +83,11 @@ type QuotaRaiseRequestPage struct {
 type AuditEventPage struct {
 	Events []model.AuditEvent
 	Page   Page
+}
+
+type IdentityProviderPage struct {
+	Providers []model.IdentityProvider
+	Page      Page
 }
 
 type RegisterInput struct {

--- a/migrations/015_oidc_identity_persistence.sql
+++ b/migrations/015_oidc_identity_persistence.sql
@@ -1,0 +1,86 @@
+CREATE TABLE IF NOT EXISTS identity_providers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider_id TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    issuer_url TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    client_secret_ref TEXT,
+    scopes TEXT[] NOT NULL DEFAULT ARRAY['openid', 'email', 'profile'],
+    enabled BOOLEAN NOT NULL DEFAULT false,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT identity_providers_provider_id_not_blank CHECK (btrim(provider_id) <> ''),
+    CONSTRAINT identity_providers_name_not_blank CHECK (btrim(name) <> ''),
+    CONSTRAINT identity_providers_type_check CHECK (type IN ('oidc')),
+    CONSTRAINT identity_providers_issuer_url_not_blank CHECK (btrim(issuer_url) <> ''),
+    CONSTRAINT identity_providers_client_id_not_blank CHECK (btrim(client_id) <> ''),
+    CONSTRAINT identity_providers_client_secret_ref_check
+        CHECK (client_secret_ref IS NULL OR client_secret_ref ~ '^env:[A-Za-z_][A-Za-z0-9_]*$')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS identity_providers_enabled_unique_idx
+    ON identity_providers (enabled)
+    WHERE enabled IS TRUE;
+
+CREATE INDEX IF NOT EXISTS identity_providers_provider_id_idx
+    ON identity_providers (provider_id);
+
+DROP TRIGGER IF EXISTS identity_providers_set_updated_at ON identity_providers;
+CREATE TRIGGER identity_providers_set_updated_at
+    BEFORE UPDATE ON identity_providers
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();
+
+CREATE TABLE IF NOT EXISTS user_identities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_id UUID NOT NULL REFERENCES identity_providers(id) ON DELETE CASCADE,
+    issuer_url TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    email TEXT NOT NULL,
+    email_verified BOOLEAN NOT NULL,
+    claims JSONB NOT NULL DEFAULT '{}'::jsonb,
+    linked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_login_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT user_identities_provider_subject_key UNIQUE (provider_id, subject),
+    CONSTRAINT user_identities_user_provider_key UNIQUE (user_id, provider_id),
+    CONSTRAINT user_identities_issuer_url_not_blank CHECK (btrim(issuer_url) <> ''),
+    CONSTRAINT user_identities_subject_not_blank CHECK (btrim(subject) <> ''),
+    CONSTRAINT user_identities_email_normalized CHECK (email = lower(btrim(email)) AND email <> ''),
+    CONSTRAINT user_identities_email_verified_check CHECK (email_verified IS TRUE)
+);
+
+CREATE INDEX IF NOT EXISTS user_identities_user_idx
+    ON user_identities (user_id);
+
+DROP TRIGGER IF EXISTS user_identities_set_updated_at ON user_identities;
+CREATE TRIGGER user_identities_set_updated_at
+    BEFORE UPDATE ON user_identities
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();
+
+CREATE TABLE IF NOT EXISTS oidc_login_states (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider_id UUID NOT NULL REFERENCES identity_providers(id) ON DELETE CASCADE,
+    state_hash TEXT NOT NULL UNIQUE,
+    nonce_hash TEXT NOT NULL,
+    redirect_url TEXT NOT NULL,
+    post_login_redirect_url TEXT,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT oidc_login_states_state_hash_not_blank CHECK (btrim(state_hash) <> ''),
+    CONSTRAINT oidc_login_states_nonce_hash_not_blank CHECK (btrim(nonce_hash) <> ''),
+    CONSTRAINT oidc_login_states_redirect_url_not_blank CHECK (btrim(redirect_url) <> '')
+);
+
+CREATE INDEX IF NOT EXISTS oidc_login_states_provider_created_idx
+    ON oidc_login_states (provider_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS oidc_login_states_active_idx
+    ON oidc_login_states (expires_at)
+    WHERE consumed_at IS NULL;


### PR DESCRIPTION
## Summary

- Adds OIDC persistence tables for identity providers, user identity links, and login state records.
- Adds model/store APIs for provider CRUD, user identity linking, and hashed state/nonce creation and consume.
- Extends store/schema integration tests for uniqueness, one-enabled-provider invariant, state replay rejection, and secret/hash persistence boundaries.

Closes #142

## Tests

- go test ./internal/store
- go test ./internal/database ./internal/model
- go test ./...
- git diff --check
