### PR TITLE
Publish release bundles to Linode Object Storage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,60 @@ jobs:
               exit 1
               ;;
           esac
+          artifact_name="rtk_account_manager"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'artifact_name=%s\n' "$artifact_name" >> "$GITHUB_OUTPUT"
 
       - name: Build release bundle
         run: VERSION="${{ steps.version.outputs.version }}" make release
+
+      - name: Prepare Linode Object Storage release objects
+        id: object
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ARTIFACT_NAME: ${{ steps.version.outputs.artifact_name }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          RELEASE_ASSET: dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
+          OUTPUT_DIR: dist
+        run: |
+          ./scripts/prepare-linode-release-objects.sh | tee .artifacts-release-objects.env
+          while IFS= read -r line; do
+            case "$line" in
+              object_bundle=*|checksum_file=*|manifest_file=*|artifact_path=*|sha256=*)
+                printf '%s\n' "$line" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          done < .artifacts-release-objects.env
+
+      - name: Upload release objects to Linode Object Storage
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-sea
+          AWS_EC2_METADATA_DISABLED: "true"
+          LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
+          LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
+          VERSION: ${{ steps.version.outputs.version }}
+          ARTIFACT_NAME: ${{ steps.version.outputs.artifact_name }}
+          OBJECT_BUNDLE: ${{ steps.object.outputs.object_bundle }}
+          CHECKSUM_FILE: ${{ steps.object.outputs.checksum_file }}
+          MANIFEST_FILE: ${{ steps.object.outputs.manifest_file }}
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$LINODE_OBJ_BUCKET"
+          test -n "$LINODE_OBJ_ENDPOINT"
+          prefix="releases/$ARTIFACT_NAME-$VERSION"
+          aws s3 cp "$OBJECT_BUNDLE" "s3://$LINODE_OBJ_BUCKET/$prefix/$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$CHECKSUM_FILE" "s3://$LINODE_OBJ_BUCKET/$prefix/$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$MANIFEST_FILE" "s3://$LINODE_OBJ_BUCKET/$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
 
       - name: Generate release test report candidate
         shell: bash
@@ -58,6 +108,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           SOURCE_COMMIT: ${{ github.sha }}
           RELEASE_ASSET: dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
+          OBJECT_STORAGE_BUNDLE_KEY: releases/${{ steps.version.outputs.artifact_name }}-${{ steps.version.outputs.version }}/${{ steps.version.outputs.version }}.tar.gz
+          OBJECT_STORAGE_CHECKSUM_KEY: releases/${{ steps.version.outputs.artifact_name }}-${{ steps.version.outputs.version }}/${{ steps.version.outputs.version }}.tar.gz.sha256
+          OBJECT_STORAGE_MANIFEST_KEY: releases/${{ steps.version.outputs.artifact_name }}-${{ steps.version.outputs.version }}/manifest.json
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           contracts_commit="$(git ls-tree HEAD contracts 2>/dev/null | awk '{print $3}' || true)"
@@ -72,6 +125,9 @@ jobs:
           path: |
             dist/rtk_account_manager-${{ steps.version.outputs.version }}
             dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
+            dist/${{ steps.version.outputs.version }}.tar.gz
+            dist/${{ steps.version.outputs.version }}.tar.gz.sha256
+            dist/manifest.json
           if-no-files-found: error
 
       - name: Upload release test report candidate

--- a/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
+++ b/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
@@ -112,8 +112,42 @@ Build an immutable release bundle with:
 VERSION=v0.1.0 make release
 ```
 
-This writes `dist/rtk_account_manager-$VERSION.tar.gz`. GitHub Actions
-publishes the same tarball through `.github/workflows/release.yml`.
+This writes `dist/rtk_account_manager-$VERSION.tar.gz`. The release workflow
+also publishes formal release objects to Linode Object Storage using the
+workspace artifact governance shape:
+
+```text
+releases/rtk_account_manager-$VERSION/$VERSION.tar.gz
+releases/rtk_account_manager-$VERSION/$VERSION.tar.gz.sha256
+releases/rtk_account_manager-$VERSION/manifest.json
+```
+
+GitHub Actions artifacts and GitHub Releases are debug/mirror surfaces. Linode
+Object Storage is the durable release store.
+
+Developer self-check with the AWS CLI as an S3-compatible client for Linode
+Object Storage:
+
+```sh
+aws s3 ls "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+
+mkdir -p ".artifacts/release-download/$VERSION"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/$VERSION.tar.gz" \
+  ".artifacts/release-download/$VERSION/$VERSION.tar.gz" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/$VERSION.tar.gz.sha256" \
+  ".artifacts/release-download/$VERSION/$VERSION.tar.gz.sha256" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/manifest.json" \
+  ".artifacts/release-download/$VERSION/manifest.json" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+
+scripts/verify-linode-release-objects.sh "$VERSION" ".artifacts/release-download/$VERSION"
+```
+
+The verifier checks manifest fields, checksum consistency, and the repo-owned
+`deploy/check-release.sh` bundle contract.
 
 ## Staging CD On `video-cloud-cd.local`
 

--- a/linode_deploy/README.md
+++ b/linode_deploy/README.md
@@ -62,6 +62,46 @@ Ignored state and artifacts stay under `linode_deploy/state/` and `.artifacts/`.
 Do not commit copied env files, state files, database dumps, or verification
 artifacts.
 
+## Release Object Storage
+
+Formal release bundles are published by `.github/workflows/release.yml` to
+Linode Object Storage. The workflow uses the AWS CLI only as an S3-compatible
+client for Linode Object Storage.
+
+Object prefix:
+
+```text
+releases/rtk_account_manager-<version>/
+```
+
+Required objects:
+
+```text
+<version>.tar.gz
+<version>.tar.gz.sha256
+manifest.json
+```
+
+Self-check:
+
+```sh
+aws s3 ls "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+
+mkdir -p ".artifacts/release-download/$VERSION"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/$VERSION.tar.gz" \
+  ".artifacts/release-download/$VERSION/$VERSION.tar.gz" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/$VERSION.tar.gz.sha256" \
+  ".artifacts/release-download/$VERSION/$VERSION.tar.gz.sha256" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/manifest.json" \
+  ".artifacts/release-download/$VERSION/manifest.json" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+
+scripts/verify-linode-release-objects.sh "$VERSION" ".artifacts/release-download/$VERSION"
+```
+
 ## Security Notes
 
 - Remote hosts never push to GitHub.

--- a/scripts/generate-release-report-candidate.sh
+++ b/scripts/generate-release-report-candidate.sh
@@ -7,6 +7,9 @@ SOURCE_COMMIT="${SOURCE_COMMIT:-${GITHUB_SHA:-}}"
 RELEASE_ASSET="${RELEASE_ASSET:-}"
 RUN_URL="${RUN_URL:-}"
 CONTRACTS_COMMIT="${CONTRACTS_COMMIT:-}"
+OBJECT_STORAGE_BUNDLE_KEY="${OBJECT_STORAGE_BUNDLE_KEY:-}"
+OBJECT_STORAGE_CHECKSUM_KEY="${OBJECT_STORAGE_CHECKSUM_KEY:-}"
+OBJECT_STORAGE_MANIFEST_KEY="${OBJECT_STORAGE_MANIFEST_KEY:-}"
 GENERATED_AT="${REPORT_GENERATED_AT:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
 
 if [ -z "$VERSION" ]; then
@@ -58,6 +61,10 @@ Generated: $GENERATED_AT
 | Source commit | \`$SOURCE_COMMIT\` |
 | Release asset | \`$asset_name\` |
 | Release asset SHA256 | \`$asset_sha256\` |
+| Object Storage SHA256 | \`$asset_sha256\` |
+| Object Storage bundle key | \`${OBJECT_STORAGE_BUNDLE_KEY:-not published}\` |
+| Object Storage checksum key | \`${OBJECT_STORAGE_CHECKSUM_KEY:-not published}\` |
+| Object Storage manifest key | \`${OBJECT_STORAGE_MANIFEST_KEY:-not published}\` |
 | Contracts commit | \`$CONTRACTS_COMMIT\` |
 | Workflow run | $RUN_URL |
 

--- a/scripts/prepare-linode-release-objects.sh
+++ b/scripts/prepare-linode-release-objects.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${VERSION:-${1:-}}"
+release_asset="${RELEASE_ASSET:-${2:-}}"
+artifact_name="${ARTIFACT_NAME:-rtk_account_manager}"
+repo="${GITHUB_REPOSITORY:-hkt999rtk/rtk_account_manager}"
+source_commit="${SOURCE_COMMIT:-${GITHUB_SHA:-}}"
+output_dir="${OUTPUT_DIR:-dist}"
+
+if [ -z "$version" ]; then
+	echo "VERSION or first argument is required" >&2
+	exit 2
+fi
+if [ -z "$release_asset" ] || [ ! -f "$release_asset" ]; then
+	echo "RELEASE_ASSET or second argument must point to an existing release tarball" >&2
+	exit 2
+fi
+if [ -z "$source_commit" ]; then
+	source_commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+fi
+
+case "$version" in
+	*[!A-Za-z0-9._-]* | "" | .* | *..*)
+		echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+		exit 2
+		;;
+esac
+
+mkdir -p "$output_dir"
+object_bundle="$output_dir/$version.tar.gz"
+checksum_file="$object_bundle.sha256"
+manifest_file="$output_dir/manifest.json"
+artifact_path="releases/$artifact_name-$version/$version.tar.gz"
+
+cp "$release_asset" "$object_bundle"
+if command -v sha256sum >/dev/null 2>&1; then
+	sha256="$(sha256sum "$object_bundle" | awk '{print $1}')"
+else
+	sha256="$(shasum -a 256 "$object_bundle" | awk '{print $1}')"
+fi
+printf '%s  %s\n' "$sha256" "$(basename "$object_bundle")" >"$checksum_file"
+
+VERSION="$version" \
+ARTIFACT_NAME="$artifact_name" \
+GITHUB_REPOSITORY="$repo" \
+SOURCE_COMMIT="$source_commit" \
+OBJECT_SHA256="$sha256" \
+python3 - "$manifest_file" <<'PY'
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+manifest_file = sys.argv[1]
+version = os.environ["VERSION"]
+artifact_name = os.environ.get("ARTIFACT_NAME", "rtk_account_manager")
+bundle = f"{version}.tar.gz"
+artifact_path = f"releases/{artifact_name}-{version}/{bundle}"
+
+data = {
+    "repo": os.environ.get("GITHUB_REPOSITORY", "hkt999rtk/rtk_account_manager"),
+    "artifact_name": artifact_name,
+    "version": version,
+    "source_commit": os.environ.get("SOURCE_COMMIT") or os.environ.get("GITHUB_SHA") or "unknown",
+    "bundle": bundle,
+    "artifact_path": artifact_path,
+    "sha256": os.environ["OBJECT_SHA256"],
+    "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+}
+with open(manifest_file, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+
+cat <<EOF
+object_bundle=$object_bundle
+checksum_file=$checksum_file
+manifest_file=$manifest_file
+artifact_path=$artifact_path
+sha256=$sha256
+EOF

--- a/scripts/report-candidate-tests.sh
+++ b/scripts/report-candidate-tests.sh
@@ -66,14 +66,50 @@ cat >"$key_report" <<'EOF'
 EOF
 assert_rejects "private key material" "$repo_root/scripts/validate-report-candidate.sh" docs/TEST_REPORT.md "$key_report"
 
+release_dir="$tmp_dir/rtk_account_manager-vtest"
+mkdir -p "$release_dir/bin" "$release_dir/deploy/systemd" "$release_dir/migrations"
+for executable in \
+	bin/rtk-account-manager \
+	bin/rtk-account-manager-migrate \
+	bin/rtk-account-manager-outbox-worker \
+	bin/rtk-account-manager-inbox-worker \
+	bin/rtk-account-manager-cleanup-tokens \
+	deploy/install.sh \
+	deploy/verify.sh; do
+	printf '#!/usr/bin/env sh\nexit 0\n' >"$release_dir/$executable"
+	chmod +x "$release_dir/$executable"
+done
+for file in \
+	deploy/account-manager.env.example \
+	deploy/systemd/rtk-account-manager.service \
+	deploy/systemd/rtk-account-manager-migrate.service \
+	deploy/systemd/rtk-account-manager-outbox-worker.service \
+	deploy/systemd/rtk-account-manager-inbox-worker.service \
+	deploy/systemd/rtk-account-manager-cleanup-tokens.service \
+	deploy/systemd/rtk-account-manager-cleanup-tokens.timer \
+	release-manifest.txt \
+	migrations/001_test.sql; do
+	printf 'test\n' >"$release_dir/$file"
+done
 asset="$tmp_dir/rtk_account_manager-vtest.tar.gz"
-printf 'release-bundle' >"$asset"
+tar -C "$tmp_dir" -czf "$asset" "$(basename "$release_dir")"
+object_output="$tmp_dir/object-output"
+mkdir -p "$object_output"
+VERSION="vtest" \
+	SOURCE_COMMIT="abc123" \
+	RELEASE_ASSET="$asset" \
+	OUTPUT_DIR="$object_output" \
+	"$repo_root/scripts/prepare-linode-release-objects.sh" >/dev/null
+"$repo_root/scripts/verify-linode-release-objects.sh" vtest "$object_output" >/dev/null
 release_output="$tmp_dir/candidates/docs/RELEASE_TEST_REPORT.md"
 OUTPUT="$release_output" \
 	VERSION="vtest" \
 	SOURCE_COMMIT="abc123" \
 	RELEASE_ASSET="$asset" \
 	CONTRACTS_COMMIT="def456" \
+	OBJECT_STORAGE_BUNDLE_KEY="releases/rtk_account_manager-vtest/vtest.tar.gz" \
+	OBJECT_STORAGE_CHECKSUM_KEY="releases/rtk_account_manager-vtest/vtest.tar.gz.sha256" \
+	OBJECT_STORAGE_MANIFEST_KEY="releases/rtk_account_manager-vtest/manifest.json" \
 	RUN_URL="https://github.example/run/1" \
 	REPORT_GENERATED_AT="test" \
 	"$repo_root/scripts/generate-release-report-candidate.sh" >/dev/null
@@ -82,6 +118,9 @@ assert_contains "$release_output" "| Release version | \`vtest\` |"
 assert_contains "$release_output" "| Source commit | \`abc123\` |"
 assert_contains "$release_output" "| Contracts commit | \`def456\` |"
 assert_contains "$release_output" "| Release asset SHA256 |"
+assert_contains "$release_output" "| Object Storage SHA256 |"
+assert_contains "$release_output" "| Object Storage bundle key | \`releases/rtk_account_manager-vtest/vtest.tar.gz\` |"
+assert_contains "$release_output" "| Object Storage manifest key | \`releases/rtk_account_manager-vtest/manifest.json\` |"
 
 evidence="$tmp_dir/deployment-evidence"
 mkdir -p "$evidence"

--- a/scripts/verify-linode-release-objects.sh
+++ b/scripts/verify-linode-release-objects.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+download_dir="${2:-}"
+artifact_name="${ARTIFACT_NAME:-rtk_account_manager}"
+
+if [ -z "$version" ] || [ -z "$download_dir" ]; then
+	echo "usage: $0 <version> <download-dir>" >&2
+	exit 2
+fi
+
+bundle="$download_dir/$version.tar.gz"
+checksum="$download_dir/$version.tar.gz.sha256"
+manifest="$download_dir/manifest.json"
+
+for path in "$bundle" "$checksum" "$manifest"; do
+	if [ ! -f "$path" ]; then
+		echo "missing release object: $path" >&2
+		exit 1
+	fi
+done
+
+python3 - "$version" "$artifact_name" "$bundle" "$checksum" "$manifest" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+version, artifact_name, bundle_path, checksum_path, manifest_path = sys.argv[1:]
+bundle = pathlib.Path(bundle_path)
+checksum_text = pathlib.Path(checksum_path).read_text(encoding="utf-8").strip()
+manifest = json.loads(pathlib.Path(manifest_path).read_text(encoding="utf-8"))
+
+expected_bundle = f"{version}.tar.gz"
+expected_path = f"releases/{artifact_name}-{version}/{expected_bundle}"
+actual_sha = hashlib.sha256(bundle.read_bytes()).hexdigest()
+published_sha = checksum_text.split()[0]
+
+checks = {
+    "repo": manifest.get("repo") == "hkt999rtk/rtk_account_manager",
+    "artifact_name": manifest.get("artifact_name") == artifact_name,
+    "version": manifest.get("version") == version,
+    "bundle": manifest.get("bundle") == expected_bundle,
+    "artifact_path": manifest.get("artifact_path") == expected_path,
+    "source_commit": bool(manifest.get("source_commit")),
+    "sha256": manifest.get("sha256") == actual_sha == published_sha,
+    "created_at": bool(manifest.get("created_at")),
+}
+failed = [name for name, ok in checks.items() if not ok]
+if failed:
+    raise SystemExit("release object verification failed: " + ", ".join(failed))
+PY
+
+extract_dir="$(mktemp -d)"
+trap 'rm -rf "$extract_dir"' EXIT
+tar -xzf "$bundle" -C "$extract_dir"
+release_dir="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+if [ -z "$release_dir" ]; then
+	echo "release bundle did not contain a top-level release directory" >&2
+	exit 1
+fi
+"$(dirname "$0")/../deploy/check-release.sh" "$release_dir" >/dev/null
+
+echo "release objects verified: $version"


### PR DESCRIPTION
## Summary

Closes #168

- publish release bundle, checksum, and manifest to Linode Object Storage under `releases/rtk_account_manager-<version>/`
- add reusable scripts to prepare canonical Object Storage release objects and verify downloaded objects locally
- extend the release test report candidate with Object Storage keys and checksum evidence
- document developer self-check commands using AWS CLI as an S3-compatible client for Linode Object Storage

## Tests

- `VERSION=issue168-test make release`
- `VERSION=issue168-test SOURCE_COMMIT=$(git rev-parse HEAD) RELEASE_ASSET=dist/rtk_account_manager-issue168-test.tar.gz OUTPUT_DIR=.artifacts/issue168-release-objects scripts/prepare-linode-release-objects.sh`
- `scripts/verify-linode-release-objects.sh issue168-test .artifacts/issue168-release-objects`
- `make check-report-candidates`
- `go test ./linode_deploy/...`
- `bash -n scripts/prepare-linode-release-objects.sh scripts/verify-linode-release-objects.sh scripts/generate-release-report-candidate.sh scripts/report-candidate-tests.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
