### PR TITLE
Gate OIDC correctness in test report

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -48,6 +48,7 @@ side effect of feature work.
 Update tests whenever changing:
 
 - Authentication, JWT, refresh-token, logout, or disabled-user behavior.
+- Keycloak/OIDC provider resolution, login callback, state/nonce handling, identity linking, or external identity management.
 - Organization membership, owner/admin/member authorization, or last-owner rules.
 - Device lifecycle behavior, status changes, soft-delete behavior, or organization scoping.
 - Provisioning, deactivation, outbox, inbox, broker adapter, or cross-service projection behavior.
@@ -124,6 +125,30 @@ name representative tests for Claim Token persistence, Claim Token resolve API
 policy, registry-only readiness behavior, and OpenAPI response validation. These
 groups are required because they close contract gaps that coverage percentage
 alone cannot prove correct.
+
+For the Keycloak/OIDC SSO scope, the maintained report must name representative
+tests for provider CRUD, state/nonce replay protection, token validation,
+unknown/disabled/unverified user rejection, auto-link policy, local login
+compatibility, current-user identity management, and secret redaction. These
+groups are required because OIDC correctness depends on security policy and
+contract behavior, not just endpoint line coverage.
+
+## Keycloak/OIDC SSO Test Matrix
+
+The Keycloak/OIDC implementation uses fake OIDC/JWKS servers in automated tests.
+Do not make CI depend on a live Keycloak container; the Docker Compose Keycloak
+profile is only for local manual integration checks.
+
+| Group | Required evidence |
+| --- | --- |
+| Provider persistence | `identity_providers`, `user_identities`, and `oidc_login_states` persistence supports CRUD, uniqueness, one-enabled-provider policy, hashed state/nonce, and replay rejection. |
+| Provider admin CRUD | Platform-admin-only create/list/show/update/disable enforces `env:VAR_NAME` secret references, rejects non-admin access, rejects a second enabled provider, and emits audit events. |
+| Provider discovery and login | Disabled OIDC returns no providers and rejects login; enabled OIDC redirects with state and nonce. |
+| Callback success | Successful callback validates token claims, links to an existing local user under policy, returns the existing Account Manager token response shape, and keeps local email/password login working. |
+| Callback rejection policy | Unknown users, disabled linked users, replayed state, invalid nonce, invalid issuer/audience/signature/expiry, unexpected signing method, and unverified email are rejected with typed errors. |
+| Identity management | Current users can list/unlink their own identities, cannot access another user's identity, and disabled users cannot manage identities. |
+| Secret redaction | Raw client secrets, Keycloak access tokens, refresh tokens, state, and nonce are not persisted, returned, logged in typed errors, or written to the maintained report. |
+| OpenAPI contract validation | Public OIDC endpoints, current-user identities, and platform-admin identity-provider endpoints validate representative responses against `openapi.yaml`. |
 
 ## V2 Provisioning And Event Channel Test Matrix
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -63,6 +63,17 @@ Generated: ci-candidate
 | Broker adapters | `TestAzureEventHubsPublisherPublishesJSONRecord` | PASS |
 | Database invariants | `TestIntegrationDatabaseSchemaInvariants` | PASS |
 | OpenAPI contract | `TestIntegrationResponsesMatchOpenAPIContract` | PASS |
+| OIDC provider persistence | `TestIdentityProviderStoreCRUDAndEnabledInvariant` | PASS |
+| OIDC provider admin CRUD | `TestIntegrationAdminIdentityProviderWorkflow` | PASS |
+| OIDC state and nonce replay guards | `TestOIDCLoginStateStoresHashesAndRejectsReplay` | PASS |
+| OIDC public login callback | `TestIntegrationOIDCProviderLoginAndCallback` | PASS |
+| OIDC unknown disabled and unverified users | `TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers` | PASS |
+| OIDC disabled provider behavior | `TestIntegrationOIDCDisabledDiscoveryAndLogin` | PASS |
+| OIDC current-user identities | `TestIntegrationCurrentUserOIDCIdentityManagement` | PASS |
+| OIDC token validation | `TestOIDCClientExchangeAndValidateIDToken` | PASS |
+| OIDC invalid token rejection | `TestOIDCClientRejectsInvalidNonce` | PASS |
+| OIDC secret redaction | `TestOIDCTokenErrorsDoNotContainProviderTokens` | PASS |
+| OIDC raw secret rejection | `TestIdentityProviderRejectsRawClientSecretRef` | PASS |
 | Configuration and maintenance | `TestLoadReadsEnvironmentAndDurations` | PASS |
 
 ## Correctness Validation
@@ -104,7 +115,16 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Lifecycle observability | `TestIntegrationAdminMetricsIncludesLifecycleVisibility` and `TestLifecycleMetricsAggregatesQueueAndOperationHealth` verify platform-admin-only lifecycle metrics for outbox/inbox status counts, dead-letter breakdowns, operation status/type counts, and active-operation age. |
 | Broker adapters | `TestNewPublisherCreatesLogPublisherAndRejectsUnsupportedKinds`, `TestNewConsumerCreatesLogConsumerAndRejectsUnsupportedKinds`, `TestLogPublisherWritesEnvelopeJSON`, `TestLogConsumerReadsEnvelopeJSON`, `TestAzureEventHubsPublisherPublishesJSONRecord`, `TestAzureEventHubsConsumerReadsAcrossPartitions`, `TestAzureEventHubsConsumerAcknowledgesAndResumesFromCheckpoint`, and `TestOpenAzurePartitionsUsesStoredCheckpointWhenPresent` cover the deterministic local default adapter plus Azure Event Hubs publish/consume and durable checkpoint resume behavior without requiring live Azure. |
 | Database invariants | `TestIntegrationDatabaseSchemaInvariants` plus existing migration tests verify idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, critical tables/columns/constraints/indexes, and automatic `updated_at` triggers. |
-| OpenAPI contract | `TestIntegrationResponsesMatchOpenAPIContract` plus OpenAPI schema validation cover representative Claim Token resolve/admin, registry-only provisioning-state with nullable `operation`, provisioned/failed provisioning-state, provisioning, deactivation, quota visibility, and audit visibility responses against `openapi.yaml`. |
+| OpenAPI contract | `TestIntegrationResponsesMatchOpenAPIContract` plus OpenAPI schema validation cover representative Claim Token resolve/admin, registry-only provisioning-state with nullable `operation`, provisioned/failed provisioning-state, provisioning, deactivation, quota visibility, audit visibility, public OIDC, current-user identity, and admin identity-provider responses against `openapi.yaml`. |
+| OIDC provider persistence | `TestIdentityProviderStoreCRUDAndEnabledInvariant`, `TestIdentityProviderRejectsRawClientSecretRef`, and `TestIntegrationDatabaseSchemaInvariants` verify provider CRUD, the one-enabled-provider invariant, secret-reference-only storage, identity link uniqueness, and OIDC schema/index presence. |
+| OIDC provider admin CRUD | `TestIntegrationAdminIdentityProviderWorkflow` verifies platform-admin-only create/list/show/update/disable, pagination, second-enabled-provider conflict handling, audit events, `env:VAR_NAME` secret references, and raw-secret non-persistence/non-response behavior. |
+| OIDC state and nonce replay guards | `TestOIDCLoginStateStoresHashesAndRejectsReplay`, `TestOIDCLoginStateRejectsExpiredState`, and `TestIntegrationOIDCProviderLoginAndCallback` verify raw state/nonce non-persistence, one-time state consumption, replay rejection, and callback nonce validation through hashed state records. |
+| OIDC public login callback | `TestIntegrationOIDCProviderLoginAndCallback` verifies discovery, login redirect, state/nonce creation, callback success, verified-email auto-link to an existing local user, Account Manager JWT issuance, identity persistence, replay rejection, and local email/password login compatibility. |
+| OIDC user rejection policy | `TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers` verifies unknown users return `user_not_provisioned`, disabled linked users cannot login through SSO, and unverified provider emails return `unverified_oidc_email`. |
+| OIDC disabled provider behavior | `TestIntegrationOIDCDisabledDiscoveryAndLogin` verifies disabled OIDC returns no public providers and rejects login with `oidc_disabled`. |
+| OIDC current-user identities | `TestIntegrationCurrentUserOIDCIdentityManagement` and `TestIntegrationDisabledUserCannotManageOIDCIdentities` verify current-user list/unlink behavior, cross-user isolation, disabled-user rejection, and that unlinking an identity does not break local password login. |
+| OIDC token validation | `TestOIDCClientExchangeAndValidateIDToken`, `TestOIDCClientRejectsInvalidIssuer`, `TestOIDCClientRejectsInvalidAudience`, `TestOIDCClientRejectsInvalidSignature`, `TestOIDCClientRejectsExpiredToken`, `TestOIDCClientRejectsInvalidNonce`, `TestOIDCClientRejectsUnverifiedEmail`, `TestOIDCClientRejectsUnexpectedSigningMethod`, and JWKS/discovery/token-response negative tests verify authorization-code exchange and ID-token issuer, audience, signature, expiry, nonce, signing method, and verified-email validation without live Keycloak. |
+| OIDC secret redaction | `TestOIDCTokenErrorsDoNotContainProviderTokens`, `TestIdentityProviderRejectsRawClientSecretRef`, and `TestIntegrationAdminIdentityProviderWorkflow` verify Keycloak token values and raw client secrets are not persisted, returned, or included in typed validation errors. |
 | Configuration and maintenance | `.env` loading, TTL parsing/fallbacks, worker-specific broker config defaults, required JWT secrets, and refresh-token cleanup behavior. |
 
 ## Executed Test Cases

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -143,6 +143,17 @@ require_passed_test "Lifecycle observability" "TestIntegrationAdminMetricsInclud
 require_passed_test "Broker adapters" "TestAzureEventHubsPublisherPublishesJSONRecord"
 require_passed_test "Database invariants" "TestIntegrationDatabaseSchemaInvariants"
 require_passed_test "OpenAPI contract" "TestIntegrationResponsesMatchOpenAPIContract"
+require_passed_test "OIDC provider persistence" "TestIdentityProviderStoreCRUDAndEnabledInvariant"
+require_passed_test "OIDC provider admin CRUD" "TestIntegrationAdminIdentityProviderWorkflow"
+require_passed_test "OIDC state and nonce replay guards" "TestOIDCLoginStateStoresHashesAndRejectsReplay"
+require_passed_test "OIDC public login callback" "TestIntegrationOIDCProviderLoginAndCallback"
+require_passed_test "OIDC unknown disabled and unverified users" "TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers"
+require_passed_test "OIDC disabled provider behavior" "TestIntegrationOIDCDisabledDiscoveryAndLogin"
+require_passed_test "OIDC current-user identities" "TestIntegrationCurrentUserOIDCIdentityManagement"
+require_passed_test "OIDC token validation" "TestOIDCClientExchangeAndValidateIDToken"
+require_passed_test "OIDC invalid token rejection" "TestOIDCClientRejectsInvalidNonce"
+require_passed_test "OIDC secret redaction" "TestOIDCTokenErrorsDoNotContainProviderTokens"
+require_passed_test "OIDC raw secret rejection" "TestIdentityProviderRejectsRawClientSecretRef"
 require_passed_test "Configuration and maintenance" "TestLoadReadsEnvironmentAndDurations"
 
 overall_status="PASS"
@@ -230,7 +241,16 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 | Lifecycle observability | \`TestIntegrationAdminMetricsIncludesLifecycleVisibility\` and \`TestLifecycleMetricsAggregatesQueueAndOperationHealth\` verify platform-admin-only lifecycle metrics for outbox/inbox status counts, dead-letter breakdowns, operation status/type counts, and active-operation age. |
 | Broker adapters | \`TestNewPublisherCreatesLogPublisherAndRejectsUnsupportedKinds\`, \`TestNewConsumerCreatesLogConsumerAndRejectsUnsupportedKinds\`, \`TestLogPublisherWritesEnvelopeJSON\`, \`TestLogConsumerReadsEnvelopeJSON\`, \`TestAzureEventHubsPublisherPublishesJSONRecord\`, \`TestAzureEventHubsConsumerReadsAcrossPartitions\`, \`TestAzureEventHubsConsumerAcknowledgesAndResumesFromCheckpoint\`, and \`TestOpenAzurePartitionsUsesStoredCheckpointWhenPresent\` cover the deterministic local default adapter plus Azure Event Hubs publish/consume and durable checkpoint resume behavior without requiring live Azure. |
 | Database invariants | \`TestIntegrationDatabaseSchemaInvariants\` plus existing migration tests verify idempotent migrations, normalized email constraint, non-blank organization/device names, owner invariant, critical tables/columns/constraints/indexes, and automatic \`updated_at\` triggers. |
-| OpenAPI contract | \`TestIntegrationResponsesMatchOpenAPIContract\` plus OpenAPI schema validation cover representative Claim Token resolve/admin, registry-only provisioning-state with nullable \`operation\`, provisioned/failed provisioning-state, provisioning, deactivation, quota visibility, and audit visibility responses against \`openapi.yaml\`. |
+| OpenAPI contract | \`TestIntegrationResponsesMatchOpenAPIContract\` plus OpenAPI schema validation cover representative Claim Token resolve/admin, registry-only provisioning-state with nullable \`operation\`, provisioned/failed provisioning-state, provisioning, deactivation, quota visibility, audit visibility, public OIDC, current-user identity, and admin identity-provider responses against \`openapi.yaml\`. |
+| OIDC provider persistence | \`TestIdentityProviderStoreCRUDAndEnabledInvariant\`, \`TestIdentityProviderRejectsRawClientSecretRef\`, and \`TestIntegrationDatabaseSchemaInvariants\` verify provider CRUD, the one-enabled-provider invariant, secret-reference-only storage, identity link uniqueness, and OIDC schema/index presence. |
+| OIDC provider admin CRUD | \`TestIntegrationAdminIdentityProviderWorkflow\` verifies platform-admin-only create/list/show/update/disable, pagination, second-enabled-provider conflict handling, audit events, \`env:VAR_NAME\` secret references, and raw-secret non-persistence/non-response behavior. |
+| OIDC state and nonce replay guards | \`TestOIDCLoginStateStoresHashesAndRejectsReplay\`, \`TestOIDCLoginStateRejectsExpiredState\`, and \`TestIntegrationOIDCProviderLoginAndCallback\` verify raw state/nonce non-persistence, one-time state consumption, replay rejection, and callback nonce validation through hashed state records. |
+| OIDC public login callback | \`TestIntegrationOIDCProviderLoginAndCallback\` verifies discovery, login redirect, state/nonce creation, callback success, verified-email auto-link to an existing local user, Account Manager JWT issuance, identity persistence, replay rejection, and local email/password login compatibility. |
+| OIDC user rejection policy | \`TestIntegrationOIDCCallbackRejectsUnknownDisabledAndUnverifiedUsers\` verifies unknown users return \`user_not_provisioned\`, disabled linked users cannot login through SSO, and unverified provider emails return \`unverified_oidc_email\`. |
+| OIDC disabled provider behavior | \`TestIntegrationOIDCDisabledDiscoveryAndLogin\` verifies disabled OIDC returns no public providers and rejects login with \`oidc_disabled\`. |
+| OIDC current-user identities | \`TestIntegrationCurrentUserOIDCIdentityManagement\` and \`TestIntegrationDisabledUserCannotManageOIDCIdentities\` verify current-user list/unlink behavior, cross-user isolation, disabled-user rejection, and that unlinking an identity does not break local password login. |
+| OIDC token validation | \`TestOIDCClientExchangeAndValidateIDToken\`, \`TestOIDCClientRejectsInvalidIssuer\`, \`TestOIDCClientRejectsInvalidAudience\`, \`TestOIDCClientRejectsInvalidSignature\`, \`TestOIDCClientRejectsExpiredToken\`, \`TestOIDCClientRejectsInvalidNonce\`, \`TestOIDCClientRejectsUnverifiedEmail\`, \`TestOIDCClientRejectsUnexpectedSigningMethod\`, and JWKS/discovery/token-response negative tests verify authorization-code exchange and ID-token issuer, audience, signature, expiry, nonce, signing method, and verified-email validation without live Keycloak. |
+| OIDC secret redaction | \`TestOIDCTokenErrorsDoNotContainProviderTokens\`, \`TestIdentityProviderRejectsRawClientSecretRef\`, and \`TestIntegrationAdminIdentityProviderWorkflow\` verify Keycloak token values and raw client secrets are not persisted, returned, or included in typed validation errors. |
 | Configuration and maintenance | \`.env\` loading, TTL parsing/fallbacks, worker-specific broker config defaults, required JWT secrets, and refresh-token cleanup behavior. |
 
 ## Executed Test Cases


### PR DESCRIPTION
## Summary
- add OIDC provider, login/callback, token-validation, identity-management, and secret-redaction behavior groups to `make test-report` gates
- update the canonical test report with the new OIDC correctness matrix entries
- document the Keycloak/OIDC SSO test matrix and fake-OIDC CI boundary in `docs/TESTING.md`

Closes #148

## Tests
- `bash -n scripts/test-report.sh`
- `REPORT_FILE=docs/TEST_REPORT.md REPORT_GENERATED_AT=ci-candidate REPORT_CANONICAL=true make test-report`
- `git diff --check`
