### PR TITLE
Add brand cloud checks to Linode verifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ check-release: release
 test-linode-deploy:
 	go test ./linode_deploy/...
 	bash -n linode_deploy/scripts/deploy-staging.sh
+	bash -n linode_deploy/scripts/verify-public-vm.sh
+	bash -n linode_deploy/scripts/verify-public-vm-test.sh
+	linode_deploy/scripts/verify-public-vm-test.sh
 	go run ./linode_deploy/cmd/linode-deploy plan --config linode_deploy/configs/account-manager-staging.yaml >/dev/null
 
 readiness-smoke:

--- a/linode_deploy/README.md
+++ b/linode_deploy/README.md
@@ -36,7 +36,7 @@ VM as a gateway. Other services should call it through public HTTPS.
 | `scripts/provision-public-vm.sh` | Creates the public-only Linode VM and firewall through the Linode API. |
 | `scripts/set-godaddy-dns.sh` | Updates the staging DNS A record through the GoDaddy API. |
 | `scripts/deploy-public-vm.sh` | Builds a Linux release, installs PostgreSQL/nginx/certbot/systemd, applies migrations, and starts the service. |
-| `scripts/verify-public-vm.sh` | Runs external HTTPS health/register/login smoke checks. |
+| `scripts/verify-public-vm.sh` | Runs external HTTPS health/register/login smoke checks, with optional platform-admin brand-cloud API verification. |
 | `scripts/backup-public-postgres.sh` | Pulls a sanitized PostgreSQL custom-format dump artifact. |
 
 ## Public VM Quick Start
@@ -57,6 +57,25 @@ linode_deploy/scripts/set-godaddy-dns.sh
 linode_deploy/scripts/deploy-public-vm.sh
 linode_deploy/scripts/verify-public-vm.sh
 ```
+
+To verify the brand-cloud API after deployment, provide Account Manager
+platform-admin credentials from ignored operator secrets and enable the optional
+check:
+
+```sh
+set -a
+. linode_deploy/secrets/account-manager-platform-admin.env
+set +a
+
+ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD=1 \
+ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD_NAME="Realtek Connect+ Verify $(date -u +%Y%m%d%H%M%S)" \
+  linode_deploy/scripts/verify-public-vm.sh
+```
+
+The brand-cloud verification logs in as the Account Manager platform admin,
+creates a `brand_cloud` organization, reads it back, lists brand clouds, and
+checks audit events. Platform-admin login request/response bodies are kept in
+temporary files only and are not persisted to verification artifacts.
 
 Ignored state and artifacts stay under `linode_deploy/state/` and `.artifacts/`.
 Do not commit copied env files, state files, database dumps, or verification

--- a/linode_deploy/docs/RUNBOOK.md
+++ b/linode_deploy/docs/RUNBOOK.md
@@ -67,6 +67,37 @@ The external verifier checks:
 - `POST /v1/auth/login`
 - `GET /v1/me` with the issued bearer token
 
+When `ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD=1` is set, the verifier also checks
+the platform-admin brand-cloud management path:
+
+- `POST /v1/auth/login` with Account Manager platform-admin credentials
+- `POST /v1/admin/brand-clouds`
+- `GET /v1/admin/brand-clouds`
+- `GET /v1/admin/brand-clouds/{id}`
+- `GET /v1/admin/audit-events?subject_type=brand_cloud`
+
+Provide the platform-admin credentials from ignored operator secrets. The
+verifier reads `ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_EMAIL` and
+`ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_PASSWORD`, or falls back to
+`ACCOUNT_MANAGER_BOOTSTRAP_PLATFORM_ADMIN_EMAIL` and
+`ACCOUNT_MANAGER_BOOTSTRAP_PLATFORM_ADMIN_PASSWORD` when those are already
+loaded for deployment bootstrap.
+
+```sh
+set -a
+. linode_deploy/secrets/account-manager-public-staging.env
+. linode_deploy/state/rtk-account-manager-staging.env
+. linode_deploy/secrets/account-manager-platform-admin.env
+set +a
+
+ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD=1 \
+ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD_NAME="Realtek Connect+ Verify $(date -u +%Y%m%d%H%M%S)" \
+  linode_deploy/scripts/verify-public-vm.sh
+```
+
+The platform-admin login request/response is held in temporary files only. Do
+not persist platform-admin bearer tokens in `.artifacts/`.
+
 Verification artifacts are written under `.artifacts/linode-account-manager-verify/`
 and must remain untracked.
 

--- a/linode_deploy/scripts/verify-public-vm-test.sh
+++ b/linode_deploy/scripts/verify-public-vm-test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bin="$tmpdir/bin"
+artifacts="$tmpdir/artifacts"
+mkdir -p "$fake_bin" "$artifacts"
+
+cat > "$fake_bin/openssl" <<'FAKE_OPENSSL'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "rand" ]; then
+  printf 'abcdef1234567890abcdef12\n'
+  exit 0
+fi
+exec /usr/bin/openssl "$@"
+FAKE_OPENSSL
+chmod +x "$fake_bin/openssl"
+
+cat > "$fake_bin/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+write_code=""
+method="GET"
+data_seen=0
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -w)
+      write_code="$2"
+      shift 2
+      ;;
+    -H)
+      shift 2
+      ;;
+    --data-binary|-d|--data)
+      data_seen=1
+      method="POST"
+      shift 2
+      ;;
+    -X)
+      method="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+body='{}'
+code=200
+case "$url" in
+  */v1/health)
+    body='{"status":"ok"}'
+    ;;
+  */v1/auth/register)
+    code=201
+    body='{"user":{"id":"user-1"}}'
+    ;;
+  */v1/auth/login)
+    body='{"tokens":{"access_token":"token-for-test"}}'
+    ;;
+  */v1/me)
+    body='{"user":{"id":"user-1"}}'
+    ;;
+  */v1/admin/brand-clouds)
+    if [ "$method" = "POST" ] || [ "$data_seen" = 1 ]; then
+      body='{"brand_cloud":{"id":"brand-1","name":"Realtek Connect+ Verify","organization_kind":"brand_cloud","status":"active"}}'
+      code=201
+    else
+      body='{"brand_clouds":[{"id":"brand-1","name":"Realtek Connect+ Verify","organization_kind":"brand_cloud"}],"pagination":{"total":1}}'
+    fi
+    ;;
+  */v1/admin/brand-clouds/brand-1)
+    body='{"brand_cloud":{"id":"brand-1","name":"Realtek Connect+ Verify","organization_kind":"brand_cloud","status":"active"}}'
+    ;;
+  */v1/admin/audit-events\?subject_type=brand_cloud)
+    body='{"audit_events":[{"event_type":"brand_cloud_created","subject_type":"brand_cloud"}]}'
+    ;;
+  *)
+    printf 'unexpected curl url: %s\n' "$url" >&2
+    code=404
+    body='{"error":"unexpected"}'
+    ;;
+esac
+
+if [ -n "$out" ]; then
+  printf '%s' "$body" > "$out"
+else
+  printf '%s' "$body"
+fi
+if [ -n "$write_code" ]; then
+  printf '%s' "$write_code" | sed "s/%{http_code}/$code/g"
+fi
+exit 0
+FAKE_CURL
+chmod +x "$fake_bin/curl"
+
+PATH="$fake_bin:$PATH" \
+ACCOUNT_MANAGER_BASE_URL="https://account-manager.example.test" \
+ACCOUNT_MANAGER_LINODE_VERIFY_ARTIFACTS="$artifacts" \
+ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_EMAIL="root@example.test" \
+ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_PASSWORD="secret-password" \
+ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD=1 \
+ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD_NAME="Realtek Connect+ Verify" \
+  "$repo_root/linode_deploy/scripts/verify-public-vm.sh" >/tmp/verify-public-vm-test.out
+
+grep -q 'PASS brand-cloud create http_201' "$artifacts/checks.txt"
+grep -q 'PASS brand-cloud list' "$artifacts/checks.txt"
+grep -q 'PASS brand-cloud audit' "$artifacts/checks.txt"
+test -f "$artifacts/create-brand-cloud.json"
+test -f "$artifacts/list-brand-clouds.json"
+test -f "$artifacts/audit-brand-cloud.json"
+if find "$artifacts" -type f -name '*platform*login*' -print -quit | grep -q .; then
+  echo 'platform-admin login artifacts must not be persisted' >&2
+  exit 1
+fi
+
+printf 'verify-public-vm brand-cloud test passed\n'

--- a/linode_deploy/scripts/verify-public-vm.sh
+++ b/linode_deploy/scripts/verify-public-vm.sh
@@ -14,18 +14,29 @@ artifacts_dir="${ACCOUNT_MANAGER_LINODE_VERIFY_ARTIFACTS:-.artifacts/linode-acco
 email="${ACCOUNT_MANAGER_VERIFY_EMAIL:-verify+$(date -u +%Y%m%d%H%M%S)@example.invalid}"
 password="${ACCOUNT_MANAGER_VERIFY_PASSWORD:-Verify-$(openssl rand -hex 12)aA1!}"
 org="${ACCOUNT_MANAGER_VERIFY_ORG:-RTK Account Manager Linode Verify}"
+verify_brand_cloud="${ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD:-0}"
+platform_admin_email="${ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_EMAIL:-${ACCOUNT_MANAGER_BOOTSTRAP_PLATFORM_ADMIN_EMAIL:-}}"
+platform_admin_password="${ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_PASSWORD:-${ACCOUNT_MANAGER_BOOTSTRAP_PLATFORM_ADMIN_PASSWORD:-}}"
+brand_cloud_name="${ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD_NAME:-Realtek Connect+ Verify $(date -u +%Y%m%d%H%M%S)}"
 command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
 command -v openssl >/dev/null 2>&1 || { echo "openssl is required" >&2; exit 1; }
 mkdir -p "$artifacts_dir"
 
 record() { printf '%s\n' "$1" | tee -a "$artifacts_dir/checks.txt" >/dev/null; }
+cleanup_files=()
+cleanup() {
+  if [ "${#cleanup_files[@]}" -gt 0 ]; then
+    rm -f "${cleanup_files[@]}"
+  fi
+}
+trap cleanup EXIT
 
 curl -fsS "$base_url/v1/health" > "$artifacts_dir/health.json"
 record "PASS health"
 
 register_body="$(mktemp)"
-trap 'rm -f "$register_body"' EXIT
+cleanup_files+=("$register_body")
 jq -cn --arg email "$email" --arg password "$password" --arg org "$org" '{email:$email,password:$password,organization_name:$org}' > "$register_body"
 status="$(curl -sS -o "$artifacts_dir/register.json" -w '%{http_code}' -H 'content-type: application/json' --data-binary "@$register_body" "$base_url/v1/auth/register")"
 if [ "$status" != 201 ] && [ "$status" != 409 ]; then
@@ -36,7 +47,7 @@ fi
 record "PASS register endpoint http_$status"
 
 login_body="$(mktemp)"
-trap 'rm -f "$register_body" "$login_body"' EXIT
+cleanup_files+=("$login_body")
 jq -cn --arg email "$email" --arg password "$password" '{email:$email,password:$password}' > "$login_body"
 status="$(curl -sS -o "$artifacts_dir/login.json" -w '%{http_code}' -H 'content-type: application/json' --data-binary "@$login_body" "$base_url/v1/auth/login")"
 if [ "$status" = 200 ]; then
@@ -48,6 +59,46 @@ else
   printf 'login returned HTTP %s\n' "$status" >&2
   cat "$artifacts_dir/login.json" >&2
   exit 1
+fi
+
+if [ "$verify_brand_cloud" = 1 ]; then
+  if [ -z "$platform_admin_email" ] || [ -z "$platform_admin_password" ]; then
+    echo "ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_EMAIL/PASSWORD or bootstrap platform-admin credentials are required for brand-cloud verification" >&2
+    exit 1
+  fi
+
+  platform_login_body="$(mktemp)"
+  platform_login_response="$(mktemp)"
+  cleanup_files+=("$platform_login_body" "$platform_login_response")
+  jq -cn --arg email "$platform_admin_email" --arg password "$platform_admin_password" '{email:$email,password:$password}' > "$platform_login_body"
+  status="$(curl -sS -o "$platform_login_response" -w '%{http_code}' -H 'content-type: application/json' --data-binary "@$platform_login_body" "$base_url/v1/auth/login")"
+  if [ "$status" != 200 ]; then
+    printf 'platform-admin login returned HTTP %s\n' "$status" >&2
+    jq '{error}' "$platform_login_response" >&2 || true
+    exit 1
+  fi
+  platform_token="$(jq -r '.tokens.access_token // .access_token // .accessToken // empty' "$platform_login_response")"
+  [ -n "$platform_token" ] || { echo "platform-admin login response did not include an access token" >&2; exit 1; }
+
+  brand_body="$(mktemp)"
+  cleanup_files+=("$brand_body")
+  jq -cn --arg name "$brand_cloud_name" '{name:$name,metadata:{verification:"linode-public-vm"}}' > "$brand_body"
+  status="$(curl -sS -o "$artifacts_dir/create-brand-cloud.json" -w '%{http_code}' -H "authorization: Bearer $platform_token" -H 'content-type: application/json' --data-binary "@$brand_body" "$base_url/v1/admin/brand-clouds")"
+  if [ "$status" != 201 ]; then
+    printf 'brand-cloud create returned HTTP %s\n' "$status" >&2
+    cat "$artifacts_dir/create-brand-cloud.json" >&2
+    exit 1
+  fi
+  record "PASS brand-cloud create http_$status"
+
+  brand_cloud_id="$(jq -r '.brand_cloud.id // empty' "$artifacts_dir/create-brand-cloud.json")"
+  [ -n "$brand_cloud_id" ] || { echo "brand-cloud create response did not include an id" >&2; exit 1; }
+  curl -fsS -H "authorization: Bearer $platform_token" "$base_url/v1/admin/brand-clouds" > "$artifacts_dir/list-brand-clouds.json"
+  record "PASS brand-cloud list"
+  curl -fsS -H "authorization: Bearer $platform_token" "$base_url/v1/admin/brand-clouds/$brand_cloud_id" > "$artifacts_dir/get-brand-cloud.json"
+  record "PASS brand-cloud get"
+  curl -fsS -H "authorization: Bearer $platform_token" "$base_url/v1/admin/audit-events?subject_type=brand_cloud" > "$artifacts_dir/audit-brand-cloud.json"
+  record "PASS brand-cloud audit"
 fi
 
 printf 'Account Manager verify passed: %s\nArtifacts: %s\n' "$base_url" "$artifacts_dir"


### PR DESCRIPTION
## Summary\n- add optional platform-admin brand-cloud verification to the public Linode verifier\n- add a fake-curl regression test for brand-cloud create/list/get/audit checks\n- document how operators enable brand-cloud verification after deployment\n\n## Validation\n- make test-linode-deploy\n- git diff --check\n- live Linode verification with ACCOUNT_MANAGER_VERIFY_BRAND_CLOUD=1\n\nLive verification created test brand cloud: Realtek Connect+ Verify 20260518085600.