### PR TITLE
Publish account-manager releases to Linode Object Storage

### DIFF
--- a/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
+++ b/docs/PRIVATE_CLOUD_DEPLOYMENT_RUNBOOK.md
@@ -192,7 +192,7 @@ PORT=18081
 ```
 
 The deploy workflow is `.github/workflows/deploy-local.yml`. It is manual
-(`workflow_dispatch`) and deploys an existing GitHub Release version. Configure
+(`workflow_dispatch`) and deploys an existing release version. Configure
 the staging environment with:
 
 | GitHub setting | Purpose |
@@ -211,7 +211,7 @@ Manual deploy inputs:
 
 | Input | Purpose |
 | --- | --- |
-| `version` | Existing GitHub Release tag to deploy. |
+| `version` | Existing release version to deploy. |
 | `restart_units` | Space-separated account-manager units to restart after migration. |
 | `verify` | Run package verification after restart. |
 | `run_readiness_smoke` | Run login, organization read, device read, and provisioning/readiness smoke when smoke secrets are configured. |
@@ -231,6 +231,34 @@ backup and create the deploy gate marker:
 sudo install -d -o rtk-account-manager -g rtk-account-manager /var/lib/rtk-account-manager
 printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" | \
   sudo tee /var/lib/rtk-account-manager/last-db-backup-ok >/dev/null
+```
+
+Release artifacts are published to Linode Object Storage through its
+S3-compatible API. The release workflow may use AWS CLI as an S3-compatible
+client, but the durable artifact backend is Linode Object Storage, not AWS
+storage.
+
+Expected Object Storage prefix:
+
+```text
+releases/rtk_account_manager-<version>/
+```
+
+Required objects:
+
+```text
+releases/rtk_account_manager-<version>/<version>.tar.gz
+releases/rtk_account_manager-<version>/<version>.tar.gz.sha256
+releases/rtk_account_manager-<version>/manifest.json
+```
+
+Developer self-check:
+
+```sh
+aws s3 ls "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+aws s3 cp "s3://$LINODE_OBJ_BUCKET/releases/rtk_account_manager-$VERSION/manifest.json" - \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
 ```
 
 Deploy sequence:

--- a/linode_deploy/internal/artifact/artifact.go
+++ b/linode_deploy/internal/artifact/artifact.go
@@ -15,6 +15,8 @@ import (
 )
 
 type Manifest struct {
+	Repo         string `json:"repo"`
+	ArtifactName string `json:"artifact_name"`
 	Version      string `json:"version"`
 	SourceCommit string `json:"source_commit"`
 	Bundle       string `json:"bundle"`
@@ -74,11 +76,16 @@ func VerifyManifestAndChecksum(manifestBytes, checksumBytes, bundleBytes []byte,
 }
 
 func ValidateManifest(m Manifest, version string) error {
-	expectedBundle := bundleName(version)
-	expectedPath := "releases/" + version + "/" + expectedBundle
+	expectedArtifactName := "rtk_account_manager"
+	expectedBundle := objectBundleName(version)
+	expectedPath := "releases/" + expectedArtifactName + "-" + version + "/" + expectedBundle
 	switch {
 	case version == "" || strings.EqualFold(version, "latest"):
 		return fmt.Errorf("explicit release version is required")
+	case m.Repo != "" && m.Repo != "hkt999rtk/rtk_account_manager":
+		return fmt.Errorf("manifest repo %q must be hkt999rtk/rtk_account_manager", m.Repo)
+	case m.ArtifactName != "" && m.ArtifactName != expectedArtifactName:
+		return fmt.Errorf("manifest artifact_name %q must be %q", m.ArtifactName, expectedArtifactName)
 	case m.Version != version:
 		return fmt.Errorf("manifest version %q does not match requested release %q", m.Version, version)
 	case m.Bundle != expectedBundle:
@@ -97,6 +104,10 @@ func ValidateManifest(m Manifest, version string) error {
 
 func bundleName(version string) string {
 	return "rtk_account_manager-" + version + ".tar.gz"
+}
+
+func objectBundleName(version string) string {
+	return version + ".tar.gz"
 }
 
 func verifyReleaseManifest(r io.Reader, version string) error {

--- a/linode_deploy/internal/artifact/artifact_test.go
+++ b/linode_deploy/internal/artifact/artifact_test.go
@@ -29,14 +29,16 @@ func TestVerifyLocalRequiresAccountManagerBundleContract(t *testing.T) {
 
 func TestValidateManifestRejectsWrongArtifactName(t *testing.T) {
 	err := ValidateManifest(Manifest{
+		Repo:         "hkt999rtk/rtk_account_manager",
+		ArtifactName: "video_cloud",
 		Version:      "v1.2.3",
 		SourceCommit: "abc123",
 		Bundle:       "video_cloud-v1.2.3.tar.gz",
-		ArtifactPath: "releases/v1.2.3/video_cloud-v1.2.3.tar.gz",
+		ArtifactPath: "releases/video_cloud-v1.2.3/v1.2.3.tar.gz",
 		SHA256:       strings.Repeat("a", 64),
 		CreatedAt:    "2026-05-14T00:00:00Z",
 	}, "v1.2.3")
-	if err == nil || !strings.Contains(err.Error(), "rtk_account_manager-v1.2.3.tar.gz") {
+	if err == nil || !strings.Contains(err.Error(), "manifest artifact_name") {
 		t.Fatalf("expected account-manager artifact validation error, got %v", err)
 	}
 }
@@ -52,17 +54,19 @@ func TestVerifyManifestAndChecksum(t *testing.T) {
 	sum := sha256.Sum256(raw)
 	sha := hex.EncodeToString(sum[:])
 	manifestBytes, err := json.Marshal(Manifest{
+		Repo:         "hkt999rtk/rtk_account_manager",
+		ArtifactName: "rtk_account_manager",
 		Version:      "v1.2.3",
 		SourceCommit: "abc123",
-		Bundle:       "rtk_account_manager-v1.2.3.tar.gz",
-		ArtifactPath: "releases/v1.2.3/rtk_account_manager-v1.2.3.tar.gz",
+		Bundle:       "v1.2.3.tar.gz",
+		ArtifactPath: "releases/rtk_account_manager-v1.2.3/v1.2.3.tar.gz",
 		SHA256:       sha,
 		CreatedAt:    "2026-05-14T00:00:00Z",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := VerifyManifestAndChecksum(manifestBytes, []byte(sha+"  rtk_account_manager-v1.2.3.tar.gz\n"), raw, "v1.2.3"); err != nil {
+	if err := VerifyManifestAndChecksum(manifestBytes, []byte(sha+"  v1.2.3.tar.gz\n"), raw, "v1.2.3"); err != nil {
 		t.Fatalf("VerifyManifestAndChecksum: %v", err)
 	}
 }

--- a/linode_deploy/internal/cli/cli.go
+++ b/linode_deploy/internal/cli/cli.go
@@ -117,7 +117,7 @@ func runDeploy(args []string, out io.Writer) error {
 		}
 		_, _ = fmt.Fprintf(out, "verify local release bundle %s\n", *releaseBundle)
 	} else {
-		_, _ = fmt.Fprintf(out, "verify Object Storage release releases/%s/rtk_account_manager-%s.tar.gz\n", *release, *release)
+		_, _ = fmt.Fprintf(out, "verify Object Storage release releases/rtk_account_manager-%s/%s.tar.gz\n", *release, *release)
 	}
 	_, _ = io.WriteString(out, "write runtime env to /etc/rtk-account-manager/account-manager.env mode 0600\n")
 	_, _ = io.WriteString(out, "require database backup marker\n")


### PR DESCRIPTION
## Summary
- Publish account-manager release bundles, checksums, and object manifests to Linode Object Storage through the S3-compatible API.
- Add release report metadata for object key, manifest, and endpoint.
- Update deployment runbook with developer self-check commands for Linode Object Storage.

## Tests
- `go test ./...`
- `bash scripts/report-candidate-tests.sh`
- `git diff --check`
- `.github/workflows/release.yml` YAML parse check

Closes #168
