### PR TITLE
Add current-user OIDC identity endpoints

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -164,9 +164,11 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestIntegrationCleanupRefreshTokensRemovesExpiredAndRevokedRows`
 - `rtk_account_manager/internal/api`: `TestIntegrationCurrentUserCanChangePassword`
 - `rtk_account_manager/internal/api`: `TestIntegrationCurrentUserCanDisableSelfWithOwnerSafety`
+- `rtk_account_manager/internal/api`: `TestIntegrationCurrentUserOIDCIdentityManagement`
 - `rtk_account_manager/internal/api`: `TestIntegrationDatabaseMaintainsUpdatedAt`
 - `rtk_account_manager/internal/api`: `TestIntegrationDatabaseRejectsInvalidCoreData`
 - `rtk_account_manager/internal/api`: `TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata`
+- `rtk_account_manager/internal/api`: `TestIntegrationDisabledUserCannotManageOIDCIdentities`
 - `rtk_account_manager/internal/api`: `TestIntegrationDisabledUserCannotUseExistingTokens`
 - `rtk_account_manager/internal/api`: `TestIntegrationEmailVerificationAndPasswordRecovery`
 - `rtk_account_manager/internal/api`: `TestIntegrationFleetGroupsAndTags`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -247,6 +247,8 @@ func (s *Server) Router() *gin.Engine {
 	protected.GET("/me", s.me)
 	protected.DELETE("/me", s.deleteCurrentUser)
 	protected.PATCH("/me/password", s.changePassword)
+	protected.GET("/me/identities", s.listCurrentUserIdentities)
+	protected.DELETE("/me/identities/:identityId", s.deleteCurrentUserIdentity)
 
 	protected.GET("/orgs", s.listOrganizations)
 	protected.POST("/orgs", s.createOrganization)
@@ -850,6 +852,23 @@ func (s *Server) me(c *gin.Context) {
 
 func (s *Server) deleteCurrentUser(c *gin.Context) {
 	if err := s.store.DisableCurrentUser(c.Request.Context(), currentUserID(c)); err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (s *Server) listCurrentUserIdentities(c *gin.Context) {
+	identities, err := s.store.ListUserIdentities(c.Request.Context(), currentUserID(c))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"identities": identities})
+}
+
+func (s *Server) deleteCurrentUserIdentity(c *gin.Context) {
+	if err := s.store.DeleteUserIdentity(c.Request.Context(), currentUserID(c), c.Param("identityId")); err != nil {
 		writeStoreError(c, err)
 		return
 	}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -340,6 +340,109 @@ func TestIntegrationOIDCDisabledDiscoveryAndLogin(t *testing.T) {
 	assertErrorCode(t, loginRes, http.StatusBadRequest, "oidc_disabled")
 }
 
+func TestIntegrationCurrentUserOIDCIdentityManagement(t *testing.T) {
+	env := newIntegrationEnv(t)
+	fake := newAPIOIDCTestServer(t)
+	defer fake.close()
+	configureOIDCTestServer(t, env.server, fake, true)
+	owner := registerUser(t, env.router, "identity-owner@example.com", "Identity Owner Org")
+	other := registerUser(t, env.router, "identity-other@example.com", "Identity Other Org")
+
+	state, nonce := startOIDCTestLogin(t, env.router)
+	fake.idToken = fake.signToken(t, apiOIDCTokenFixture{
+		Subject:       "identity-subject",
+		Email:         "identity-owner@example.com",
+		EmailVerified: true,
+		Nonce:         nonce,
+	})
+	callbackRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+	if callbackRes.Code != http.StatusOK {
+		t.Fatalf("expected callback 200, got %d: %s", callbackRes.Code, callbackRes.Body.String())
+	}
+	callbackBody := decodeBody[tokenBody](t, callbackRes)
+
+	listRes := performJSON(env.router, http.MethodGet, "/v1/me/identities", nil, callbackBody.Tokens.AccessToken)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected identities list 200, got %d: %s", listRes.Code, listRes.Body.String())
+	}
+	var listBody struct {
+		Identities []model.UserIdentity `json:"identities"`
+	}
+	listBody = decodeBody[struct {
+		Identities []model.UserIdentity `json:"identities"`
+	}](t, listRes)
+	if len(listBody.Identities) != 1 || listBody.Identities[0].Subject != "identity-subject" || listBody.Identities[0].Email != "identity-owner@example.com" {
+		t.Fatalf("unexpected identities list: %+v", listBody)
+	}
+	identityID := listBody.Identities[0].ID
+
+	otherDeleteRes := performJSON(env.router, http.MethodDelete, "/v1/me/identities/"+identityID, nil, other.Tokens.AccessToken)
+	assertErrorCode(t, otherDeleteRes, http.StatusNotFound, "not_found")
+
+	deleteRes := performJSON(env.router, http.MethodDelete, "/v1/me/identities/"+identityID, nil, callbackBody.Tokens.AccessToken)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("expected identity delete 204, got %d: %s", deleteRes.Code, deleteRes.Body.String())
+	}
+
+	listAfterDeleteRes := performJSON(env.router, http.MethodGet, "/v1/me/identities", nil, callbackBody.Tokens.AccessToken)
+	if listAfterDeleteRes.Code != http.StatusOK {
+		t.Fatalf("expected identities list after delete 200, got %d: %s", listAfterDeleteRes.Code, listAfterDeleteRes.Body.String())
+	}
+	listAfterDelete := decodeBody[struct {
+		Identities []model.UserIdentity `json:"identities"`
+	}](t, listAfterDeleteRes)
+	if len(listAfterDelete.Identities) != 0 {
+		t.Fatalf("expected no identities after delete, got %+v", listAfterDelete)
+	}
+
+	configureOIDCTestServer(t, env.server, fake, false)
+	state, nonce = startOIDCTestLogin(t, env.router)
+	fake.idToken = fake.signToken(t, apiOIDCTokenFixture{
+		Subject:       "identity-subject",
+		Email:         "identity-owner@example.com",
+		EmailVerified: true,
+		Nonce:         nonce,
+	})
+	unlinkedCallbackRes := performJSON(env.router, http.MethodGet, "/v1/auth/oidc/keycloak/callback?code=auth-code&state="+url.QueryEscape(state), nil, "")
+	assertErrorCode(t, unlinkedCallbackRes, http.StatusForbidden, "user_not_provisioned")
+
+	localLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    owner.User.Email,
+		"password": "password123",
+	}, "")
+	if localLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected local password login to survive identity unlink, got %d: %s", localLoginRes.Code, localLoginRes.Body.String())
+	}
+}
+
+func TestIntegrationDisabledUserCannotManageOIDCIdentities(t *testing.T) {
+	env := newIntegrationEnv(t)
+	fake := newAPIOIDCTestServer(t)
+	defer fake.close()
+	configureOIDCTestServer(t, env.server, fake, true)
+	registered := registerUser(t, env.router, "disabled-identities@example.com", "Disabled Identities Org")
+	provider := seedOIDCTestProvider(t, env.db, fake)
+	if _, err := store.New(env.db).CreateUserIdentity(context.Background(), store.UserIdentityCreateInput{
+		UserID:        registered.User.ID,
+		ProviderID:    provider.ID,
+		IssuerURL:     fake.server.URL,
+		Subject:       "disabled-identities-subject",
+		Email:         registered.User.Email,
+		EmailVerified: true,
+		Claims:        map[string]any{"sub": "disabled-identities-subject"},
+		Now:           time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.db.Exec(context.Background(), `UPDATE users SET disabled_at = now(), updated_at = now() WHERE id = $1`, registered.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	listRes := performJSON(env.router, http.MethodGet, "/v1/me/identities", nil, registered.Tokens.AccessToken)
+	if listRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected disabled user identities list 401, got %d: %s", listRes.Code, listRes.Body.String())
+	}
+}
+
 func TestIntegrationEmailVerificationAndPasswordRecovery(t *testing.T) {
 	env := newIntegrationEnv(t)
 


### PR DESCRIPTION
## Summary
- add GET and DELETE endpoints for current-user OIDC identities
- enforce current-user scoping through existing store delete semantics
- cover list/delete, cross-user rejection, disabled-user rejection, and unlink behavior in integration tests
- update canonical test report

Closes #145.

## Tests
- TEST_DATABASE_URL=... go test ./internal/api -run 'TestIntegration(CurrentUserOIDCIdentityManagement|DisabledUserCannotManageOIDCIdentities)' -count=1
- go test ./...
- REPORT_FILE=docs/TEST_REPORT.md REPORT_GENERATED_AT=ci-candidate REPORT_CANONICAL=true make test-report
- git diff --check