### PR TITLE
Add Linode deployment script artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UNIT_TEST_PACKAGES := ./internal/api ./internal/auth ./internal/broker ./interna
 RACE_TEST_PACKAGES := ./internal/channel ./internal/broker ./internal/worker/... ./internal/auth ./internal/config ./internal/readiness
 FUZZ_SMOKE_TIME ?= 2s
 
-.PHONY: tidy test integration-test test-report check-report-candidates test-race test-repeat fuzz-smoke build release check-release readiness-smoke run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
+.PHONY: tidy test integration-test test-report check-report-candidates test-race test-repeat fuzz-smoke build release check-release readiness-smoke test-linode-deploy run run-outbox-worker run-inbox-worker db-up db-down migrate cleanup-tokens
 
 tidy:
 	go mod tidy
@@ -64,6 +64,11 @@ release:
 	tar -C dist -czf "dist/rtk_account_manager-$(VERSION).tar.gz" "rtk_account_manager-$(VERSION)"
 
 check-release: release
+
+test-linode-deploy:
+	go test ./linode_deploy/...
+	bash -n linode_deploy/scripts/deploy-staging.sh
+	go run ./linode_deploy/cmd/linode-deploy plan --config linode_deploy/configs/account-manager-staging.yaml >/dev/null
 
 readiness-smoke:
 	go run ./cmd/readiness-smoke

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The implementation stays aligned with the `contracts/` submodule for provisionin
 The local provisioning and worker flow, including the `log` broker adapter runbook, is documented in `docs/PROVISIONING_EVENT_WORKERS_RUNBOOK.md`.
 The optional local Keycloak/OIDC login flow is documented in `docs/KEYCLOAK_LOCAL_RUNBOOK.md`; normal local development does not require Keycloak.
 Private-cloud deployment packaging, systemd templates, migration/upgrade/rollback, and backup/restore operations are documented in `docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md`; reference deploy assets live under `deploy/`.
+Linode staging deployment for admins is documented in `linode_deploy/docs/RUNBOOK.md`; it uses an operator-run script and explicit release versions, not GitHub CD Actions.
 The local auth verification and password reset delivery adapter is `AUTH_TOKEN_DELIVERY=log`; generated one-time tokens are written to the API server log for dev/test use until a production mail or SMS adapter replaces it. Quota-raise approval and decline notifications use the SMTP mail path when `SMTP_HOST` and `SMTP_FROM` are configured, and otherwise fall back to the local log adapter for dev/test.
 Set `CROSS_SERVICE_BROKER=azure_eventhubs` plus `AZURE_EVENTHUB_CONNECTION_STRING` to run the workers against Azure Event Hubs instead of the local `log` adapter. The inbox worker persists Azure consumer checkpoints at `.state/azure_eventhubs/<stream>__<consumer-group>.json` by default; set `AZURE_EVENTHUB_CHECKPOINT_FILE` to override that path.
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -26,7 +26,7 @@ Generated: ci-candidate
 
 | Metric | Value |
 | --- | --- |
-| Go packages | 20 |
+| Go packages | 27 |
 | Test cases started | recorded in reports/test-events.json |
 | JSON pass events | recorded in reports/test-events.json |
 | JSON fail events | recorded in reports/test-events.json |
@@ -487,6 +487,20 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/worker/outbox`: `TestRunOnceIgnoresStaleLeaseTransitionConflict`
 - `rtk_account_manager/internal/worker/outbox`: `TestRunOnceMarksSuccessfulPublishes`
 - `rtk_account_manager/internal/worker/outbox`: `TestRunOnceSchedulesTransientRetry`
+- `rtk_account_manager/linode_deploy/internal/artifact`: `TestValidateManifestRejectsWrongArtifactName`
+- `rtk_account_manager/linode_deploy/internal/artifact`: `TestVerifyLocalRequiresAccountManagerBundleContract`
+- `rtk_account_manager/linode_deploy/internal/artifact`: `TestVerifyManifestAndChecksum`
+- `rtk_account_manager/linode_deploy/internal/cli`: `TestDeployDryRunRequiresReleaseAndSecrets`
+- `rtk_account_manager/linode_deploy/internal/cli`: `TestDeployRejectsLatestRelease`
+- `rtk_account_manager/linode_deploy/internal/cli`: `TestPlanCommandPrintsDeploymentPlan`
+- `rtk_account_manager/linode_deploy/internal/manifest`: `TestLoadAccountManagerStagingManifest`
+- `rtk_account_manager/linode_deploy/internal/manifest`: `TestManifestRejectsUnsafeAccountManagerShape`
+- `rtk_account_manager/linode_deploy/internal/manifest`: `TestManifestRequiresNoLatestRelease`
+- `rtk_account_manager/linode_deploy/internal/planner`: `TestPlanIncludesAccountManagerDeploymentGates`
+- `rtk_account_manager/linode_deploy/internal/planner`: `TestPlanShowsWorkersWhenEnabled`
+- `rtk_account_manager/linode_deploy/internal/render`: `TestRuntimeEnvRendersDefaultsAndSecretsWithoutLeakingRawValuesInReport`
+- `rtk_account_manager/linode_deploy/internal/secrets`: `TestLoadRequiredSecretsAndRedact`
+- `rtk_account_manager/linode_deploy/internal/secrets`: `TestRequireReportsMissingKeys`
 
 ## Commands
 

--- a/linode_deploy/.gitignore
+++ b/linode_deploy/.gitignore
@@ -1,0 +1,4 @@
+secrets/
+state/
+artifacts/
+.artifacts/

--- a/linode_deploy/.gitignore
+++ b/linode_deploy/.gitignore
@@ -1,4 +1,4 @@
-secrets/
-state/
-artifacts/
-.artifacts/
+/secrets/
+/state/
+/artifacts/
+/.artifacts/

--- a/linode_deploy/README.md
+++ b/linode_deploy/README.md
@@ -1,0 +1,8 @@
+# Account Manager Linode Deploy
+
+Operator-local deployment assets for placing `rtk_account_manager` on Linode.
+
+GitHub CI remains artifact-only. Deployment is run by an admin through
+`scripts/deploy-staging.sh` with an explicit release version.
+
+See [`docs/RUNBOOK.md`](docs/RUNBOOK.md).

--- a/linode_deploy/cmd/linode-deploy/main.go
+++ b/linode_deploy/cmd/linode-deploy/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"rtk_account_manager/linode_deploy/internal/cli"
+)
+
+func main() {
+	if err := cli.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/linode_deploy/configs/account-manager-staging.yaml
+++ b/linode_deploy/configs/account-manager-staging.yaml
@@ -1,0 +1,74 @@
+# Account Manager Linode staging manifest.
+# Do not commit generated state, rendered env files, or real secrets.
+
+stack: account-manager-staging
+region: us-sea
+
+tags:
+  - account-manager-staging
+  - managed-by:account-manager-linode-deploy
+
+vpc:
+  label: video-cloud-staging-vpc
+  cidr: 10.42.0.0/16
+  subnet:
+    label: video-cloud-staging-subnet
+    cidr: 10.42.1.0/24
+
+ssh:
+  user: root
+  public_key_path: ~/.ssh/id_ed25519_rtkcloud.pub
+  allowed_source_cidrs:
+    - 203.0.113.10/32
+  bastion_host: video-cloud-staging.realtekconnect.com
+
+instances:
+  edge:
+    label: video-cloud-staging-edge
+    networking: public_plus_vpc
+    private_ip: 10.42.1.5
+    firewall_profile: edge
+  infra:
+    label: video-cloud-staging-infra
+    networking: vpc_only
+    private_ip: 10.42.1.30
+    firewall_profile: infra
+  account-manager:
+    label: account-manager-staging-account-manager
+    type: g6-standard-2
+    image: linode/ubuntu24.04
+    networking: vpc_only
+    private_ip: 10.42.1.20
+    firewall_profile: account-manager
+    roles:
+      - account_manager_api
+      - account_manager_cleanup
+
+firewalls:
+  edge:
+    public_tcp: ["22", "80", "443"]
+    private_tcp: ["18081"]
+  infra:
+    private_tcp: ["22", "5432", "4222"]
+  account-manager:
+    private_tcp: ["22", "18081"]
+    private_egress_tcp: ["5432"]
+    optional_private_egress_tcp: ["4222"]
+
+deploy:
+  release: v0.1.0
+  domain: account-manager-staging.realtekconnect.com
+  public_base_url: https://account-manager-staging.realtekconnect.com
+  api_port: 18081
+  database_name: rtk_account_manager
+  database_role: rtk_account_manager
+  install_prefix: /opt/rtk-account-manager
+  etc_dir: /etc/rtk-account-manager
+  state_dir: /var/lib/rtk-account-manager
+  backup_marker: /var/lib/rtk-account-manager/last-db-backup-ok
+  restart_units:
+    - rtk-account-manager.service
+    - rtk-account-manager-cleanup-tokens.timer
+  worker_units:
+    - rtk-account-manager-outbox-worker.service
+    - rtk-account-manager-inbox-worker.service

--- a/linode_deploy/docs/RUNBOOK.md
+++ b/linode_deploy/docs/RUNBOOK.md
@@ -1,0 +1,171 @@
+# Account Manager Linode Deploy Runbook
+
+This runbook defines the operator-local Linode deployment flow for
+`rtk_account_manager`. GitHub CI remains artifact-only. It must not SSH into
+Linode hosts or run deployment.
+
+## Topology
+
+Account Manager runs on a dedicated VPC-only VM in the existing video-cloud
+Linode staging stack:
+
+| Role | Placement |
+| --- | --- |
+| `edge` | Existing public/VPC edge VM, terminates HTTPS. |
+| `infra` | Existing VPC-only infra VM, hosts PostgreSQL. |
+| `account-manager` | New VPC-only VM at `10.42.1.20`, API on `18081`. |
+
+Public route:
+
+```text
+account-manager-staging.realtekconnect.com
+  -> edge nginx
+  -> 10.42.1.20:18081
+```
+
+Account Manager uses a separate Postgres database and role:
+
+```text
+database: rtk_account_manager
+role:     rtk_account_manager
+```
+
+Do not reuse the `video_cloud` database or database role.
+
+## Operator Secrets
+
+Create a local ignored secrets file:
+
+```sh
+mkdir -p linode_deploy/secrets
+install -m 0600 /dev/null linode_deploy/secrets/account-manager-staging.env
+```
+
+Minimum keys:
+
+```sh
+ACCOUNT_MANAGER_DB_PASSWORD='<db-role-password>'
+JWT_ACCESS_SECRET='<access-token-secret>'
+JWT_REFRESH_SECRET='<refresh-token-secret>'
+```
+
+OIDC keys when SSO smoke is enabled:
+
+```sh
+OIDC_ISSUER_URL='https://<keycloak>/realms/<realm>'
+OIDC_CLIENT_ID='rtk-account-manager'
+OIDC_CLIENT_SECRET='<oidc-client-secret>'
+```
+
+Optional keys:
+
+```sh
+SMTP_HOST=
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_FROM=
+AZURE_EVENTHUB_CONNECTION_STRING=
+```
+
+Secrets must stay out of git, issue comments, generated reports, and shell
+history where possible.
+
+## Plan
+
+Review the manifest:
+
+```sh
+go run ./linode_deploy/cmd/linode-deploy plan \
+  --config linode_deploy/configs/account-manager-staging.yaml
+```
+
+The plan must show:
+
+- Account Manager VM `account-manager-staging-account-manager` at `10.42.1.20`
+- edge route for `account-manager-staging.realtekconnect.com`
+- edge -> account-manager `18081/tcp`
+- account-manager -> infra `5432/tcp`
+- DB migration gate before runtime restart
+- workers disabled by default
+
+## Deploy Script
+
+Run a dry-run first:
+
+```sh
+linode_deploy/scripts/deploy-staging.sh \
+  --release vX.Y.Z \
+  --stack account-manager-staging \
+  --config linode_deploy/configs/account-manager-staging.yaml \
+  --secrets-file linode_deploy/secrets/account-manager-staging.env \
+  --report .artifacts/account-manager-linode-deploy.md
+```
+
+Use a local bundle only for debug:
+
+```sh
+linode_deploy/scripts/deploy-staging.sh \
+  --release vX.Y.Z \
+  --release-bundle dist/rtk_account_manager-vX.Y.Z.tar.gz
+```
+
+The script refuses `latest`. Operators must choose an explicit release.
+
+## Live Execution Notes
+
+The current deploy artifact validates and records the ordered Linode deployment
+plan. The operator performs live Linode/API/SSH mutation using the generated
+report until a dedicated Account Manager Linode executor is wired.
+
+Live steps from the report:
+
+1. Confirm `10.42.1.20` is unused.
+2. Create or update the `account-manager` VPC-only VM.
+3. Update Linode firewall rules for edge, infra, and account-manager.
+4. Add the edge nginx vhost for `account-manager-staging.realtekconnect.com`.
+5. Create/verify `rtk_account_manager` Postgres role and database on infra.
+6. Install the release under `/opt/rtk-account-manager`.
+7. Write `/etc/rtk-account-manager/account-manager.env` with mode `0600`.
+8. Confirm DB backup marker at `/var/lib/rtk-account-manager/last-db-backup-ok`.
+9. Run `rtk-account-manager-migrate.service`.
+10. Restart API and cleanup timer.
+11. Start outbox/inbox workers only when explicitly enabled.
+12. Run health and smoke checks.
+
+## Runtime Defaults
+
+```sh
+DATABASE_URL='postgres://rtk_account_manager:<secret>@10.42.1.30:5432/rtk_account_manager?sslmode=disable'
+PORT=18081
+AUTH_TOKEN_DELIVERY=log
+CROSS_SERVICE_BROKER=log
+OIDC_REDIRECT_URL='https://account-manager-staging.realtekconnect.com/v1/auth/oidc/keycloak/callback'
+```
+
+## Verification
+
+Private VM health:
+
+```sh
+curl -fsS http://127.0.0.1:18081/v1/health
+```
+
+Edge/public health:
+
+```sh
+curl -fsS https://account-manager-staging.realtekconnect.com/v1/health
+```
+
+Optional smoke checks:
+
+- login with existing smoke user
+- read smoke organization
+- read smoke device
+- read provisioning state
+- OIDC provider discovery when OIDC is enabled
+
+## Evidence
+
+The report must include release, manifest digest, planned service changes,
+health/smoke status, and redacted env inventory. It must not include DSNs,
+JWT secrets, OIDC secrets, SMTP passwords, broker credentials, or raw tokens.

--- a/linode_deploy/internal/artifact/artifact.go
+++ b/linode_deploy/internal/artifact/artifact.go
@@ -1,0 +1,136 @@
+package artifact
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Manifest struct {
+	Version      string `json:"version"`
+	SourceCommit string `json:"source_commit"`
+	Bundle       string `json:"bundle"`
+	ArtifactPath string `json:"artifact_path"`
+	SHA256       string `json:"sha256"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type Bundle struct {
+	Version    string
+	Path       string
+	BundleName string
+	SHA256     string
+	Manifest   Manifest
+}
+
+func VerifyLocal(path string, version string) (Bundle, error) {
+	if path == "" {
+		return Bundle{}, fmt.Errorf("release bundle is required")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("read release bundle: %w", err)
+	}
+	if err := verifyReleaseManifest(bytes.NewReader(raw), version); err != nil {
+		return Bundle{}, err
+	}
+	sum := sha256.Sum256(raw)
+	name := filepath.Base(path)
+	expected := bundleName(version)
+	if name != expected {
+		return Bundle{}, fmt.Errorf("release bundle name %q must be %q", name, expected)
+	}
+	return Bundle{Version: version, Path: path, BundleName: name, SHA256: hex.EncodeToString(sum[:])}, nil
+}
+
+func VerifyManifestAndChecksum(manifestBytes, checksumBytes, bundleBytes []byte, version string) error {
+	var m Manifest
+	if err := json.Unmarshal(manifestBytes, &m); err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+	if err := ValidateManifest(m, version); err != nil {
+		return err
+	}
+	fields := strings.Fields(string(checksumBytes))
+	if len(fields) == 0 {
+		return fmt.Errorf("empty checksum")
+	}
+	if fields[0] != m.SHA256 {
+		return fmt.Errorf("checksum object does not match manifest")
+	}
+	sum := sha256.Sum256(bundleBytes)
+	if hex.EncodeToString(sum[:]) != m.SHA256 {
+		return fmt.Errorf("bundle checksum mismatch")
+	}
+	return verifyReleaseManifest(bytes.NewReader(bundleBytes), version)
+}
+
+func ValidateManifest(m Manifest, version string) error {
+	expectedBundle := bundleName(version)
+	expectedPath := "releases/" + version + "/" + expectedBundle
+	switch {
+	case version == "" || strings.EqualFold(version, "latest"):
+		return fmt.Errorf("explicit release version is required")
+	case m.Version != version:
+		return fmt.Errorf("manifest version %q does not match requested release %q", m.Version, version)
+	case m.Bundle != expectedBundle:
+		return fmt.Errorf("manifest bundle %q must be %q", m.Bundle, expectedBundle)
+	case m.ArtifactPath != expectedPath:
+		return fmt.Errorf("manifest artifact_path %q must be %q", m.ArtifactPath, expectedPath)
+	case m.SourceCommit == "":
+		return fmt.Errorf("manifest source_commit is required")
+	case m.SHA256 == "":
+		return fmt.Errorf("manifest sha256 is required")
+	case m.CreatedAt == "":
+		return fmt.Errorf("manifest created_at is required")
+	}
+	return nil
+}
+
+func bundleName(version string) string {
+	return "rtk_account_manager-" + version + ".tar.gz"
+}
+
+func verifyReleaseManifest(r io.Reader, version string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("open release bundle: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read release bundle: %w", err)
+		}
+		if filepath.Base(h.Name) != "release-manifest.txt" && filepath.Base(h.Name) != "manifest.txt" {
+			continue
+		}
+		content, err := io.ReadAll(tr)
+		if err != nil {
+			return fmt.Errorf("read release manifest: %w", err)
+		}
+		for _, line := range strings.Split(string(content), "\n") {
+			k, v, ok := strings.Cut(line, "=")
+			if ok && strings.TrimSpace(k) == "version" {
+				if strings.TrimSpace(v) != version {
+					return fmt.Errorf("release manifest version %q does not match requested release %q", strings.TrimSpace(v), version)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("release manifest missing version")
+	}
+	return fmt.Errorf("release bundle missing release-manifest.txt")
+}

--- a/linode_deploy/internal/artifact/artifact_test.go
+++ b/linode_deploy/internal/artifact/artifact_test.go
@@ -1,0 +1,91 @@
+package artifact
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyLocalRequiresAccountManagerBundleContract(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "rtk_account_manager-v1.2.3.tar.gz")
+	writeBundle(t, bundlePath, "v1.2.3")
+
+	bundle, err := VerifyLocal(bundlePath, "v1.2.3")
+	if err != nil {
+		t.Fatalf("VerifyLocal: %v", err)
+	}
+	if bundle.BundleName != "rtk_account_manager-v1.2.3.tar.gz" || bundle.Version != "v1.2.3" || bundle.SHA256 == "" {
+		t.Fatalf("unexpected bundle: %+v", bundle)
+	}
+}
+
+func TestValidateManifestRejectsWrongArtifactName(t *testing.T) {
+	err := ValidateManifest(Manifest{
+		Version:      "v1.2.3",
+		SourceCommit: "abc123",
+		Bundle:       "video_cloud-v1.2.3.tar.gz",
+		ArtifactPath: "releases/v1.2.3/video_cloud-v1.2.3.tar.gz",
+		SHA256:       strings.Repeat("a", 64),
+		CreatedAt:    "2026-05-14T00:00:00Z",
+	}, "v1.2.3")
+	if err == nil || !strings.Contains(err.Error(), "rtk_account_manager-v1.2.3.tar.gz") {
+		t.Fatalf("expected account-manager artifact validation error, got %v", err)
+	}
+}
+
+func TestVerifyManifestAndChecksum(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "rtk_account_manager-v1.2.3.tar.gz")
+	writeBundle(t, bundlePath, "v1.2.3")
+	raw, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	sha := hex.EncodeToString(sum[:])
+	manifestBytes, err := json.Marshal(Manifest{
+		Version:      "v1.2.3",
+		SourceCommit: "abc123",
+		Bundle:       "rtk_account_manager-v1.2.3.tar.gz",
+		ArtifactPath: "releases/v1.2.3/rtk_account_manager-v1.2.3.tar.gz",
+		SHA256:       sha,
+		CreatedAt:    "2026-05-14T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyManifestAndChecksum(manifestBytes, []byte(sha+"  rtk_account_manager-v1.2.3.tar.gz\n"), raw, "v1.2.3"); err != nil {
+		t.Fatalf("VerifyManifestAndChecksum: %v", err)
+	}
+}
+
+func writeBundle(t *testing.T, path string, version string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	content := []byte("version=" + version + "\ngit_sha=abc123\n")
+	if err := tw.WriteHeader(&tar.Header{Name: "rtk_account_manager-" + version + "/release-manifest.txt", Mode: 0o644, Size: int64(len(content))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/linode_deploy/internal/cli/cli.go
+++ b/linode_deploy/internal/cli/cli.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"rtk_account_manager/linode_deploy/internal/artifact"
+	"rtk_account_manager/linode_deploy/internal/manifest"
+	"rtk_account_manager/linode_deploy/internal/planner"
+	"rtk_account_manager/linode_deploy/internal/render"
+	"rtk_account_manager/linode_deploy/internal/secrets"
+)
+
+const help = `account-manager linode-deploy
+
+Usage:
+  linode-deploy plan --config linode_deploy/configs/account-manager-staging.yaml
+  linode-deploy deploy --config linode_deploy/configs/account-manager-staging.yaml --stack account-manager-staging --release vX.Y.Z --secrets-file linode_deploy/secrets/account-manager-staging.env [--dry-run] [--skip-infra-apply] [--enable-workers] [--skip-oidc] [--report .artifacts/account-manager-linode-deploy.md]
+`
+
+func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	_ = ctx
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if len(args) == 0 || args[0] == "help" || args[0] == "--help" {
+		_, _ = io.WriteString(stdout, help)
+		return nil
+	}
+	switch args[0] {
+	case "plan":
+		return runPlan(args[1:], stdout)
+	case "deploy":
+		return runDeploy(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown command %s", args[0])
+	}
+}
+
+func runPlan(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("plan", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cfg := fs.String("config", "", "")
+	enableWorkers := fs.Bool("enable-workers", false, "")
+	skipOIDC := fs.Bool("skip-oidc", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfg == "" {
+		return fmt.Errorf("--config is required")
+	}
+	m, err := manifest.Load(*cfg)
+	if err != nil {
+		return err
+	}
+	_, _ = io.WriteString(out, planner.Text(m, planner.Options{EnableWorkers: *enableWorkers, SkipOIDC: *skipOIDC}))
+	return nil
+}
+
+func runDeploy(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("deploy", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cfg := fs.String("config", "", "")
+	stack := fs.String("stack", "", "")
+	release := fs.String("release", "", "")
+	secretsFile := fs.String("secrets-file", "", "")
+	dryRun := fs.Bool("dry-run", false, "")
+	skipInfraApply := fs.Bool("skip-infra-apply", false, "")
+	enableWorkers := fs.Bool("enable-workers", false, "")
+	skipOIDC := fs.Bool("skip-oidc", false, "")
+	report := fs.String("report", ".artifacts/account-manager-linode-deploy.md", "")
+	releaseBundle := fs.String("release-bundle", "", "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *cfg == "" || *stack == "" || *release == "" {
+		return fmt.Errorf("--config, --stack, and --release are required")
+	}
+	if strings.EqualFold(*release, "latest") {
+		return fmt.Errorf("explicit release is required; latest is not allowed")
+	}
+	m, err := manifest.Load(*cfg)
+	if err != nil {
+		return err
+	}
+	if m.Stack != *stack {
+		return fmt.Errorf("manifest stack %q does not match --stack %q", m.Stack, *stack)
+	}
+	vals, err := secrets.Load(*secretsFile)
+	if err != nil {
+		return err
+	}
+	required := []string{"ACCOUNT_MANAGER_DB_PASSWORD", "JWT_ACCESS_SECRET", "JWT_REFRESH_SECRET"}
+	if !*skipOIDC {
+		required = append(required, "OIDC_CLIENT_SECRET", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID")
+	}
+	if err := vals.Require(required...); err != nil {
+		return err
+	}
+	env, redactedEnv := render.RuntimeEnv(m, vals, render.Options{SkipOIDC: *skipOIDC, EnableWorkers: *enableWorkers})
+	_ = env
+	_, _ = fmt.Fprintf(out, "dry-run deploy %s release %s\n", *stack, *release)
+	if !*dryRun {
+		_, _ = io.WriteString(out, "live execution is intentionally script-driven; run with --dry-run first and review generated commands\n")
+	}
+	if *skipInfraApply {
+		_, _ = io.WriteString(out, "skip infrastructure apply\n")
+	} else {
+		_, _ = io.WriteString(out, "apply/create account-manager VM and edge route if missing\n")
+	}
+	if *releaseBundle != "" {
+		if _, err := artifact.VerifyLocal(*releaseBundle, *release); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(out, "verify local release bundle %s\n", *releaseBundle)
+	} else {
+		_, _ = fmt.Fprintf(out, "verify Object Storage release releases/%s/rtk_account_manager-%s.tar.gz\n", *release, *release)
+	}
+	_, _ = io.WriteString(out, "write runtime env to /etc/rtk-account-manager/account-manager.env mode 0600\n")
+	_, _ = io.WriteString(out, "require database backup marker\n")
+	_, _ = io.WriteString(out, "run rtk-account-manager-migrate.service\n")
+	_, _ = io.WriteString(out, "restart rtk-account-manager.service rtk-account-manager-cleanup-tokens.timer\n")
+	if *enableWorkers {
+		_, _ = io.WriteString(out, "restart rtk-account-manager-outbox-worker.service rtk-account-manager-inbox-worker.service\n")
+	}
+	_, _ = io.WriteString(out, "run private and edge HTTPS health smoke checks\n")
+	_, _ = fmt.Fprintf(out, "write deployment evidence report %s\n", *report)
+	_, _ = io.WriteString(out, "redacted env inventory\n")
+	_, _ = io.WriteString(out, redactedEnv)
+	return nil
+}

--- a/linode_deploy/internal/cli/cli_test.go
+++ b/linode_deploy/internal/cli/cli_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPlanCommandPrintsDeploymentPlan(t *testing.T) {
+	var out bytes.Buffer
+	err := Run(context.Background(), []string{"plan", "--config", filepath.Join("..", "..", "configs", "account-manager-staging.yaml")}, &out, &out)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(out.String(), "account-manager-staging.realtekconnect.com") || !strings.Contains(out.String(), "workers disabled by default") {
+		t.Fatalf("unexpected plan output:\n%s", out.String())
+	}
+}
+
+func TestDeployDryRunRequiresReleaseAndSecrets(t *testing.T) {
+	var out bytes.Buffer
+	err := Run(context.Background(), []string{
+		"deploy",
+		"--config", filepath.Join("..", "..", "configs", "account-manager-staging.yaml"),
+		"--stack", "account-manager-staging",
+		"--release", "v1.2.3",
+		"--secrets-file", filepath.Join("testdata", "account-manager-staging.env"),
+		"--dry-run",
+		"--skip-infra-apply",
+	}, &out, &out)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, want := range []string{"dry-run deploy account-manager-staging release v1.2.3", "rtk-account-manager-migrate.service", "redacted env inventory"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("deploy output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "db-secret") || strings.Contains(out.String(), "access-secret") {
+		t.Fatalf("deploy output leaked secret:\n%s", out.String())
+	}
+}
+
+func TestDeployRejectsLatestRelease(t *testing.T) {
+	var out bytes.Buffer
+	err := Run(context.Background(), []string{
+		"deploy",
+		"--config", filepath.Join("..", "..", "configs", "account-manager-staging.yaml"),
+		"--stack", "account-manager-staging",
+		"--release", "latest",
+		"--secrets-file", filepath.Join("testdata", "account-manager-staging.env"),
+		"--dry-run",
+	}, &out, &out)
+	if err == nil || !strings.Contains(err.Error(), "latest is not allowed") {
+		t.Fatalf("expected latest rejection, got %v", err)
+	}
+}

--- a/linode_deploy/internal/cli/testdata/account-manager-staging.env
+++ b/linode_deploy/internal/cli/testdata/account-manager-staging.env
@@ -1,0 +1,6 @@
+ACCOUNT_MANAGER_DB_PASSWORD=db-secret
+JWT_ACCESS_SECRET=access-secret
+JWT_REFRESH_SECRET=refresh-secret
+OIDC_CLIENT_SECRET=oidc-secret
+OIDC_ISSUER_URL=https://keycloak.example.test/realms/rtk
+OIDC_CLIENT_ID=rtk-account-manager

--- a/linode_deploy/internal/manifest/manifest.go
+++ b/linode_deploy/internal/manifest/manifest.go
@@ -1,0 +1,161 @@
+package manifest
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Manifest struct {
+	Stack     string                     `yaml:"stack"`
+	Region    string                     `yaml:"region"`
+	Tags      []string                   `yaml:"tags"`
+	VPC       VPC                        `yaml:"vpc"`
+	SSH       SSH                        `yaml:"ssh"`
+	Instances map[string]Instance        `yaml:"instances"`
+	Firewalls map[string]FirewallProfile `yaml:"firewalls"`
+	Deploy    Deploy                     `yaml:"deploy"`
+	Digest    string                     `yaml:"-"`
+}
+
+type VPC struct {
+	Label  string `yaml:"label"`
+	CIDR   string `yaml:"cidr"`
+	Subnet struct {
+		Label string `yaml:"label"`
+		CIDR  string `yaml:"cidr"`
+	} `yaml:"subnet"`
+}
+
+type SSH struct {
+	User               string   `yaml:"user"`
+	PublicKeyPath      string   `yaml:"public_key_path"`
+	AllowedSourceCIDRs []string `yaml:"allowed_source_cidrs"`
+	BastionHost        string   `yaml:"bastion_host"`
+}
+
+type Instance struct {
+	Label           string   `yaml:"label"`
+	Type            string   `yaml:"type"`
+	Image           string   `yaml:"image"`
+	Networking      string   `yaml:"networking"`
+	PrivateIP       string   `yaml:"private_ip"`
+	FirewallProfile string   `yaml:"firewall_profile"`
+	Roles           []string `yaml:"roles"`
+}
+
+type FirewallProfile struct {
+	PublicTCP                []string `yaml:"public_tcp"`
+	PrivateTCP               []string `yaml:"private_tcp"`
+	PrivateEgressTCP         []string `yaml:"private_egress_tcp"`
+	OptionalPrivateEgressTCP []string `yaml:"optional_private_egress_tcp"`
+}
+
+type Deploy struct {
+	Release       string   `yaml:"release"`
+	Domain        string   `yaml:"domain"`
+	PublicBaseURL string   `yaml:"public_base_url"`
+	APIPort       int      `yaml:"api_port"`
+	DatabaseName  string   `yaml:"database_name"`
+	DatabaseRole  string   `yaml:"database_role"`
+	InstallPrefix string   `yaml:"install_prefix"`
+	EtcDir        string   `yaml:"etc_dir"`
+	StateDir      string   `yaml:"state_dir"`
+	BackupMarker  string   `yaml:"backup_marker"`
+	RestartUnits  []string `yaml:"restart_units"`
+	WorkerUnits   []string `yaml:"worker_units"`
+}
+
+func Load(path string) (Manifest, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, err
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		return Manifest{}, err
+	}
+	sum := sha256.Sum256(b)
+	m.Digest = fmt.Sprintf("%x", sum[:])
+	return m, m.Validate()
+}
+
+func (m Manifest) Validate() error {
+	if m.Stack == "" || m.Region == "" {
+		return fmt.Errorf("stack and region are required")
+	}
+	if _, _, err := net.ParseCIDR(m.VPC.CIDR); err != nil {
+		return fmt.Errorf("invalid vpc cidr: %w", err)
+	}
+	_, subnet, err := net.ParseCIDR(m.VPC.Subnet.CIDR)
+	if err != nil {
+		return fmt.Errorf("invalid subnet cidr: %w", err)
+	}
+	if m.SSH.User == "" || m.SSH.PublicKeyPath == "" || m.SSH.BastionHost == "" {
+		return fmt.Errorf("ssh user, public_key_path, and bastion_host are required")
+	}
+	for _, cidr := range m.SSH.AllowedSourceCIDRs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("invalid allowed ssh cidr %q: %w", cidr, err)
+		}
+	}
+	for _, role := range []string{"edge", "infra", "account-manager"} {
+		inst, ok := m.Instances[role]
+		if !ok {
+			return fmt.Errorf("missing instance %s", role)
+		}
+		if inst.Label == "" || inst.Networking == "" || inst.PrivateIP == "" || inst.FirewallProfile == "" {
+			return fmt.Errorf("instance %s missing required fields", role)
+		}
+		if _, ok := m.Firewalls[inst.FirewallProfile]; !ok {
+			return fmt.Errorf("instance %s references missing firewall profile %s", role, inst.FirewallProfile)
+		}
+		ip := net.ParseIP(inst.PrivateIP)
+		if ip == nil || !subnet.Contains(ip) {
+			return fmt.Errorf("instance %s private_ip %q is outside subnet %s", role, inst.PrivateIP, subnet.String())
+		}
+	}
+	acct := m.Instances["account-manager"]
+	if acct.Networking != "vpc_only" {
+		return fmt.Errorf("account-manager networking must be vpc_only")
+	}
+	if acct.PrivateIP != "10.42.1.20" {
+		return fmt.Errorf("account-manager private_ip must be 10.42.1.20")
+	}
+	if acct.Type == "" || acct.Image == "" {
+		return fmt.Errorf("account-manager type and image are required")
+	}
+	if m.Deploy.Release == "" || strings.EqualFold(m.Deploy.Release, "latest") {
+		return fmt.Errorf("explicit release is required; latest is not allowed")
+	}
+	if m.Deploy.Domain == "" || m.Deploy.PublicBaseURL == "" || m.Deploy.APIPort != 18081 {
+		return fmt.Errorf("domain, public_base_url, and api_port 18081 are required")
+	}
+	if m.Deploy.DatabaseName != "rtk_account_manager" || m.Deploy.DatabaseRole != "rtk_account_manager" {
+		return fmt.Errorf("account-manager database and role must be isolated as rtk_account_manager")
+	}
+	if m.Deploy.InstallPrefix == "" || m.Deploy.EtcDir == "" || m.Deploy.StateDir == "" || m.Deploy.BackupMarker == "" {
+		return fmt.Errorf("install_prefix, etc_dir, state_dir, and backup_marker are required")
+	}
+	return nil
+}
+
+func (m Manifest) AccountManager() Instance {
+	return m.Instances["account-manager"]
+}
+
+func (m Manifest) Edge() Instance {
+	return m.Instances["edge"]
+}
+
+func (m Manifest) Infra() Instance {
+	return m.Instances["infra"]
+}
+
+func (m Manifest) WorkersDisabledByDefault() bool {
+	return len(m.Deploy.WorkerUnits) > 0
+}

--- a/linode_deploy/internal/manifest/manifest_test.go
+++ b/linode_deploy/internal/manifest/manifest_test.go
@@ -1,0 +1,65 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadAccountManagerStagingManifest(t *testing.T) {
+	path := filepath.Join("..", "..", "configs", "account-manager-staging.yaml")
+	m, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.Stack != "account-manager-staging" {
+		t.Fatalf("unexpected stack: %q", m.Stack)
+	}
+	acct := m.Instances["account-manager"]
+	if acct.PrivateIP != "10.42.1.20" || acct.Networking != "vpc_only" {
+		t.Fatalf("unexpected account-manager instance: %+v", acct)
+	}
+	if m.Deploy.Domain != "account-manager-staging.realtekconnect.com" {
+		t.Fatalf("unexpected domain: %q", m.Deploy.Domain)
+	}
+	if !m.WorkersDisabledByDefault() {
+		t.Fatal("workers should be disabled unless explicitly enabled")
+	}
+}
+
+func TestManifestRejectsUnsafeAccountManagerShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	body := strings.Replace(validManifest(t), "private_ip: 10.42.1.20\n    firewall_profile", "private_ip: 10.42.1.20\n    networking: public_plus_vpc\n    firewall_profile", 1)
+	body = strings.Replace(body, "networking: vpc_only\n    private_ip: 10.42.1.20", "private_ip: 10.42.1.20", 1)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "account-manager networking") {
+		t.Fatalf("expected account-manager networking validation error, got %v", err)
+	}
+}
+
+func TestManifestRequiresNoLatestRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	body := strings.Replace(validManifest(t), "release: v0.1.0", "release: latest", 1)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "explicit release") {
+		t.Fatalf("expected explicit release validation error, got %v", err)
+	}
+}
+
+func validManifest(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", "configs", "account-manager-staging.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/linode_deploy/internal/planner/planner.go
+++ b/linode_deploy/internal/planner/planner.go
@@ -1,0 +1,44 @@
+package planner
+
+import (
+	"fmt"
+	"strings"
+
+	"rtk_account_manager/linode_deploy/internal/manifest"
+)
+
+type Options struct {
+	EnableWorkers bool
+	SkipOIDC      bool
+}
+
+func Text(m manifest.Manifest, opts Options) string {
+	acct := m.AccountManager()
+	edge := m.Edge()
+	infra := m.Infra()
+	lines := []string{
+		fmt.Sprintf("stack %s region %s", m.Stack, m.Region),
+		fmt.Sprintf("public route %s -> edge %s -> account-manager %s:%d", m.Deploy.Domain, edge.PrivateIP, acct.PrivateIP, m.Deploy.APIPort),
+		fmt.Sprintf("account-manager VM %s %s", acct.Label, acct.PrivateIP),
+		"edge -> account-manager 18081/tcp",
+		"account-manager -> infra 5432/tcp",
+		fmt.Sprintf("database %s role %s on infra %s", m.Deploy.DatabaseName, m.Deploy.DatabaseRole, infra.PrivateIP),
+		"verify release manifest and SHA256",
+		"write /etc/rtk-account-manager/account-manager.env mode 0600",
+		"require database backup marker",
+		"run rtk-account-manager-migrate.service before runtime restart",
+		"restart rtk-account-manager.service and rtk-account-manager-cleanup-tokens.timer",
+	}
+	if opts.EnableWorkers {
+		lines = append(lines, "restart outbox/inbox workers")
+	} else {
+		lines = append(lines, "workers disabled by default")
+	}
+	if opts.SkipOIDC {
+		lines = append(lines, "OIDC smoke skipped by operator flag")
+	} else {
+		lines = append(lines, "OIDC redirect "+m.Deploy.PublicBaseURL+"/v1/auth/oidc/keycloak/callback")
+	}
+	lines = append(lines, "write redacted deployment evidence report")
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/linode_deploy/internal/planner/planner_test.go
+++ b/linode_deploy/internal/planner/planner_test.go
@@ -1,0 +1,40 @@
+package planner
+
+import (
+	"strings"
+	"testing"
+
+	"rtk_account_manager/linode_deploy/internal/manifest"
+)
+
+func TestPlanIncludesAccountManagerDeploymentGates(t *testing.T) {
+	m, err := manifest.Load("../../configs/account-manager-staging.yaml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plan := Text(m, Options{})
+	for _, want := range []string{
+		"account-manager-staging.realtekconnect.com",
+		"account-manager VM account-manager-staging-account-manager 10.42.1.20",
+		"edge -> account-manager 18081/tcp",
+		"account-manager -> infra 5432/tcp",
+		"verify release manifest and SHA256",
+		"require database backup marker",
+		"workers disabled by default",
+	} {
+		if !strings.Contains(plan, want) {
+			t.Fatalf("plan missing %q:\n%s", want, plan)
+		}
+	}
+}
+
+func TestPlanShowsWorkersWhenEnabled(t *testing.T) {
+	m, err := manifest.Load("../../configs/account-manager-staging.yaml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plan := Text(m, Options{EnableWorkers: true})
+	if !strings.Contains(plan, "restart outbox/inbox workers") {
+		t.Fatalf("plan missing worker restart:\n%s", plan)
+	}
+}

--- a/linode_deploy/internal/render/render.go
+++ b/linode_deploy/internal/render/render.go
@@ -1,0 +1,85 @@
+package render
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"rtk_account_manager/linode_deploy/internal/manifest"
+	"rtk_account_manager/linode_deploy/internal/secrets"
+)
+
+type Options struct {
+	SkipOIDC      bool
+	EnableWorkers bool
+}
+
+func RuntimeEnv(m manifest.Manifest, vals secrets.Values, opts Options) (string, string) {
+	dbPass := vals.Get("ACCOUNT_MANAGER_DB_PASSWORD")
+	accessSecret := vals.Get("JWT_ACCESS_SECRET")
+	refreshSecret := vals.Get("JWT_REFRESH_SECRET")
+	oidcSecret := vals.Get("OIDC_CLIENT_SECRET")
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?sslmode=disable", m.Deploy.DatabaseRole, dbPass, m.Infra().PrivateIP, m.Deploy.DatabaseName)
+	lines := []string{
+		"DATABASE_URL=" + dsn,
+		"JWT_ACCESS_SECRET=" + accessSecret,
+		"JWT_REFRESH_SECRET=" + refreshSecret,
+		fmt.Sprintf("PORT=%d", m.Deploy.APIPort),
+		"ACCESS_TOKEN_TTL=15m",
+		"REFRESH_TOKEN_TTL=720h",
+		"AUTH_TOKEN_DELIVERY=log",
+		"EMAIL_VERIFICATION_TTL=30m",
+		"PASSWORD_RESET_TTL=30m",
+		"OTP_RESEND_INTERVAL=60s",
+		"OTP_MAX_ATTEMPTS=5",
+		"SIGNUP_CAPTCHA_REQUIRED=false",
+		"SIGNUP_DISPOSABLE_DOMAINS=",
+		"SMTP_HOST=" + vals.Get("SMTP_HOST"),
+		"SMTP_PORT=587",
+		"SMTP_USERNAME=" + vals.Get("SMTP_USERNAME"),
+		"SMTP_PASSWORD=" + vals.Get("SMTP_PASSWORD"),
+		"SMTP_FROM=" + vals.Get("SMTP_FROM"),
+		"CROSS_SERVICE_BROKER=log",
+		"ACCOUNT_VIDEO_COMMANDS_STREAM=account.video.commands",
+		"VIDEO_ACCOUNT_EVENTS_STREAM=video.account.events",
+		"CROSS_SERVICE_CONSUMER_GROUP=rtk_account_manager",
+		"CROSS_SERVICE_MAX_ATTEMPTS=5",
+		"CROSS_SERVICE_POLL_INTERVAL=5s",
+		"AZURE_EVENTHUB_CONNECTION_STRING=" + vals.Get("AZURE_EVENTHUB_CONNECTION_STRING"),
+		"AZURE_EVENTHUB_CHECKPOINT_FILE=" + m.Deploy.StateDir + "/azure_eventhubs_checkpoint.json",
+	}
+	if opts.SkipOIDC {
+		lines = append(lines, "OIDC_ENABLED=false")
+	} else {
+		lines = append(lines,
+			"OIDC_ENABLED=true",
+			"OIDC_PROVIDER_ID=keycloak",
+			"OIDC_PROVIDER_NAME=Keycloak",
+			"OIDC_ISSUER_URL="+vals.Get("OIDC_ISSUER_URL"),
+			"OIDC_CLIENT_ID="+vals.Get("OIDC_CLIENT_ID"),
+			"OIDC_CLIENT_SECRET="+oidcSecret,
+			"OIDC_REDIRECT_URL="+m.Deploy.PublicBaseURL+"/v1/auth/oidc/keycloak/callback",
+			"OIDC_SCOPES=openid email profile",
+			"OIDC_AUTO_LINK_EMAIL=false",
+		)
+	}
+	env := strings.Join(lines, "\n") + "\n"
+	reportLines := append([]string{}, lines...)
+	for i, line := range reportLines {
+		k, _, _ := strings.Cut(line, "=")
+		if secretKey(k) {
+			reportLines[i] = k + "=<redacted>"
+		}
+	}
+	sort.Strings(reportLines)
+	return env, strings.Join(reportLines, "\n") + "\n"
+}
+
+func secretKey(key string) bool {
+	key = strings.ToUpper(key)
+	return strings.Contains(key, "PASSWORD") ||
+		strings.Contains(key, "SECRET") ||
+		strings.Contains(key, "TOKEN") ||
+		key == "DATABASE_URL" ||
+		strings.Contains(key, "CONNECTION_STRING")
+}

--- a/linode_deploy/internal/render/render_test.go
+++ b/linode_deploy/internal/render/render_test.go
@@ -1,0 +1,40 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"rtk_account_manager/linode_deploy/internal/manifest"
+	"rtk_account_manager/linode_deploy/internal/secrets"
+)
+
+func TestRuntimeEnvRendersDefaultsAndSecretsWithoutLeakingRawValuesInReport(t *testing.T) {
+	m, err := manifest.Load("../../configs/account-manager-staging.yaml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	vals := secrets.Values{
+		"ACCOUNT_MANAGER_DB_PASSWORD": "db-secret",
+		"JWT_ACCESS_SECRET":           "access-secret",
+		"JWT_REFRESH_SECRET":          "refresh-secret",
+		"OIDC_CLIENT_SECRET":          "oidc-secret",
+	}
+	env, report := RuntimeEnv(m, vals, Options{SkipOIDC: false})
+	for _, want := range []string{
+		"PORT=18081",
+		"DATABASE_URL=postgres://rtk_account_manager:db-secret@10.42.1.30:5432/rtk_account_manager?sslmode=disable",
+		"OIDC_REDIRECT_URL=https://account-manager-staging.realtekconnect.com/v1/auth/oidc/keycloak/callback",
+	} {
+		if !strings.Contains(env, want) {
+			t.Fatalf("env missing %q:\n%s", want, env)
+		}
+	}
+	for _, leaked := range []string{"db-secret", "access-secret", "refresh-secret", "oidc-secret"} {
+		if strings.Contains(report, leaked) {
+			t.Fatalf("report leaked %q:\n%s", leaked, report)
+		}
+	}
+	if !strings.Contains(report, "OIDC_CLIENT_SECRET=<redacted>") {
+		t.Fatalf("report missing redacted OIDC key:\n%s", report)
+	}
+}

--- a/linode_deploy/internal/secrets/secrets.go
+++ b/linode_deploy/internal/secrets/secrets.go
@@ -1,0 +1,82 @@
+package secrets
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+type Values map[string]string
+
+func Load(path string) (Values, error) {
+	if path == "" {
+		return Values{}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read secrets: %w", err)
+	}
+	defer f.Close()
+	vals := Values{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		vals[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return vals, nil
+}
+
+func (v Values) Get(key string) string {
+	if v == nil {
+		return ""
+	}
+	return v[key]
+}
+
+func (v Values) Require(keys ...string) error {
+	missing := []string{}
+	for _, key := range keys {
+		if strings.TrimSpace(v.Get(key)) == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required secrets: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func (v Values) Redact(s string) string {
+	values := []string{}
+	for key, value := range v {
+		if !secretLikeKey(key) || len(value) < 4 {
+			continue
+		}
+		values = append(values, value)
+	}
+	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	for _, value := range values {
+		s = strings.ReplaceAll(s, value, "<redacted>")
+	}
+	return s
+}
+
+func secretLikeKey(key string) bool {
+	key = strings.ToUpper(key)
+	return strings.Contains(key, "PASSWORD") ||
+		strings.Contains(key, "SECRET") ||
+		strings.Contains(key, "TOKEN") ||
+		strings.Contains(key, "DSN")
+}

--- a/linode_deploy/internal/secrets/secrets_test.go
+++ b/linode_deploy/internal/secrets/secrets_test.go
@@ -1,0 +1,42 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRequiredSecretsAndRedact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "account-manager-staging.env")
+	body := `
+ACCOUNT_MANAGER_DB_PASSWORD=db-secret
+JWT_ACCESS_SECRET=access-secret
+JWT_REFRESH_SECRET=refresh-secret
+OIDC_CLIENT_SECRET=oidc-secret
+SMTP_PASSWORD=smtp-secret
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vals, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := vals.Require("ACCOUNT_MANAGER_DB_PASSWORD", "JWT_ACCESS_SECRET", "JWT_REFRESH_SECRET"); err != nil {
+		t.Fatalf("Require: %v", err)
+	}
+	redacted := vals.Redact("postgres://rtk_account_manager:db-secret@10.42.1.30/db? jwt=access-secret oidc=oidc-secret smtp=smtp-secret")
+	for _, secret := range []string{"db-secret", "access-secret", "oidc-secret", "smtp-secret"} {
+		if strings.Contains(redacted, secret) {
+			t.Fatalf("redaction leaked %s in %q", secret, redacted)
+		}
+	}
+}
+
+func TestRequireReportsMissingKeys(t *testing.T) {
+	err := Values{"JWT_ACCESS_SECRET": "x"}.Require("JWT_ACCESS_SECRET", "JWT_REFRESH_SECRET")
+	if err == nil || !strings.Contains(err.Error(), "JWT_REFRESH_SECRET") {
+		t.Fatalf("expected missing key error, got %v", err)
+	}
+}

--- a/linode_deploy/scripts/deploy-staging.sh
+++ b/linode_deploy/scripts/deploy-staging.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+config="linode_deploy/configs/account-manager-staging.yaml"
+stack="account-manager-staging"
+secrets_file="linode_deploy/secrets/account-manager-staging.env"
+report=".artifacts/account-manager-linode-deploy.md"
+release=""
+release_bundle=""
+execute=false
+skip_infra_apply=false
+enable_workers=false
+skip_oidc=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  linode_deploy/scripts/deploy-staging.sh --release vX.Y.Z [options]
+
+Options:
+  --config PATH          Manifest path. Default: linode_deploy/configs/account-manager-staging.yaml
+  --stack NAME           Stack name. Default: account-manager-staging
+  --secrets-file PATH    Operator secrets file. Default: linode_deploy/secrets/account-manager-staging.env
+  --release-bundle PATH  Local release bundle override for debug only.
+  --report PATH          Redacted evidence report path.
+  --skip-infra-apply     Skip infrastructure apply checks for deploy-only reruns.
+  --enable-workers       Include outbox/inbox workers in runtime restart plan.
+  --skip-oidc            Render OIDC disabled and mark OIDC smoke skipped.
+  --execute              Leave dry-run mode. Review dry-run output before using.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config) config="$2"; shift 2 ;;
+    --stack) stack="$2"; shift 2 ;;
+    --secrets-file) secrets_file="$2"; shift 2 ;;
+    --release) release="$2"; shift 2 ;;
+    --release-bundle) release_bundle="$2"; shift 2 ;;
+    --report) report="$2"; shift 2 ;;
+    --skip-infra-apply) skip_infra_apply=true; shift ;;
+    --enable-workers) enable_workers=true; shift ;;
+    --skip-oidc) skip_oidc=true; shift ;;
+    --execute) execute=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$release" ]; then
+  echo "--release is required; latest is not allowed" >&2
+  exit 2
+fi
+if [ "$release" = "latest" ]; then
+  echo "--release latest is not allowed" >&2
+  exit 2
+fi
+if [ ! -f "$config" ]; then
+  echo "missing config: $config" >&2
+  exit 1
+fi
+if [ ! -f "$secrets_file" ]; then
+  echo "missing secrets file: $secrets_file" >&2
+  exit 1
+fi
+
+args=(deploy --config "$config" --stack "$stack" --release "$release" --secrets-file "$secrets_file" --report "$report")
+if [ -n "$release_bundle" ]; then
+  args+=(--release-bundle "$release_bundle")
+fi
+if [ "$skip_infra_apply" = true ]; then
+  args+=(--skip-infra-apply)
+fi
+if [ "$enable_workers" = true ]; then
+  args+=(--enable-workers)
+fi
+if [ "$skip_oidc" = true ]; then
+  args+=(--skip-oidc)
+fi
+if [ "$execute" = false ]; then
+  args+=(--dry-run)
+fi
+
+mkdir -p "$(dirname "$report")"
+
+{
+  echo "# Account Manager Linode Deployment Evidence"
+  echo
+  echo "- stack: $stack"
+  echo "- release: $release"
+  echo "- config: $config"
+  echo "- mode: $(if [ "$execute" = true ]; then echo execute; else echo dry-run; fi)"
+  echo
+  echo "## Plan"
+  echo
+  go run ./linode_deploy/cmd/linode-deploy plan --config "$config" \
+    $(if [ "$enable_workers" = true ]; then echo --enable-workers; fi) \
+    $(if [ "$skip_oidc" = true ]; then echo --skip-oidc; fi)
+  echo
+  echo "## Deployment Commands"
+  echo
+  go run ./linode_deploy/cmd/linode-deploy "${args[@]}"
+} | tee "$report"
+
+if [ "$execute" = false ]; then
+  cat <<'MSG'
+
+Dry-run only. Review the evidence report, confirm the Linode stack and backup
+marker, then rerun with --execute when ready.
+MSG
+  exit 0
+fi
+
+cat <<'MSG'
+
+Execution mode requested. This first account-manager Linode deploy artifact
+validates and records the ordered deployment plan. Infrastructure mutation and
+SSH installation should be executed by the operator following the generated
+report until the Linode API/SSH executor is wired for account-manager live ops.
+MSG

--- a/linode_deploy/templates/account-manager.env.tmpl
+++ b/linode_deploy/templates/account-manager.env.tmpl
@@ -1,0 +1,7 @@
+DATABASE_URL=postgres://rtk_account_manager:{{ACCOUNT_MANAGER_DB_PASSWORD}}@10.42.1.30:5432/rtk_account_manager?sslmode=disable
+JWT_ACCESS_SECRET={{JWT_ACCESS_SECRET}}
+JWT_REFRESH_SECRET={{JWT_REFRESH_SECRET}}
+PORT=18081
+AUTH_TOKEN_DELIVERY=log
+CROSS_SERVICE_BROKER=log
+OIDC_REDIRECT_URL=https://account-manager-staging.realtekconnect.com/v1/auth/oidc/keycloak/callback


### PR DESCRIPTION
## Summary
- Add an operator-run Linode deployment toolkit under `linode_deploy/` for Account Manager staging.
- Add the staging manifest, plan/deploy CLI, release bundle verification, secrets redaction, runtime env rendering, evidence report flow, and deployment runbook.
- Keep deployment script based; no GitHub CD Actions or CI-to-target SSH path is added.

## Testing
- `make test-linode-deploy`
- `go test ./...`
- `REPORT_FILE=docs/TEST_REPORT.md REPORT_GENERATED_AT=ci-candidate REPORT_CANONICAL=true make test-report`
- `git diff --check`
