### PR TITLE
Implement public OIDC login and callback API

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,7 +35,21 @@ func main() {
 		log.Fatalf("unsupported AUTH_TOKEN_DELIVERY %q", cfg.AuthTokenDelivery)
 	}
 	notificationSink := quotaRaiseNotificationSink(cfg)
-	server := api.NewWithAuthTokenAndNotificationSink(store.New(db), authService, authTokenSink, notificationSink)
+	accountStore := store.New(db)
+	server := api.NewWithAuthTokenAndNotificationSink(accountStore, authService, authTokenSink, notificationSink)
+	server.ConfigureOIDC(api.OIDCOptions{
+		Env: auth.OIDCEnvConfig{
+			Enabled:       cfg.OIDCEnabled,
+			ProviderID:    cfg.OIDCProviderID,
+			ProviderName:  cfg.OIDCProviderName,
+			IssuerURL:     cfg.OIDCIssuerURL,
+			ClientID:      cfg.OIDCClientID,
+			ClientSecret:  cfg.OIDCClientSecret,
+			RedirectURL:   cfg.OIDCRedirectURL,
+			Scopes:        cfg.OIDCScopes,
+			AutoLinkEmail: cfg.OIDCAutoLinkEmail,
+		},
+	})
 
 	log.Printf("listening on :%s", cfg.Port)
 	if err := server.Router().Run(":" + cfg.Port); err != nil {

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -173,6 +173,12 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestIntegrationLastOwnerCannotBeRemovedOrDowngraded`
 - `rtk_account_manager/internal/api`: `TestIntegrationListPaginationMetadata`
 - `rtk_account_manager/internal/api`: `TestIntegrationMigrationsAreIdempotent`
+- `rtk_account_manager/internal/api`: `TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers/disabled_linked_user`
+- `rtk_account_manager/internal/api`: `TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers/unknown_without_auto_link`
+- `rtk_account_manager/internal/api`: `TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers/unverified_email`
+- `rtk_account_manager/internal/api`: `TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers`
+- `rtk_account_manager/internal/api`: `TestIntegrationOIDCDisabledDiscoveryAndLogin`
+- `rtk_account_manager/internal/api`: `TestIntegrationOIDCProviderLoginAndCallback`
 - `rtk_account_manager/internal/api`: `TestIntegrationOwnerCanDisableAndEnableMemberUser`
 - `rtk_account_manager/internal/api`: `TestIntegrationOwnerCanUpdateAndRemoveMember`
 - `rtk_account_manager/internal/api`: `TestIntegrationOwnerCanUpdateOrganization`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -28,6 +28,10 @@ type Server struct {
 	quotaRaiseNotificationSink QuotaRaiseNotificationSink
 	signupLimiter              *signupLimiter
 	signupPolicy               signupPolicy
+	oidcResolver               auth.ProviderResolver
+	oidcClient                 auth.OIDCClient
+	oidcStateTTL               time.Duration
+	oidcEnvClientSecretRef     string
 }
 
 var ErrAuthTokenSinkUnavailable = errors.New("auth token sink unavailable")
@@ -44,6 +48,36 @@ func newServer(store *store.Store, authService *auth.Service, sink AuthTokenSink
 
 func New(store *store.Store, authService *auth.Service) *Server {
 	return newServer(store, authService, nil)
+}
+
+type OIDCOptions struct {
+	Env             auth.OIDCEnvConfig
+	HTTPClient      *http.Client
+	Now             func() time.Time
+	StateTTL        time.Duration
+	ClientSecretRef string
+}
+
+func (s *Server) ConfigureOIDC(options OIDCOptions) {
+	s.oidcResolver = auth.ProviderResolver{
+		Store: s.store,
+		Env:   options.Env,
+		IsNotFound: func(err error) bool {
+			return errors.Is(err, store.ErrNotFound)
+		},
+	}
+	s.oidcClient = auth.OIDCClient{
+		HTTPClient: options.HTTPClient,
+		Now:        options.Now,
+	}
+	s.oidcStateTTL = options.StateTTL
+	if s.oidcStateTTL <= 0 {
+		s.oidcStateTTL = 10 * time.Minute
+	}
+	s.oidcEnvClientSecretRef = options.ClientSecretRef
+	if s.oidcEnvClientSecretRef == "" {
+		s.oidcEnvClientSecretRef = "env:OIDC_CLIENT_SECRET"
+	}
 }
 
 type AuthTokenDelivery struct {
@@ -203,6 +237,9 @@ func (s *Server) Router() *gin.Engine {
 	v1.POST("/auth/resend-verification", s.resendVerification)
 	v1.POST("/auth/forgot-password", s.forgotPassword)
 	v1.POST("/auth/reset-password", s.resetPassword)
+	v1.GET("/auth/oidc/providers", s.listOIDCProviders)
+	v1.GET("/auth/oidc/:providerId/login", s.startOIDCLogin)
+	v1.GET("/auth/oidc/:providerId/callback", s.handleOIDCCallback)
 
 	protected := v1.Group("")
 	protected.Use(s.requireAuth())
@@ -337,6 +374,243 @@ func (s *Server) login(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"user": user, "tokens": tokens})
+}
+
+func (s *Server) listOIDCProviders(c *gin.Context) {
+	provider, err := s.resolveOIDCProvider(c, "", false)
+	if err != nil {
+		if errors.Is(err, auth.ErrOIDCDisabled) || errors.Is(err, auth.ErrOIDCProviderNotFound) {
+			c.JSON(http.StatusOK, gin.H{"providers": []any{}})
+			return
+		}
+		writeOIDCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"providers": []gin.H{publicOIDCProvider(provider)}})
+}
+
+func (s *Server) startOIDCLogin(c *gin.Context) {
+	provider, err := s.resolveOIDCProvider(c, c.Param("providerId"), true)
+	if err != nil {
+		writeOIDCError(c, err)
+		return
+	}
+	state, err := auth.RandomToken()
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "oidc_state_failed", "Could not create OIDC login state")
+		return
+	}
+	nonce, err := auth.RandomToken()
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "oidc_state_failed", "Could not create OIDC login state")
+		return
+	}
+	var postLoginRedirect *string
+	if value := strings.TrimSpace(c.Query("redirect_uri")); value != "" {
+		postLoginRedirect = &value
+	}
+	if _, err := s.store.CreateOIDCLoginState(c.Request.Context(), store.OIDCLoginStateCreateInput{
+		ProviderID:           provider.ID,
+		StateHash:            auth.HashToken(state),
+		NonceHash:            auth.HashToken(nonce),
+		RedirectURL:          provider.RedirectURL,
+		PostLoginRedirectURL: postLoginRedirect,
+		ExpiresAt:            s.now().Add(s.oidcStateTTL),
+		Now:                  s.now(),
+	}); err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	location, err := s.oidcClient.AuthorizationURL(c.Request.Context(), provider, state, nonce)
+	if err != nil {
+		writeOIDCError(c, err)
+		return
+	}
+	c.Redirect(http.StatusFound, location)
+}
+
+func (s *Server) handleOIDCCallback(c *gin.Context) {
+	if providerErr := strings.TrimSpace(c.Query("error")); providerErr != "" {
+		message := strings.TrimSpace(c.Query("error_description"))
+		if message == "" {
+			message = "OIDC provider returned an error"
+		}
+		writeError(c, http.StatusBadRequest, "invalid_oidc_token", message)
+		return
+	}
+	code := strings.TrimSpace(c.Query("code"))
+	state := strings.TrimSpace(c.Query("state"))
+	if code == "" || state == "" {
+		writeError(c, http.StatusBadRequest, "invalid_oidc_state", "Invalid OIDC login state")
+		return
+	}
+	provider, err := s.resolveOIDCProvider(c, c.Param("providerId"), true)
+	if err != nil {
+		writeOIDCError(c, err)
+		return
+	}
+	loginState, err := s.store.ConsumeOIDCLoginState(c.Request.Context(), auth.HashToken(state), s.now())
+	if err != nil {
+		writeOIDCError(c, err)
+		return
+	}
+	if loginState.ProviderID != provider.ID {
+		writeError(c, http.StatusBadRequest, "invalid_oidc_state", "Invalid OIDC login state")
+		return
+	}
+	identity, _, err := s.oidcClient.ExchangeAndValidateNonceHash(c.Request.Context(), provider, code, loginState.NonceHash)
+	if err != nil {
+		writeOIDCError(c, err)
+		return
+	}
+	user, err := s.resolveOIDCUser(c, provider, identity)
+	if err != nil {
+		writeOIDCError(c, err)
+		return
+	}
+	tokens, err := s.issueTokens(c, user.ID)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"user": user, "tokens": tokens})
+}
+
+func (s *Server) resolveOIDCUser(c *gin.Context, provider auth.OIDCProvider, oidcIdentity auth.OIDCIdentity) (model.User, error) {
+	linked, err := s.store.GetUserIdentityByProviderSubject(c.Request.Context(), provider.ID, oidcIdentity.Subject)
+	if err == nil {
+		user, getErr := s.store.GetUser(c.Request.Context(), linked.UserID)
+		if getErr != nil {
+			return model.User{}, errOIDCUserNotProvisioned
+		}
+		if user.SignupPendingVerification {
+			return model.User{}, errOIDCUserNotProvisioned
+		}
+		now := s.now()
+		if _, updateErr := s.store.UpdateUserIdentityLastLogin(c.Request.Context(), linked.ID, now); updateErr != nil {
+			return model.User{}, updateErr
+		}
+		return user, nil
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		return model.User{}, err
+	}
+	if !provider.AutoLinkEmail {
+		return model.User{}, errOIDCUserNotProvisioned
+	}
+	user, err := s.store.GetUserByEmail(c.Request.Context(), oidcIdentity.Email)
+	if err != nil || user.SignupPendingVerification {
+		return model.User{}, errOIDCUserNotProvisioned
+	}
+	if _, err := s.store.CreateUserIdentity(c.Request.Context(), store.UserIdentityCreateInput{
+		UserID:        user.ID,
+		ProviderID:    provider.ID,
+		IssuerURL:     oidcIdentity.Issuer,
+		Subject:       oidcIdentity.Subject,
+		Email:         oidcIdentity.Email,
+		EmailVerified: oidcIdentity.EmailVerified,
+		Claims:        oidcIdentity.Claims,
+		Now:           s.now(),
+	}); err != nil {
+		return model.User{}, err
+	}
+	return user, nil
+}
+
+func (s *Server) resolveOIDCProvider(c *gin.Context, providerID string, persistEnvProvider bool) (auth.OIDCProvider, error) {
+	if s.store == nil {
+		return auth.OIDCProvider{}, auth.ErrOIDCProviderMisconfigured
+	}
+	provider, err := s.oidcResolver.Resolve(c.Request.Context())
+	if err != nil {
+		return auth.OIDCProvider{}, err
+	}
+	if providerID != "" && provider.ProviderID != providerID {
+		return auth.OIDCProvider{}, auth.ErrOIDCProviderNotFound
+	}
+	if provider.ID == "" && persistEnvProvider {
+		persisted, err := s.persistEnvOIDCProvider(c, provider)
+		if err != nil {
+			return auth.OIDCProvider{}, err
+		}
+		provider.ID = persisted.ID
+	}
+	if provider.ID == "" && persistEnvProvider {
+		return auth.OIDCProvider{}, auth.ErrOIDCProviderMisconfigured
+	}
+	return provider, nil
+}
+
+func (s *Server) persistEnvOIDCProvider(c *gin.Context, provider auth.OIDCProvider) (model.IdentityProvider, error) {
+	existing, err := s.store.GetIdentityProviderByProviderID(c.Request.Context(), provider.ProviderID)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		return model.IdentityProvider{}, err
+	}
+	secretRef := s.oidcEnvClientSecretRef
+	created, err := s.store.CreateIdentityProvider(c.Request.Context(), store.IdentityProviderCreateInput{
+		ProviderID:      provider.ProviderID,
+		Name:            provider.Name,
+		Type:            model.IdentityProviderTypeOIDC,
+		IssuerURL:       provider.IssuerURL,
+		ClientID:        provider.ClientID,
+		ClientSecretRef: &secretRef,
+		Scopes:          provider.Scopes,
+		Enabled:         true,
+		Metadata:        map[string]any{"source": "env"},
+		Now:             s.now(),
+	})
+	if err == nil {
+		return created, nil
+	}
+	existing, getErr := s.store.GetIdentityProviderByProviderID(c.Request.Context(), provider.ProviderID)
+	if getErr == nil {
+		return existing, nil
+	}
+	return model.IdentityProvider{}, err
+}
+
+func publicOIDCProvider(provider auth.OIDCProvider) gin.H {
+	return gin.H{
+		"provider_id": provider.ProviderID,
+		"name":        provider.Name,
+		"type":        string(model.IdentityProviderTypeOIDC),
+		"issuer_url":  provider.IssuerURL,
+		"scopes":      provider.Scopes,
+		"enabled":     provider.Enabled,
+	}
+}
+
+var errOIDCUserNotProvisioned = errors.New("oidc user is not provisioned")
+
+func writeOIDCError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, auth.ErrOIDCDisabled):
+		writeError(c, http.StatusBadRequest, "oidc_disabled", "OIDC authentication is disabled")
+	case errors.Is(err, auth.ErrOIDCProviderNotFound):
+		writeError(c, http.StatusNotFound, "oidc_provider_not_found", "OIDC provider not found")
+	case errors.Is(err, store.ErrOIDCStateInvalid), errors.Is(err, store.ErrOIDCStateExpired):
+		writeError(c, http.StatusBadRequest, "invalid_oidc_state", "Invalid OIDC login state")
+	case errors.Is(err, auth.ErrUnverifiedOIDCEmail):
+		writeError(c, http.StatusBadRequest, "unverified_oidc_email", "OIDC email is not verified")
+	case errors.Is(err, auth.ErrInvalidOIDCToken):
+		writeError(c, http.StatusBadRequest, "invalid_oidc_token", "Invalid OIDC token")
+	case errors.Is(err, auth.ErrOIDCProviderMisconfigured):
+		writeError(c, http.StatusServiceUnavailable, "oidc_provider_misconfigured", "OIDC provider is misconfigured")
+	case errors.Is(err, errOIDCUserNotProvisioned):
+		writeError(c, http.StatusForbidden, "user_not_provisioned", "SSO user is not provisioned in account manager")
+	default:
+		writeStoreError(c, err)
+	}
+}
+
+func (s *Server) now() time.Time {
+	if s.oidcClient.Now != nil {
+		return s.oidcClient.Now()
+	}
+	return time.Now().UTC()
 }
 
 type tokenResponse struct {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -3,17 +3,23 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"rtk_account_manager/internal/auth"
@@ -26,6 +32,7 @@ import (
 
 type integrationEnv struct {
 	router           *gin.Engine
+	server           *Server
 	db               *pgxpool.Pool
 	tokenSink        *recordingAuthTokenSink
 	notificationSink *recordingQuotaRaiseNotificationSink
@@ -70,7 +77,7 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-		TRUNCATE auth_tokens, quota_raise_requests, device_claims, device_claim_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
+		TRUNCATE oidc_login_states, user_identities, identity_providers, auth_tokens, quota_raise_requests, device_claims, device_claim_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
 		RESTART IDENTITY CASCADE
 	`); err != nil {
 		t.Fatal(err)
@@ -80,8 +87,10 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 	authService := auth.NewService("test-access-secret", "test-refresh-secret", time.Minute, time.Hour)
 	tokenSink := &recordingAuthTokenSink{}
 	notificationSink := &recordingQuotaRaiseNotificationSink{}
+	server := NewWithAuthTokenAndNotificationSink(store.New(db), authService, tokenSink, notificationSink)
 	return integrationEnv{
-		router:           NewWithAuthTokenAndNotificationSink(store.New(db), authService, tokenSink, notificationSink).Router(),
+		router:           server.Router(),
+		server:           server,
 		db:               db,
 		tokenSink:        tokenSink,
 		notificationSink: notificationSink,
@@ -157,6 +166,178 @@ func TestIntegrationRegisterLoginRefreshAndLogout(t *testing.T) {
 	if invalidRefreshRes.Code != http.StatusUnauthorized {
 		t.Fatalf("expected invalid refresh token 401, got %d", invalidRefreshRes.Code)
 	}
+}
+
+func TestIntegrationOIDCProviderLoginAndCallback(t *testing.T) {
+	env := newIntegrationEnv(t)
+	fake := newAPIOIDCTestServer(t)
+	defer fake.close()
+	configureOIDCTestServer(t, env.server, fake, true)
+
+	registered := registerUser(t, env.router, "oidc-user@example.com", "OIDC Org")
+
+	providersRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/providers", nil, "")
+	if providersRes.Code != http.StatusOK {
+		t.Fatalf("expected OIDC providers 200, got %d: %s", providersRes.Code, providersRes.Body.String())
+	}
+	var providersBody struct {
+		Providers []struct {
+			ProviderID string   `json:"provider_id"`
+			Name       string   `json:"name"`
+			Type       string   `json:"type"`
+			IssuerURL  string   `json:"issuer_url"`
+			Scopes     []string `json:"scopes"`
+			Enabled    bool     `json:"enabled"`
+		} `json:"providers"`
+	}
+	providersBody = decodeBody[struct {
+		Providers []struct {
+			ProviderID string   `json:"provider_id"`
+			Name       string   `json:"name"`
+			Type       string   `json:"type"`
+			IssuerURL  string   `json:"issuer_url"`
+			Scopes     []string `json:"scopes"`
+			Enabled    bool     `json:"enabled"`
+		} `json:"providers"`
+	}](t, providersRes)
+	if len(providersBody.Providers) != 1 || providersBody.Providers[0].ProviderID != "keycloak" || !providersBody.Providers[0].Enabled {
+		t.Fatalf("unexpected providers response: %+v", providersBody)
+	}
+
+	loginRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/login", nil, "")
+	if loginRes.Code != http.StatusFound {
+		t.Fatalf("expected OIDC login redirect, got %d: %s", loginRes.Code, loginRes.Body.String())
+	}
+	location := loginRes.Header().Get("Location")
+	authURL, err := url.Parse(location)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := authURL.Query().Get("state")
+	nonce := authURL.Query().Get("nonce")
+	if state == "" || nonce == "" || authURL.Path != "/authorize" {
+		t.Fatalf("unexpected authorization redirect: %s", location)
+	}
+	assertOIDCStateStoredAsHash(t, env.db, state, nonce)
+
+	fake.idToken = fake.signToken(t, apiOIDCTokenFixture{
+		Subject:       "subject-1",
+		Email:         "OIDC-User@Example.com",
+		EmailVerified: true,
+		Nonce:         nonce,
+	})
+	callbackRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+	if callbackRes.Code != http.StatusOK {
+		t.Fatalf("expected OIDC callback 200, got %d: %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	callbackBody := decodeBody[struct {
+		User struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"user"`
+		Tokens struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"tokens"`
+	}](t, callbackRes)
+	if callbackBody.User.ID != registered.User.ID || callbackBody.User.Email != "oidc-user@example.com" || callbackBody.Tokens.AccessToken == "" || callbackBody.Tokens.RefreshToken == "" {
+		t.Fatalf("unexpected callback body: %+v", callbackBody)
+	}
+
+	var identityCount int
+	if err := env.db.QueryRow(context.Background(), `
+		SELECT count(*) FROM user_identities WHERE user_id = $1 AND subject = 'subject-1'
+	`, registered.User.ID).Scan(&identityCount); err != nil {
+		t.Fatal(err)
+	}
+	if identityCount != 1 {
+		t.Fatalf("expected exactly one linked identity, got %d", identityCount)
+	}
+
+	replayRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+	assertErrorCode(t, replayRes, http.StatusBadRequest, "invalid_oidc_state")
+
+	localLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "oidc-user@example.com",
+		"password": "password123",
+	}, "")
+	if localLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected local login to remain available, got %d: %s", localLoginRes.Code, localLoginRes.Body.String())
+	}
+}
+
+func TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers(t *testing.T) {
+	t.Run("unknown without auto link", func(t *testing.T) {
+		env := newIntegrationEnv(t)
+		fake := newAPIOIDCTestServer(t)
+		defer fake.close()
+		configureOIDCTestServer(t, env.server, fake, false)
+
+		state, nonce := startOIDCTestLogin(t, env.router)
+		fake.idToken = fake.signToken(t, apiOIDCTokenFixture{Subject: "unknown-subject", Email: "missing@example.com", EmailVerified: true, Nonce: nonce})
+		res := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+		assertErrorCode(t, res, http.StatusForbidden, "user_not_provisioned")
+	})
+
+	t.Run("disabled linked user", func(t *testing.T) {
+		env := newIntegrationEnv(t)
+		fake := newAPIOIDCTestServer(t)
+		defer fake.close()
+		configureOIDCTestServer(t, env.server, fake, false)
+		registered := registerUser(t, env.router, "disabled-oidc@example.com", "Disabled OIDC Org")
+		provider := seedOIDCTestProvider(t, env.db, fake)
+		if _, err := store.New(env.db).CreateUserIdentity(context.Background(), store.UserIdentityCreateInput{
+			UserID:        registered.User.ID,
+			ProviderID:    provider.ID,
+			IssuerURL:     fake.server.URL,
+			Subject:       "disabled-subject",
+			Email:         "disabled-oidc@example.com",
+			EmailVerified: true,
+			Claims:        map[string]any{"sub": "disabled-subject"},
+			Now:           time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := env.db.Exec(context.Background(), `UPDATE users SET disabled_at = now(), updated_at = now() WHERE id = $1`, registered.User.ID); err != nil {
+			t.Fatal(err)
+		}
+		state, nonce := seedOIDCTestState(t, env.db, provider.ID)
+		fake.idToken = fake.signToken(t, apiOIDCTokenFixture{Subject: "disabled-subject", Email: "disabled-oidc@example.com", EmailVerified: true, Nonce: nonce})
+		res := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+		assertErrorCode(t, res, http.StatusForbidden, "user_not_provisioned")
+	})
+
+	t.Run("unverified email", func(t *testing.T) {
+		env := newIntegrationEnv(t)
+		fake := newAPIOIDCTestServer(t)
+		defer fake.close()
+		configureOIDCTestServer(t, env.server, fake, true)
+		state, nonce := startOIDCTestLogin(t, env.router)
+		fake.idToken = fake.signToken(t, apiOIDCTokenFixture{Subject: "subject-2", Email: "unverified@example.com", EmailVerified: false, Nonce: nonce})
+		res := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+		assertErrorCode(t, res, http.StatusBadRequest, "unverified_oidc_email")
+	})
+}
+
+func TestIntegrationOIDCDisabledDiscoveryAndLogin(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	providersRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/providers", nil, "")
+	if providersRes.Code != http.StatusOK {
+		t.Fatalf("expected disabled discovery 200, got %d", providersRes.Code)
+	}
+	var providers struct {
+		Providers []any `json:"providers"`
+	}
+	providers = decodeBody[struct {
+		Providers []any `json:"providers"`
+	}](t, providersRes)
+	if len(providers.Providers) != 0 {
+		t.Fatalf("expected no providers when disabled, got %+v", providers)
+	}
+
+	loginRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/login", nil, "")
+	assertErrorCode(t, loginRes, http.StatusBadRequest, "oidc_disabled")
 }
 
 func TestIntegrationEmailVerificationAndPasswordRecovery(t *testing.T) {
@@ -3343,6 +3524,206 @@ func latestAuthToken(t *testing.T, sink *recordingAuthTokenSink, email, purpose 
 	}
 	t.Fatalf("missing %s token delivery for %s in %+v", purpose, email, sink.deliveries)
 	return ""
+}
+
+func configureOIDCTestServer(t *testing.T, server *Server, fake *apiOIDCTestServer, autoLink bool) {
+	t.Helper()
+	t.Setenv("OIDC_CLIENT_SECRET", "client-secret")
+	server.ConfigureOIDC(OIDCOptions{
+		Env: auth.OIDCEnvConfig{
+			Enabled:       true,
+			ProviderID:    "keycloak",
+			ProviderName:  "Keycloak",
+			IssuerURL:     fake.server.URL,
+			ClientID:      "rtk-account-manager",
+			ClientSecret:  "client-secret",
+			RedirectURL:   "https://api.example.test/v1/auth/oidc/keycloak/callback",
+			Scopes:        []string{"openid", "email", "profile"},
+			AutoLinkEmail: autoLink,
+		},
+		HTTPClient: fake.server.Client(),
+		Now:        fake.nowFn,
+	})
+}
+
+func startOIDCTestLogin(t *testing.T, router *gin.Engine) (string, string) {
+	t.Helper()
+	loginRes := performJSON(router, http.MethodGet, "/v1/auth/oidc/keycloak/login", nil, "")
+	if loginRes.Code != http.StatusFound {
+		t.Fatalf("expected OIDC login redirect, got %d: %s", loginRes.Code, loginRes.Body.String())
+	}
+	authURL, err := url.Parse(loginRes.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := authURL.Query().Get("state")
+	nonce := authURL.Query().Get("nonce")
+	if state == "" || nonce == "" {
+		t.Fatalf("missing state/nonce in redirect: %s", loginRes.Header().Get("Location"))
+	}
+	return state, nonce
+}
+
+func seedOIDCTestProvider(t *testing.T, db *pgxpool.Pool, fake *apiOIDCTestServer) model.IdentityProvider {
+	t.Helper()
+	secretRef := "env:OIDC_CLIENT_SECRET"
+	provider, err := store.New(db).CreateIdentityProvider(context.Background(), store.IdentityProviderCreateInput{
+		ProviderID:      "keycloak",
+		Name:            "Keycloak",
+		Type:            model.IdentityProviderTypeOIDC,
+		IssuerURL:       fake.server.URL,
+		ClientID:        "rtk-account-manager",
+		ClientSecretRef: &secretRef,
+		Scopes:          []string{"openid", "email", "profile"},
+		Enabled:         true,
+		Metadata:        map[string]any{"source": "test"},
+		Now:             time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return provider
+}
+
+func seedOIDCTestState(t *testing.T, db *pgxpool.Pool, providerID string) (string, string) {
+	t.Helper()
+	state := "state-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	nonce := "nonce-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	if _, err := store.New(db).CreateOIDCLoginState(context.Background(), store.OIDCLoginStateCreateInput{
+		ProviderID:  providerID,
+		StateHash:   auth.HashToken(state),
+		NonceHash:   auth.HashToken(nonce),
+		RedirectURL: "https://api.example.test/v1/auth/oidc/keycloak/callback",
+		ExpiresAt:   time.Now().UTC().Add(24 * time.Hour),
+		Now:         time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return state, nonce
+}
+
+func assertOIDCStateStoredAsHash(t *testing.T, db *pgxpool.Pool, state, nonce string) {
+	t.Helper()
+	var rawCount int
+	if err := db.QueryRow(context.Background(), `
+		SELECT count(*) FROM oidc_login_states WHERE state_hash = $1 OR nonce_hash = $2
+	`, state, nonce).Scan(&rawCount); err != nil {
+		t.Fatal(err)
+	}
+	if rawCount != 0 {
+		t.Fatal("raw OIDC state or nonce was persisted")
+	}
+	var hashedCount int
+	if err := db.QueryRow(context.Background(), `
+		SELECT count(*) FROM oidc_login_states WHERE state_hash = $1 AND nonce_hash = $2
+	`, auth.HashToken(state), auth.HashToken(nonce)).Scan(&hashedCount); err != nil {
+		t.Fatal(err)
+	}
+	if hashedCount != 1 {
+		t.Fatalf("expected hashed OIDC state row, got %d", hashedCount)
+	}
+}
+
+type apiOIDCTestServer struct {
+	server  *httptest.Server
+	key     *rsa.PrivateKey
+	keyID   string
+	now     time.Time
+	idToken string
+}
+
+func newAPIOIDCTestServer(t *testing.T) *apiOIDCTestServer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &apiOIDCTestServer{
+		key:   key,
+		keyID: "api-oidc-test-key",
+		now:   time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(t, w, map[string]any{
+			"issuer":                 fake.server.URL,
+			"authorization_endpoint": fake.server.URL + "/authorize",
+			"token_endpoint":         fake.server.URL + "/token",
+			"jwks_uri":               fake.server.URL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if r.Form.Get("grant_type") != "authorization_code" || r.Form.Get("code") != "auth-code" || r.Form.Get("client_id") != "rtk-account-manager" || r.Form.Get("client_secret") != "client-secret" {
+			http.Error(w, "invalid token request", http.StatusBadRequest)
+			return
+		}
+		writeJSONResponse(t, w, map[string]any{
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"access_token":  "provider-access-token",
+			"refresh_token": "provider-refresh-token",
+			"id_token":      fake.idToken,
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(t, w, map[string]any{"keys": []map[string]string{{
+			"kid": fake.keyID,
+			"kty": "RSA",
+			"alg": "RS256",
+			"use": "sig",
+			"n":   base64.RawURLEncoding.EncodeToString(fake.key.PublicKey.N.Bytes()),
+			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(fake.key.PublicKey.E)).Bytes()),
+		}}})
+	})
+	fake.server = httptest.NewServer(mux)
+	return fake
+}
+
+func (s *apiOIDCTestServer) close() {
+	s.server.Close()
+}
+
+func (s *apiOIDCTestServer) nowFn() time.Time {
+	return s.now
+}
+
+type apiOIDCTokenFixture struct {
+	Subject       string
+	Email         string
+	EmailVerified bool
+	Nonce         string
+}
+
+func (s *apiOIDCTestServer) signToken(t *testing.T, fixture apiOIDCTokenFixture) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"iss":            s.server.URL,
+		"sub":            fixture.Subject,
+		"aud":            "rtk-account-manager",
+		"exp":            s.now.Add(time.Hour).Unix(),
+		"iat":            s.now.Unix(),
+		"nonce":          fixture.Nonce,
+		"email":          fixture.Email,
+		"email_verified": fixture.EmailVerified,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = s.keyID
+	signed, err := token.SignedString(s.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}
+
+func writeJSONResponse(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func devicePayload(name, serial string) map[string]any {

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -236,6 +236,18 @@ func (c OIDCClient) ExchangeAndValidate(ctx context.Context, provider OIDCProvid
 	return identity, tokens, nil
 }
 
+func (c OIDCClient) ExchangeAndValidateNonceHash(ctx context.Context, provider OIDCProvider, code, expectedNonceHash string) (OIDCIdentity, OIDCTokenResponse, error) {
+	tokens, err := c.ExchangeCode(ctx, provider, code)
+	if err != nil {
+		return OIDCIdentity{}, OIDCTokenResponse{}, err
+	}
+	identity, err := c.ValidateIDTokenNonceHash(ctx, provider, tokens.IDToken, expectedNonceHash)
+	if err != nil {
+		return OIDCIdentity{}, OIDCTokenResponse{}, err
+	}
+	return identity, tokens, nil
+}
+
 func (c OIDCClient) ExchangeCode(ctx context.Context, provider OIDCProvider, code string) (OIDCTokenResponse, error) {
 	discovery, err := c.Discover(ctx, provider)
 	if err != nil {
@@ -272,6 +284,18 @@ func (c OIDCClient) ExchangeCode(ctx context.Context, provider OIDCProvider, cod
 }
 
 func (c OIDCClient) ValidateIDToken(ctx context.Context, provider OIDCProvider, idToken, expectedNonce string) (OIDCIdentity, error) {
+	return c.validateIDToken(ctx, provider, idToken, func(nonce string) bool {
+		return nonce == expectedNonce
+	})
+}
+
+func (c OIDCClient) ValidateIDTokenNonceHash(ctx context.Context, provider OIDCProvider, idToken, expectedNonceHash string) (OIDCIdentity, error) {
+	return c.validateIDToken(ctx, provider, idToken, func(nonce string) bool {
+		return HashToken(nonce) == expectedNonceHash
+	})
+}
+
+func (c OIDCClient) validateIDToken(ctx context.Context, provider OIDCProvider, idToken string, validNonce func(string) bool) (OIDCIdentity, error) {
 	discovery, err := c.Discover(ctx, provider)
 	if err != nil {
 		return OIDCIdentity{}, err
@@ -288,7 +312,7 @@ func (c OIDCClient) ValidateIDToken(ctx context.Context, provider OIDCProvider, 
 	if !token.Valid {
 		return OIDCIdentity{}, ErrInvalidOIDCToken
 	}
-	if claims.Nonce != expectedNonce {
+	if validNonce == nil || !validNonce(claims.Nonce) {
 		return OIDCIdentity{}, fmt.Errorf("%w: invalid nonce", ErrInvalidOIDCToken)
 	}
 	if claims.Subject == "" || claims.Email == "" {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -208,6 +209,19 @@ func (s *Store) GetUser(ctx context.Context, userID string) (model.User, error) 
 		FROM users
 		WHERE id = $1 AND disabled_at IS NULL
 	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.User{}, ErrNotFound
+	}
+	return user, err
+}
+
+func (s *Store) GetUserByEmail(ctx context.Context, email string) (model.User, error) {
+	var user model.User
+	err := s.db.QueryRow(ctx, `
+		SELECT id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+		FROM users
+		WHERE email = $1 AND disabled_at IS NULL
+	`, strings.ToLower(strings.TrimSpace(email))).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return model.User{}, ErrNotFound
 	}


### PR DESCRIPTION
## Summary
- add public OIDC provider discovery, login redirect, and callback endpoints
- persist hashed OIDC state/nonce and validate callback tokens against nonce hash
- resolve existing linked identities or auto-link verified email to existing users when configured
- wire OIDC runtime config into the server and update integration test coverage/report

Closes #144.

## Tests
- TEST_DATABASE_URL=... go test ./internal/api -run TestIntegrationOIDC -count=1
- go test ./...
- REPORT_FILE=docs/TEST_REPORT.md REPORT_GENERATED_AT=ci-candidate REPORT_CANONICAL=true make test-report
- git diff --check