### PR TITLE
[codex] Add account manager Linode public VM deploy path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ release:
 	cp -R deploy/systemd "dist/rtk_account_manager-$(VERSION)/deploy/systemd"
 	cp deploy/account-manager.env.example "dist/rtk_account_manager-$(VERSION)/deploy/account-manager.env.example"
 	cp deploy/install.sh deploy/verify.sh "dist/rtk_account_manager-$(VERSION)/deploy/"
+	find "dist/rtk_account_manager-$(VERSION)" -name '._*' -delete
 	{ \
 		echo "version=$(VERSION)"; \
 		echo "git_sha=$$(git rev-parse HEAD 2>/dev/null || echo unknown)"; \
@@ -61,7 +62,7 @@ release:
 		echo "module=$$(go list -m)"; \
 	} > "dist/rtk_account_manager-$(VERSION)/release-manifest.txt"
 	./deploy/check-release.sh "dist/rtk_account_manager-$(VERSION)"
-	tar -C dist -czf "dist/rtk_account_manager-$(VERSION).tar.gz" "rtk_account_manager-$(VERSION)"
+	COPYFILE_DISABLE=1 tar -C dist -czf "dist/rtk_account_manager-$(VERSION).tar.gz" "rtk_account_manager-$(VERSION)"
 
 check-release: release
 

--- a/linode_deploy/README.md
+++ b/linode_deploy/README.md
@@ -2,7 +2,71 @@
 
 Operator-local deployment assets for placing `rtk_account_manager` on Linode.
 
-GitHub CI remains artifact-only. Deployment is run by an admin through
-`scripts/deploy-staging.sh` with an explicit release version.
+GitHub CI remains artifact-only. Live Linode mutation, DNS updates, host
+installation, and secret handling are run by a trusted operator machine.
 
 See [`docs/RUNBOOK.md`](docs/RUNBOOK.md).
+
+## Deployment Modes
+
+| Mode | Entry Point | Purpose |
+| --- | --- | --- |
+| Manifest plan | `scripts/deploy-staging.sh` | Existing dry-run/planning evidence flow. |
+| Public VM live deploy | `scripts/provision-public-vm.sh`, `scripts/deploy-public-vm.sh` | Dedicated public-only Account Manager staging VM. |
+
+## Public VM Target Shape
+
+```text
+internet
+  -> account-manager.video-cloud-staging.realtekconnect.com:443
+  -> nginx on Account Manager VM
+  -> rtk_account_manager on 127.0.0.1:18081
+  -> local PostgreSQL on 127.0.0.1:5432
+```
+
+The Account Manager VM is independent from the `rtk_video_cloud` VPC. It does
+not join the Video Cloud private network and does not use the Video Cloud edge
+VM as a gateway. Other services should call it through public HTTPS.
+
+## Public VM Files
+
+| File | Purpose |
+| --- | --- |
+| `templates/account-manager-public-staging.env.example` | Local operator env template. Copy before editing. |
+| `scripts/provision-public-vm.sh` | Creates the public-only Linode VM and firewall through the Linode API. |
+| `scripts/set-godaddy-dns.sh` | Updates the staging DNS A record through the GoDaddy API. |
+| `scripts/deploy-public-vm.sh` | Builds a Linux release, installs PostgreSQL/nginx/certbot/systemd, applies migrations, and starts the service. |
+| `scripts/verify-public-vm.sh` | Runs external HTTPS health/register/login smoke checks. |
+| `scripts/backup-public-postgres.sh` | Pulls a sanitized PostgreSQL custom-format dump artifact. |
+
+## Public VM Quick Start
+
+```sh
+cp linode_deploy/templates/account-manager-public-staging.env.example \
+  linode_deploy/secrets/account-manager-public-staging.env
+$EDITOR linode_deploy/secrets/account-manager-public-staging.env
+
+set -a
+. ~/.env                         # LINODE_TOKEN, GODADDY_KEY, GODADDY_SECRET
+. linode_deploy/secrets/account-manager-public-staging.env
+set +a
+
+linode_deploy/scripts/provision-public-vm.sh
+. linode_deploy/state/rtk-account-manager-staging.env
+linode_deploy/scripts/set-godaddy-dns.sh
+linode_deploy/scripts/deploy-public-vm.sh
+linode_deploy/scripts/verify-public-vm.sh
+```
+
+Ignored state and artifacts stay under `linode_deploy/state/` and `.artifacts/`.
+Do not commit copied env files, state files, database dumps, or verification
+artifacts.
+
+## Security Notes
+
+- Remote hosts never push to GitHub.
+- The VM exposes only SSH from operator CIDRs and public HTTP/HTTPS.
+- PostgreSQL binds locally on the VM and is not exposed publicly.
+- Staging defaults use `AUTH_TOKEN_DELIVERY=log`, `CROSS_SERVICE_BROKER=log`,
+  and `OIDC_ENABLED=false`; production-like deployments must explicitly supply
+  SMTP/OIDC/broker settings and record those choices in service-owned docs.

--- a/linode_deploy/docs/RUNBOOK.md
+++ b/linode_deploy/docs/RUNBOOK.md
@@ -1,171 +1,98 @@
-# Account Manager Linode Deploy Runbook
+# Account Manager Linode Runbook
 
-This runbook defines the operator-local Linode deployment flow for
-`rtk_account_manager`. GitHub CI remains artifact-only. It must not SSH into
-Linode hosts or run deployment.
+This runbook covers the dedicated public VM staging profile for
+`rtk_account_manager`.
 
-## Topology
+## Source Of Truth
 
-Account Manager runs on a dedicated VPC-only VM in the existing video-cloud
-Linode staging stack:
+- Runtime API and service behavior: repo code and `openapi.yaml`.
+- Deployment scripts: `linode_deploy/scripts/`.
+- Operator secrets: ignored files under `linode_deploy/secrets/` and local shell
+  environment.
+- Deployment state: ignored files under `linode_deploy/state/`.
 
-| Role | Placement |
-| --- | --- |
-| `edge` | Existing public/VPC edge VM, terminates HTTPS. |
-| `infra` | Existing VPC-only infra VM, hosts PostgreSQL. |
-| `account-manager` | New VPC-only VM at `10.42.1.20`, API on `18081`. |
+## Prerequisites
 
-Public route:
+Operator machine:
 
-```text
-account-manager-staging.realtekconnect.com
-  -> edge nginx
-  -> 10.42.1.20:18081
-```
+- `curl`, `jq`, `openssl`, `go`, `ssh`, `scp`, `tar`
+- `LINODE_TOKEN` with Linode instance/firewall permissions
+- `GODADDY_KEY` and `GODADDY_SECRET` for `realtekconnect.com` DNS
+- an SSH key pair for the VM
+- operator public CIDR for SSH allowlisting
 
-Account Manager uses a separate Postgres database and role:
+Remote VM target:
 
-```text
-database: rtk_account_manager
-role:     rtk_account_manager
-```
+- Ubuntu 24.04
+- public IPv4 only
+- inbound `22/tcp` restricted to operator CIDRs
+- inbound `80/tcp` and `443/tcp` public for certbot and HTTPS
 
-Do not reuse the `video_cloud` database or database role.
+## Runtime Shape
 
-## Operator Secrets
+- service user: `rtk-account-manager`
+- install prefix: `/opt/rtk-account-manager`
+- env file: `/etc/rtk-account-manager/account-manager.env`
+- state dir: `/var/lib/rtk-account-manager`
+- API bind: `127.0.0.1:18081` behind nginx
+- PostgreSQL: local database `rtk_account_manager`
 
-Create a local ignored secrets file:
-
-```sh
-mkdir -p linode_deploy/secrets
-install -m 0600 /dev/null linode_deploy/secrets/account-manager-staging.env
-```
-
-Minimum keys:
+## Deploy
 
 ```sh
-ACCOUNT_MANAGER_DB_PASSWORD='<db-role-password>'
-JWT_ACCESS_SECRET='<access-token-secret>'
-JWT_REFRESH_SECRET='<refresh-token-secret>'
+set -a
+. ~/.env
+. linode_deploy/secrets/account-manager-public-staging.env
+set +a
+
+linode_deploy/scripts/provision-public-vm.sh
+. linode_deploy/state/rtk-account-manager-staging.env
+linode_deploy/scripts/set-godaddy-dns.sh
+linode_deploy/scripts/deploy-public-vm.sh
+linode_deploy/scripts/verify-public-vm.sh
 ```
 
-OIDC keys when SSO smoke is enabled:
+`deploy-public-vm.sh` builds a Linux/amd64 release from the checked-out commit,
+uploads it to the VM, installs OS dependencies, creates or updates the local
+PostgreSQL role/database, writes the environment file, runs migrations, starts
+the API service and cleanup timer, configures nginx, and obtains the Let's
+Encrypt certificate when enabled.
+
+## Verify
+
+The external verifier checks:
+
+- `GET /v1/health`
+- `POST /v1/auth/register`
+- `POST /v1/auth/login`
+- `GET /v1/me` with the issued bearer token
+
+Verification artifacts are written under `.artifacts/linode-account-manager-verify/`
+and must remain untracked.
+
+## Backup
 
 ```sh
-OIDC_ISSUER_URL='https://<keycloak>/realms/<realm>'
-OIDC_CLIENT_ID='rtk-account-manager'
-OIDC_CLIENT_SECRET='<oidc-client-secret>'
+set -a
+. linode_deploy/secrets/account-manager-public-staging.env
+. linode_deploy/state/rtk-account-manager-staging.env
+set +a
+
+linode_deploy/scripts/backup-public-postgres.sh
 ```
 
-Optional keys:
+The backup script creates a PostgreSQL custom-format dump and a checksum under
+`.artifacts/linode-account-manager-backups/`. Raw dumps are not committed.
 
-```sh
-SMTP_HOST=
-SMTP_USERNAME=
-SMTP_PASSWORD=
-SMTP_FROM=
-AZURE_EVENTHUB_CONNECTION_STRING=
-```
+## Staging Limitations
 
-Secrets must stay out of git, issue comments, generated reports, and shell
-history where possible.
+The default public VM profile is appropriate for staging smoke and admin
+integration:
 
-## Plan
+- `AUTH_TOKEN_DELIVERY=log`
+- `CROSS_SERVICE_BROKER=log`
+- `OIDC_ENABLED=false`
+- SMTP optional and usually unset
 
-Review the manifest:
-
-```sh
-go run ./linode_deploy/cmd/linode-deploy plan \
-  --config linode_deploy/configs/account-manager-staging.yaml
-```
-
-The plan must show:
-
-- Account Manager VM `account-manager-staging-account-manager` at `10.42.1.20`
-- edge route for `account-manager-staging.realtekconnect.com`
-- edge -> account-manager `18081/tcp`
-- account-manager -> infra `5432/tcp`
-- DB migration gate before runtime restart
-- workers disabled by default
-
-## Deploy Script
-
-Run a dry-run first:
-
-```sh
-linode_deploy/scripts/deploy-staging.sh \
-  --release vX.Y.Z \
-  --stack account-manager-staging \
-  --config linode_deploy/configs/account-manager-staging.yaml \
-  --secrets-file linode_deploy/secrets/account-manager-staging.env \
-  --report .artifacts/account-manager-linode-deploy.md
-```
-
-Use a local bundle only for debug:
-
-```sh
-linode_deploy/scripts/deploy-staging.sh \
-  --release vX.Y.Z \
-  --release-bundle dist/rtk_account_manager-vX.Y.Z.tar.gz
-```
-
-The script refuses `latest`. Operators must choose an explicit release.
-
-## Live Execution Notes
-
-The current deploy artifact validates and records the ordered Linode deployment
-plan. The operator performs live Linode/API/SSH mutation using the generated
-report until a dedicated Account Manager Linode executor is wired.
-
-Live steps from the report:
-
-1. Confirm `10.42.1.20` is unused.
-2. Create or update the `account-manager` VPC-only VM.
-3. Update Linode firewall rules for edge, infra, and account-manager.
-4. Add the edge nginx vhost for `account-manager-staging.realtekconnect.com`.
-5. Create/verify `rtk_account_manager` Postgres role and database on infra.
-6. Install the release under `/opt/rtk-account-manager`.
-7. Write `/etc/rtk-account-manager/account-manager.env` with mode `0600`.
-8. Confirm DB backup marker at `/var/lib/rtk-account-manager/last-db-backup-ok`.
-9. Run `rtk-account-manager-migrate.service`.
-10. Restart API and cleanup timer.
-11. Start outbox/inbox workers only when explicitly enabled.
-12. Run health and smoke checks.
-
-## Runtime Defaults
-
-```sh
-DATABASE_URL='postgres://rtk_account_manager:<secret>@10.42.1.30:5432/rtk_account_manager?sslmode=disable'
-PORT=18081
-AUTH_TOKEN_DELIVERY=log
-CROSS_SERVICE_BROKER=log
-OIDC_REDIRECT_URL='https://account-manager-staging.realtekconnect.com/v1/auth/oidc/keycloak/callback'
-```
-
-## Verification
-
-Private VM health:
-
-```sh
-curl -fsS http://127.0.0.1:18081/v1/health
-```
-
-Edge/public health:
-
-```sh
-curl -fsS https://account-manager-staging.realtekconnect.com/v1/health
-```
-
-Optional smoke checks:
-
-- login with existing smoke user
-- read smoke organization
-- read smoke device
-- read provisioning state
-- OIDC provider discovery when OIDC is enabled
-
-## Evidence
-
-The report must include release, manifest digest, planned service changes,
-health/smoke status, and redacted env inventory. It must not include DSNs,
-JWT secrets, OIDC secrets, SMTP passwords, broker credentials, or raw tokens.
+Production-like identity, notification, and cross-service lifecycle testing must
+set SMTP/OIDC/broker configuration explicitly before deployment.

--- a/linode_deploy/scripts/backup-public-postgres.sh
+++ b/linode_deploy/scripts/backup-public-postgres.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${ACCOUNT_MANAGER_LINODE_HOST:-${ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4:-}}"
+ssh_user="${ACCOUNT_MANAGER_LINODE_SSH_USER:-root}"
+ssh_key="${ACCOUNT_MANAGER_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"
+db_name="${ACCOUNT_MANAGER_POSTGRES_DB:-rtk_account_manager}"
+backup_dir="${ACCOUNT_MANAGER_LINODE_BACKUP_DIR:-.artifacts/linode-account-manager-backups}"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+remote_archive="/tmp/rtk-account-manager-db-$stamp.dump"
+local_archive="$backup_dir/rtk-account-manager-db-$stamp.dump"
+
+[ -n "$host" ] || { echo "ACCOUNT_MANAGER_LINODE_HOST or ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4 is required" >&2; exit 1; }
+[ -s "$ssh_key" ] || { echo "SSH key not found: $ssh_key" >&2; exit 1; }
+mkdir -p "$backup_dir"
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+remote="$ssh_user@$host"
+
+ssh "${ssh_opts[@]}" "$remote" "sudo -u postgres pg_dump -Fc '$db_name' > '$remote_archive'"
+scp "${ssh_opts[@]}" "$remote:$remote_archive" "$local_archive"
+ssh "${ssh_opts[@]}" "$remote" "rm -f '$remote_archive'"
+sha256sum "$local_archive" > "$local_archive.sha256"
+printf 'Backup written: %s\n' "$local_archive"

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+label="${ACCOUNT_MANAGER_LINODE_LABEL:-rtk-account-manager-staging}"
+release="${ACCOUNT_MANAGER_LINODE_RELEASE:-$(git -C "$root_dir" rev-parse --short HEAD)}"
+domain="${ACCOUNT_MANAGER_LINODE_DOMAIN:-account-manager.video-cloud-staging.realtekconnect.com}"
+certbot_email="${ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL:-}"
+ssh_user="${ACCOUNT_MANAGER_LINODE_SSH_USER:-root}"
+ssh_key="${ACCOUNT_MANAGER_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"
+host="${ACCOUNT_MANAGER_LINODE_HOST:-${ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4:-}}"
+remote_bundle="${ACCOUNT_MANAGER_LINODE_REMOTE_BUNDLE:-/tmp/rtk-account-manager-${release}.tar.gz}"
+artifact_dir="${ACCOUNT_MANAGER_LINODE_ARTIFACT_DIR:-$root_dir/.artifacts/linode-account-manager-deploy/$release}"
+bundle="$artifact_dir/rtk_account_manager-${release}.tar.gz"
+certbot_enable="${ACCOUNT_MANAGER_LINODE_CERTBOT_ENABLE:-1}"
+http_only="${ACCOUNT_MANAGER_LINODE_HTTP_ONLY:-0}"
+port="${ACCOUNT_MANAGER_PORT:-18081}"
+db_name="${ACCOUNT_MANAGER_POSTGRES_DB:-rtk_account_manager}"
+db_user="${ACCOUNT_MANAGER_POSTGRES_USER:-rtk_account_manager}"
+db_password="${ACCOUNT_MANAGER_POSTGRES_PASSWORD:-}"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required"; }
+write_env() {
+  local key="$1"
+  local value="${!key:-}"
+  if printf '%s' "$value" | grep -q '[[:cntrl:]]'; then die "$key contains control characters"; fi
+  printf '%s=%s\n' "$key" "$value"
+}
+
+need ssh
+need scp
+need go
+need tar
+need openssl
+[ -n "$host" ] || die "ACCOUNT_MANAGER_LINODE_HOST or ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4 is required"
+[ -s "$ssh_key" ] || die "SSH key not found: $ssh_key"
+[ -n "$certbot_email" ] || [ "$certbot_enable" = 0 ] || die "ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL is required when certbot is enabled"
+[ -n "${JWT_ACCESS_SECRET:-}" ] || die "JWT_ACCESS_SECRET is required"
+[ -n "${JWT_REFRESH_SECRET:-}" ] || die "JWT_REFRESH_SECRET is required"
+if [ -z "$db_password" ]; then
+  db_password="$(openssl rand -hex 32)"
+  printf '[account-manager-deploy] generated local PostgreSQL password for this deploy\n' >&2
+fi
+
+database_url="postgres://${db_user}:${db_password}@127.0.0.1:5432/${db_name}?sslmode=disable"
+mkdir -p "$artifact_dir"
+
+printf '[account-manager-deploy] building Linux release %s\n' "$release" >&2
+(
+  cd "$root_dir"
+  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 VERSION="$release" make release >/dev/null
+)
+cp "$root_dir/dist/rtk_account_manager-${release}.tar.gz" "$bundle"
+
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+remote="$ssh_user@$host"
+
+tmp_env="$(mktemp)"
+cleanup() { rm -f "$tmp_env"; }
+trap cleanup EXIT
+{
+  printf 'DATABASE_URL=%s\n' "$database_url"
+  write_env JWT_ACCESS_SECRET
+  write_env JWT_REFRESH_SECRET
+  printf 'PORT=%s\n' "$port"
+  printf 'ACCESS_TOKEN_TTL=%s\n' "${ACCESS_TOKEN_TTL:-15m}"
+  printf 'REFRESH_TOKEN_TTL=%s\n' "${REFRESH_TOKEN_TTL:-720h}"
+  printf 'AUTH_TOKEN_DELIVERY=%s\n' "${AUTH_TOKEN_DELIVERY:-log}"
+  printf 'EMAIL_VERIFICATION_TTL=%s\n' "${EMAIL_VERIFICATION_TTL:-30m}"
+  printf 'PASSWORD_RESET_TTL=%s\n' "${PASSWORD_RESET_TTL:-30m}"
+  printf 'OTP_RESEND_INTERVAL=%s\n' "${OTP_RESEND_INTERVAL:-60s}"
+  printf 'OTP_MAX_ATTEMPTS=%s\n' "${OTP_MAX_ATTEMPTS:-5}"
+  printf 'SIGNUP_CAPTCHA_REQUIRED=%s\n' "${SIGNUP_CAPTCHA_REQUIRED:-false}"
+  printf 'SIGNUP_DISPOSABLE_DOMAINS=%s\n' "${SIGNUP_DISPOSABLE_DOMAINS:-}"
+  printf 'SMTP_HOST=%s\n' "${SMTP_HOST:-}"
+  printf 'SMTP_PORT=%s\n' "${SMTP_PORT:-587}"
+  printf 'SMTP_USERNAME=%s\n' "${SMTP_USERNAME:-}"
+  printf 'SMTP_PASSWORD=%s\n' "${SMTP_PASSWORD:-}"
+  printf 'SMTP_FROM=%s\n' "${SMTP_FROM:-}"
+  printf 'OIDC_ENABLED=%s\n' "${OIDC_ENABLED:-false}"
+  printf 'OIDC_PROVIDER_ID=%s\n' "${OIDC_PROVIDER_ID:-keycloak}"
+  printf 'OIDC_PROVIDER_NAME=%s\n' "${OIDC_PROVIDER_NAME:-Keycloak}"
+  printf 'OIDC_ISSUER_URL=%s\n' "${OIDC_ISSUER_URL:-}"
+  printf 'OIDC_CLIENT_ID=%s\n' "${OIDC_CLIENT_ID:-}"
+  printf 'OIDC_CLIENT_SECRET=%s\n' "${OIDC_CLIENT_SECRET:-}"
+  printf 'OIDC_REDIRECT_URL=%s\n' "${OIDC_REDIRECT_URL:-}"
+  printf 'OIDC_SCOPES=%s\n' "${OIDC_SCOPES:-openid email profile}"
+  printf 'OIDC_AUTO_LINK_EMAIL=%s\n' "${OIDC_AUTO_LINK_EMAIL:-false}"
+  printf 'CROSS_SERVICE_BROKER=%s\n' "${CROSS_SERVICE_BROKER:-log}"
+  printf 'ACCOUNT_VIDEO_COMMANDS_STREAM=%s\n' "${ACCOUNT_VIDEO_COMMANDS_STREAM:-account.video.commands}"
+  printf 'VIDEO_ACCOUNT_EVENTS_STREAM=%s\n' "${VIDEO_ACCOUNT_EVENTS_STREAM:-video.account.events}"
+  printf 'CROSS_SERVICE_CONSUMER_GROUP=%s\n' "${CROSS_SERVICE_CONSUMER_GROUP:-rtk_account_manager}"
+  printf 'CROSS_SERVICE_MAX_ATTEMPTS=%s\n' "${CROSS_SERVICE_MAX_ATTEMPTS:-5}"
+  printf 'CROSS_SERVICE_POLL_INTERVAL=%s\n' "${CROSS_SERVICE_POLL_INTERVAL:-5s}"
+  printf 'AZURE_EVENTHUB_CONNECTION_STRING=%s\n' "${AZURE_EVENTHUB_CONNECTION_STRING:-}"
+  printf 'AZURE_EVENTHUB_CHECKPOINT_FILE=%s\n' "${AZURE_EVENTHUB_CHECKPOINT_FILE:-/var/lib/rtk-account-manager/azure_eventhubs_checkpoint.json}"
+} > "$tmp_env"
+chmod 0600 "$tmp_env"
+
+printf '[account-manager-deploy] uploading release bundle to %s\n' "$remote" >&2
+ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy"
+scp "${ssh_opts[@]}" "$bundle" "$remote:$remote_bundle"
+scp "${ssh_opts[@]}" "$tmp_env" "$remote:/tmp/rtk-account-manager-deploy/account-manager.env"
+
+printf '[account-manager-deploy] installing runtime on %s\n' "$remote" >&2
+ssh "${ssh_opts[@]}" "$remote" bash -s -- "$remote_bundle" "$release" "$domain" "$certbot_email" "$certbot_enable" "$http_only" "$port" "$db_name" "$db_user" "$db_password" <<'REMOTE'
+set -euo pipefail
+remote_bundle="$1"
+release="$2"
+domain="$3"
+certbot_email="$4"
+certbot_enable="$5"
+http_only="$6"
+port="$7"
+db_name="$8"
+db_user="$9"
+db_password="${10}"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y ca-certificates curl nginx certbot python3-certbot-nginx postgresql postgresql-contrib systemd tar
+systemctl enable --now postgresql nginx
+
+sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$db_user') THEN
+    CREATE ROLE "$db_user" LOGIN PASSWORD '$db_password';
+  ELSE
+    ALTER ROLE "$db_user" WITH PASSWORD '$db_password';
+  END IF;
+END
+\$\$;
+SELECT 'CREATE DATABASE "$db_name" OWNER "$db_user"'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$db_name')\gexec
+SQL
+
+rm -rf /tmp/rtk-account-manager-release
+mkdir -p /tmp/rtk-account-manager-release
+tar -xzf "$remote_bundle" -C /tmp/rtk-account-manager-release --strip-components=1
+cp /tmp/rtk-account-manager-deploy/account-manager.env /tmp/rtk-account-manager-release/deploy/account-manager.env.example
+(cd /tmp/rtk-account-manager-release && ./deploy/install.sh)
+install -m 0600 -o root -g root /tmp/rtk-account-manager-deploy/account-manager.env /etc/rtk-account-manager/account-manager.env
+
+systemctl daemon-reload
+systemctl start rtk-account-manager-migrate.service
+systemctl enable --now rtk-account-manager-cleanup-tokens.timer
+systemctl enable --now rtk-account-manager.service
+systemctl restart rtk-account-manager.service
+
+cat > /etc/nginx/sites-available/rtk-account-manager.conf <<NGINX
+server {
+    listen 80;
+    server_name $domain;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://127.0.0.1:$port;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+NGINX
+ln -sf /etc/nginx/sites-available/rtk-account-manager.conf /etc/nginx/sites-enabled/rtk-account-manager.conf
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl reload nginx
+
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:$port/v1/health" >/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "${ready:-0}" != "1" ]; then
+  journalctl -u rtk-account-manager -n 160 --no-pager >&2 || true
+  exit 1
+fi
+
+if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+  certbot --nginx --non-interactive --agree-tos --email "$certbot_email" -d "$domain" --redirect
+fi
+
+systemctl is-active rtk-account-manager.service
+systemctl is-active nginx
+printf 'rtk_account_manager %s deployed for %s\n' "$release" "$domain"
+REMOTE
+
+printf '[account-manager-deploy] deployed %s to %s\n' "$release" "$domain" >&2

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -119,7 +119,25 @@ db_password="${10}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y ca-certificates curl nginx certbot python3-certbot-nginx postgresql postgresql-contrib systemd tar
+apt-get install -y ca-certificates curl gnupg2 lsb-release ubuntu-keyring postgresql postgresql-contrib systemd tar
+curl -fsS https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg.tmp
+mv /usr/share/keyrings/nginx-archive-keyring.gpg.tmp /usr/share/keyrings/nginx-archive-keyring.gpg
+printf 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu %s nginx\n' "$(lsb_release -cs)" > /etc/apt/sources.list.d/nginx-org.list
+cat > /etc/apt/preferences.d/99nginx <<'PREF'
+Package: *
+Pin: origin nginx.org
+Pin-Priority: 900
+PREF
+apt-get update -y
+nginx_candidate="$(apt-cache policy nginx | awk '/Candidate:/ {print $2}')"
+dpkg --compare-versions "$nginx_candidate" ge 1.30.0
+apt-get install -y -o Dpkg::Options::=--force-confold nginx certbot python3-certbot-nginx
+if ! grep -q 'server_names_hash_bucket_size' /etc/nginx/nginx.conf; then
+  sed -i '/http {/a\    server_names_hash_bucket_size 128;' /etc/nginx/nginx.conf
+fi
+if [ -d /etc/nginx/sites-enabled ] && ! grep -q 'sites-enabled' /etc/nginx/nginx.conf && [ ! -f /etc/nginx/conf.d/rtk-sites-enabled.conf ]; then
+  printf 'include /etc/nginx/sites-enabled/*;\n' > /etc/nginx/conf.d/rtk-sites-enabled.conf
+fi
 systemctl enable --now postgresql nginx
 
 sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL

--- a/linode_deploy/scripts/provision-public-vm.sh
+++ b/linode_deploy/scripts/provision-public-vm.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+label="${ACCOUNT_MANAGER_LINODE_LABEL:-rtk-account-manager-staging}"
+region="${ACCOUNT_MANAGER_LINODE_REGION:-us-sea}"
+type="${ACCOUNT_MANAGER_LINODE_TYPE:-g6-standard-2}"
+image="${ACCOUNT_MANAGER_LINODE_IMAGE:-linode/ubuntu24.04}"
+public_key_path="${ACCOUNT_MANAGER_LINODE_PUBLIC_KEY_PATH:-$HOME/.ssh/id_ed25519_rtkcloud.pub}"
+allowed_ssh_cidrs="${ACCOUNT_MANAGER_LINODE_ALLOWED_SSH_CIDRS:-}"
+firewall_label="${ACCOUNT_MANAGER_LINODE_FIREWALL_LABEL:-${label}-fw}"
+state_path="${ACCOUNT_MANAGER_LINODE_STATE_PATH:-linode_deploy/state/${label}.env}"
+api_base="${LINODE_API_BASE:-https://api.linode.com/v4}"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required"; }
+api() {
+  local method="$1" path="$2" data="${3:-}"
+  if [ -n "$data" ]; then
+    curl -fsS -X "$method" "$api_base$path" \
+      -H "Authorization: Bearer $LINODE_TOKEN" \
+      -H 'Content-Type: application/json' \
+      --data-binary "$data"
+  else
+    curl -fsS -X "$method" "$api_base$path" \
+      -H "Authorization: Bearer $LINODE_TOKEN" \
+      -H 'Content-Type: application/json'
+  fi
+}
+
+need curl
+need jq
+need openssl
+[ -n "${LINODE_TOKEN:-}" ] || die "LINODE_TOKEN is required"
+[ -s "$public_key_path" ] || die "public key not found: $public_key_path"
+[ -n "$allowed_ssh_cidrs" ] || die "ACCOUNT_MANAGER_LINODE_ALLOWED_SSH_CIDRS must be set"
+
+if api GET "/linode/instances?page_size=500" | jq -e --arg label "$label" '.data[] | select(.label == $label)' >/dev/null; then
+  die "Linode label already exists: $label"
+fi
+if api GET "/networking/firewalls?page_size=500" | jq -e --arg label "$firewall_label" '.data[] | select(.label == $label)' >/dev/null; then
+  die "Firewall label already exists: $firewall_label"
+fi
+
+root_pass="$(openssl rand -base64 36)"
+ssh_key="$(cat "$public_key_path")"
+create_payload="$(jq -cn \
+  --arg label "$label" \
+  --arg region "$region" \
+  --arg type "$type" \
+  --arg image "$image" \
+  --arg root_pass "$root_pass" \
+  --arg ssh_key "$ssh_key" \
+  '{label:$label, region:$region, type:$type, image:$image, root_pass:$root_pass, authorized_keys:[$ssh_key], tags:["rtk-account-manager","account-manager-staging"]}')"
+
+printf '[account-manager-linode] creating public-only Linode %s in %s\n' "$label" "$region" >&2
+create_json="$(api POST /linode/instances "$create_payload")"
+linode_id="$(printf '%s' "$create_json" | jq -r '.id')"
+public_ipv4="$(printf '%s' "$create_json" | jq -r '.ipv4[0]')"
+[ -n "$linode_id" ] && [ "$linode_id" != null ] || die "failed to read Linode id"
+[ -n "$public_ipv4" ] && [ "$public_ipv4" != null ] || die "failed to read Linode public IPv4"
+
+firewall_payload="$(jq -cn --arg label "$firewall_label" --arg cidrs "$allowed_ssh_cidrs" '{
+  label: $label,
+  rules: {
+    inbound_policy: "DROP",
+    outbound_policy: "ACCEPT",
+    inbound: [
+      {label:"ssh", action:"ACCEPT", protocol:"TCP", ports:"22", addresses:{ipv4:($cidrs|split(","))}},
+      {label:"http", action:"ACCEPT", protocol:"TCP", ports:"80", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
+      {label:"https", action:"ACCEPT", protocol:"TCP", ports:"443", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}}
+    ],
+    outbound: []
+  }
+}')"
+
+printf '[account-manager-linode] creating firewall %s\n' "$firewall_label" >&2
+firewall_json="$(api POST /networking/firewalls "$firewall_payload")"
+firewall_id="$(printf '%s' "$firewall_json" | jq -r '.id')"
+[ -n "$firewall_id" ] && [ "$firewall_id" != null ] || die "failed to read firewall id"
+api POST "/networking/firewalls/$firewall_id/devices" "$(jq -cn --argjson id "$linode_id" '{id:$id,type:"linode"}')" >/dev/null
+
+mkdir -p "$(dirname "$state_path")"
+cat > "$state_path" <<STATE
+ACCOUNT_MANAGER_LINODE_ID=$linode_id
+ACCOUNT_MANAGER_LINODE_LABEL=$label
+ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4=$public_ipv4
+ACCOUNT_MANAGER_LINODE_HOST=$public_ipv4
+ACCOUNT_MANAGER_LINODE_FIREWALL_ID=$firewall_id
+ACCOUNT_MANAGER_LINODE_FIREWALL_LABEL=$firewall_label
+STATE
+chmod 0600 "$state_path"
+
+cat <<EOF_OUT
+Linode created.
+
+State file: $state_path
+Public IPv4: $public_ipv4
+
+Next DNS step:
+  ACCOUNT_MANAGER_LINODE_DOMAIN=${ACCOUNT_MANAGER_LINODE_DOMAIN:-account-manager.video-cloud-staging.realtekconnect.com} \\
+  ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4=$public_ipv4 \\
+  linode_deploy/scripts/set-godaddy-dns.sh
+EOF_OUT

--- a/linode_deploy/scripts/set-godaddy-dns.sh
+++ b/linode_deploy/scripts/set-godaddy-dns.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+domain="${ACCOUNT_MANAGER_LINODE_DOMAIN:-account-manager.video-cloud-staging.realtekconnect.com}"
+root_domain="${GODADDY_ROOT_DOMAIN:-realtekconnect.com}"
+ipv4="${ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4:-${ACCOUNT_MANAGER_LINODE_HOST:-}}"
+ttl="${GODADDY_RECORD_TTL:-600}"
+api_base="${GODADDY_API_BASE:-https://api.godaddy.com/v1}"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required"; }
+need curl
+need jq
+[ -n "${GODADDY_KEY:-}" ] || die "GODADDY_KEY is required"
+[ -n "${GODADDY_SECRET:-}" ] || die "GODADDY_SECRET is required"
+[ -n "$ipv4" ] || die "ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4 or ACCOUNT_MANAGER_LINODE_HOST is required"
+
+if [ "$domain" = "$root_domain" ]; then
+  record_name="@"
+else
+  record_name="${domain%.$root_domain}"
+  [ "$record_name" != "$domain" ] || die "domain $domain is not under root domain $root_domain"
+fi
+payload="$(jq -cn --arg data "$ipv4" --argjson ttl "$ttl" '[{data:$data, ttl:$ttl}]')"
+
+curl -fsS -X PUT "$api_base/domains/$root_domain/records/A/$record_name" \
+  -H "Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET" \
+  -H 'Content-Type: application/json' \
+  --data-binary "$payload" >/dev/null
+
+printf 'Updated DNS: %s A %s\n' "$domain" "$ipv4"

--- a/linode_deploy/scripts/verify-public-vm.sh
+++ b/linode_deploy/scripts/verify-public-vm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+domain="${ACCOUNT_MANAGER_LINODE_DOMAIN:-account-manager.video-cloud-staging.realtekconnect.com}"
+base_url="${ACCOUNT_MANAGER_BASE_URL:-}"
+if [ -z "$base_url" ]; then
+  if [ "${ACCOUNT_MANAGER_LINODE_HTTP_ONLY:-0}" = 1 ]; then
+    base_url="http://$domain"
+  else
+    base_url="https://$domain"
+  fi
+fi
+artifacts_dir="${ACCOUNT_MANAGER_LINODE_VERIFY_ARTIFACTS:-.artifacts/linode-account-manager-verify}"
+email="${ACCOUNT_MANAGER_VERIFY_EMAIL:-verify+$(date -u +%Y%m%d%H%M%S)@example.invalid}"
+password="${ACCOUNT_MANAGER_VERIFY_PASSWORD:-Verify-$(openssl rand -hex 12)aA1!}"
+org="${ACCOUNT_MANAGER_VERIFY_ORG:-RTK Account Manager Linode Verify}"
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "openssl is required" >&2; exit 1; }
+mkdir -p "$artifacts_dir"
+
+record() { printf '%s\n' "$1" | tee -a "$artifacts_dir/checks.txt" >/dev/null; }
+
+curl -fsS "$base_url/v1/health" > "$artifacts_dir/health.json"
+record "PASS health"
+
+register_body="$(mktemp)"
+trap 'rm -f "$register_body"' EXIT
+jq -cn --arg email "$email" --arg password "$password" --arg org "$org" '{email:$email,password:$password,organization_name:$org}' > "$register_body"
+status="$(curl -sS -o "$artifacts_dir/register.json" -w '%{http_code}' -H 'content-type: application/json' --data-binary "@$register_body" "$base_url/v1/auth/register")"
+if [ "$status" != 201 ] && [ "$status" != 409 ]; then
+  printf 'register returned HTTP %s\n' "$status" >&2
+  cat "$artifacts_dir/register.json" >&2
+  exit 1
+fi
+record "PASS register endpoint http_$status"
+
+login_body="$(mktemp)"
+trap 'rm -f "$register_body" "$login_body"' EXIT
+jq -cn --arg email "$email" --arg password "$password" '{email:$email,password:$password}' > "$login_body"
+status="$(curl -sS -o "$artifacts_dir/login.json" -w '%{http_code}' -H 'content-type: application/json' --data-binary "@$login_body" "$base_url/v1/auth/login")"
+if [ "$status" = 200 ]; then
+  token="$(jq -r '.tokens.access_token // .access_token // .accessToken // empty' "$artifacts_dir/login.json")"
+  [ -n "$token" ] || { echo "login response did not include an access token" >&2; exit 1; }
+  curl -fsS -H "authorization: Bearer $token" "$base_url/v1/me" > "$artifacts_dir/me.json"
+  record "PASS login and me"
+else
+  printf 'login returned HTTP %s\n' "$status" >&2
+  cat "$artifacts_dir/login.json" >&2
+  exit 1
+fi
+
+printf 'Account Manager verify passed: %s\nArtifacts: %s\n' "$base_url" "$artifacts_dir"

--- a/linode_deploy/templates/account-manager-public-staging.env.example
+++ b/linode_deploy/templates/account-manager-public-staging.env.example
@@ -1,0 +1,28 @@
+# Copy to linode_deploy/secrets/account-manager-public-staging.env before live deploy.
+# Do not commit the copied file. Source ~/.env separately for LINODE_TOKEN and GoDaddy credentials.
+
+ACCOUNT_MANAGER_LINODE_LABEL=rtk-account-manager-staging
+ACCOUNT_MANAGER_LINODE_REGION=us-sea
+ACCOUNT_MANAGER_LINODE_TYPE=g6-standard-2
+ACCOUNT_MANAGER_LINODE_IMAGE=linode/ubuntu24.04
+ACCOUNT_MANAGER_LINODE_DOMAIN=account-manager.video-cloud-staging.realtekconnect.com
+ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL=admin@example.com
+ACCOUNT_MANAGER_LINODE_SSH_USER=root
+ACCOUNT_MANAGER_LINODE_SSH_KEY=$HOME/.ssh/id_ed25519_rtkcloud
+ACCOUNT_MANAGER_LINODE_PUBLIC_KEY_PATH=$HOME/.ssh/id_ed25519_rtkcloud.pub
+ACCOUNT_MANAGER_LINODE_ALLOWED_SSH_CIDRS=203.0.113.10/32
+ACCOUNT_MANAGER_LINODE_CERTBOT_ENABLE=1
+ACCOUNT_MANAGER_LINODE_HTTP_ONLY=0
+
+# Runtime secrets. Generate with openssl rand -hex 32.
+JWT_ACCESS_SECRET=replace-me
+JWT_REFRESH_SECRET=replace-me
+ACCOUNT_MANAGER_POSTGRES_PASSWORD=replace-me
+
+# Staging defaults.
+ACCOUNT_MANAGER_PORT=18081
+AUTH_TOKEN_DELIVERY=log
+CROSS_SERVICE_BROKER=log
+OIDC_ENABLED=false
+SMTP_HOST=
+SMTP_FROM=


### PR DESCRIPTION
## Summary

Adds operator-local Linode public VM deployment support for account manager staging.

## What changed

- Adds public VM provision/deploy/verify/backup scripts under `linode_deploy/scripts/`.
- Adds GoDaddy DNS helper and public staging env example.
- Updates the Linode deployment README/runbook for the public VM flow.
- Strips macOS AppleDouble files from release packaging.
- Uses nginx.org 1.30 packages for the Linode deploy path.

## Validation

- `go test ./...`
- `bash -n linode_deploy/scripts/*.sh`
- `git diff --check`

## Notes

This PR only adds deployment automation and docs; it does not deploy live infrastructure by itself.
