### PR TITLE
[codex] Add Linode certificate cache renewal support

### DIFF
--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -30,6 +30,7 @@ remote_bundle="${ACCOUNT_MANAGER_LINODE_REMOTE_BUNDLE:-/tmp/rtk-account-manager-
 artifact_dir="${ACCOUNT_MANAGER_LINODE_ARTIFACT_DIR:-$root_dir/.artifacts/linode-account-manager-deploy/$release}"
 bundle="$artifact_dir/rtk_account_manager-${release}.tar.gz"
 certbot_enable="${ACCOUNT_MANAGER_LINODE_CERTBOT_ENABLE:-1}"
+cert_cache_dir="${ACCOUNT_MANAGER_LINODE_CERT_CACHE_DIR:-}"
 http_only="${ACCOUNT_MANAGER_LINODE_HTTP_ONLY:-0}"
 port="${ACCOUNT_MANAGER_PORT:-18081}"
 db_name="${ACCOUNT_MANAGER_POSTGRES_DB:-rtk_account_manager}"
@@ -53,6 +54,12 @@ need openssl
 [ -n "$host" ] || die "ACCOUNT_MANAGER_LINODE_HOST or ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4 is required"
 [ -s "$ssh_key" ] || die "SSH key not found: $ssh_key"
 [ -n "$certbot_email" ] || [ "$certbot_enable" = 0 ] || die "ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL is required when certbot is enabled"
+if [ -n "$cert_cache_dir" ]; then
+  [ -s "$cert_cache_dir/fullchain.pem" ] || die "cached certificate fullchain not found: $cert_cache_dir/fullchain.pem"
+  [ -s "$cert_cache_dir/privkey.pem" ] || die "cached certificate private key not found: $cert_cache_dir/privkey.pem"
+  openssl x509 -in "$cert_cache_dir/fullchain.pem" -noout -checkend "${ACCOUNT_MANAGER_LINODE_CERT_CACHE_MIN_VALID_SECONDS:-604800}" >/dev/null \
+    || die "cached certificate is expired or too close to expiry: $cert_cache_dir/fullchain.pem"
+fi
 [ -n "${JWT_ACCESS_SECRET:-}" ] || die "JWT_ACCESS_SECRET is required"
 [ -n "${JWT_REFRESH_SECRET:-}" ] || die "JWT_REFRESH_SECRET is required"
 if [ -z "$db_password" ]; then
@@ -119,9 +126,15 @@ printf '[account-manager-deploy] uploading release bundle to %s\n' "$remote" >&2
 ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy"
 scp "${ssh_opts[@]}" "$bundle" "$remote:$remote_bundle"
 scp "${ssh_opts[@]}" "$tmp_env" "$remote:/tmp/rtk-account-manager-deploy/account-manager.env"
+if [ -n "$cert_cache_dir" ]; then
+  printf '[account-manager-deploy] uploading cached certificate for %s\n' "$domain" >&2
+  ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy/cert-cache"
+  scp "${ssh_opts[@]}" "$cert_cache_dir/fullchain.pem" "$remote:/tmp/rtk-account-manager-deploy/cert-cache/fullchain.pem"
+  scp "${ssh_opts[@]}" "$cert_cache_dir/privkey.pem" "$remote:/tmp/rtk-account-manager-deploy/cert-cache/privkey.pem"
+fi
 
 printf '[account-manager-deploy] installing runtime on %s\n' "$remote" >&2
-ssh "${ssh_opts[@]}" "$remote" bash -s -- "$remote_bundle" "$release" "$domain" "$certbot_email" "$certbot_enable" "$http_only" "$port" "$db_name" "$db_user" "$db_password" <<'REMOTE'
+ssh "${ssh_opts[@]}" "$remote" bash -s -- "$remote_bundle" "$release" "$domain" "$certbot_email" "$certbot_enable" "$http_only" "$port" "$db_name" "$db_user" "$db_password" "$cert_cache_dir" <<'REMOTE'
 set -euo pipefail
 remote_bundle="$1"
 release="$2"
@@ -133,6 +146,7 @@ port="$7"
 db_name="$8"
 db_user="$9"
 db_password="${10}"
+cert_cache_dir="${11:-}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
@@ -157,6 +171,7 @@ if [ -d /etc/nginx/sites-enabled ] && ! grep -q 'sites-enabled' /etc/nginx/nginx
   printf 'include /etc/nginx/sites-enabled/*;\n' > /etc/nginx/conf.d/rtk-sites-enabled.conf
 fi
 systemctl enable --now postgresql nginx
+mkdir -p /var/www/certbot/.well-known/acme-challenge
 
 sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL
 DO \$\$
@@ -192,6 +207,11 @@ server {
 
     client_max_body_size 10m;
 
+    location ^~ /.well-known/acme-challenge/ {
+        alias /var/www/certbot/.well-known/acme-challenge/;
+        default_type text/plain;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:$port;
         proxy_http_version 1.1;
@@ -220,7 +240,87 @@ if [ "${ready:-0}" != "1" ]; then
   exit 1
 fi
 
-if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+if [ -n "$cert_cache_dir" ] && [ "$http_only" != "1" ]; then
+  archive_dir="/etc/letsencrypt/archive/$domain"
+  live_dir="/etc/letsencrypt/live/$domain"
+  renewal_conf="/etc/letsencrypt/renewal/$domain.conf"
+  mkdir -p "$archive_dir" "$live_dir" /etc/letsencrypt/renewal /var/www/certbot/.well-known/acme-challenge
+  install -m 0644 /tmp/rtk-account-manager-deploy/cert-cache/fullchain.pem "$archive_dir/fullchain1.pem"
+  install -m 0600 /tmp/rtk-account-manager-deploy/cert-cache/privkey.pem "$archive_dir/privkey1.pem"
+  awk 'BEGIN{n=0} /-----BEGIN CERTIFICATE-----/{n++} n==1{print > cert} n>1{print > chain}' \
+    cert="$archive_dir/cert1.pem" chain="$archive_dir/chain1.pem" "$archive_dir/fullchain1.pem"
+  if [ ! -s "$archive_dir/chain1.pem" ]; then
+    cp "$archive_dir/fullchain1.pem" "$archive_dir/chain1.pem"
+  fi
+  ln -sfn "../../archive/$domain/cert1.pem" "$live_dir/cert.pem"
+  ln -sfn "../../archive/$domain/chain1.pem" "$live_dir/chain.pem"
+  ln -sfn "../../archive/$domain/fullchain1.pem" "$live_dir/fullchain.pem"
+  ln -sfn "../../archive/$domain/privkey1.pem" "$live_dir/privkey.pem"
+  cat > "$renewal_conf" <<RENEWAL
+version = 2.9.0
+archive_dir = /etc/letsencrypt/archive/$domain
+cert = /etc/letsencrypt/live/$domain/cert.pem
+privkey = /etc/letsencrypt/live/$domain/privkey.pem
+chain = /etc/letsencrypt/live/$domain/chain.pem
+fullchain = /etc/letsencrypt/live/$domain/fullchain.pem
+
+[renewalparams]
+account =
+authenticator = webroot
+webroot_path = /var/www/certbot
+server = https://acme-v02.api.letsencrypt.org/directory
+key_type = rsa
+deploy_hook = systemctl reload nginx
+RENEWAL
+  certbot register --non-interactive --agree-tos --email "$certbot_email" >/dev/null 2>&1 || true
+  account="$(find /etc/letsencrypt/accounts/acme-v02.api.letsencrypt.org/directory -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n1 | xargs basename || true)"
+  if [ -n "$account" ]; then
+    sed -i "s/^account =.*/account = $account/" "$renewal_conf"
+  fi
+  cat > /etc/nginx/sites-available/rtk-account-manager.conf <<NGINX
+server {
+    listen 80;
+    server_name $domain;
+
+    location ^~ /.well-known/acme-challenge/ {
+        alias /var/www/certbot/.well-known/acme-challenge/;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name $domain;
+
+    ssl_certificate /etc/letsencrypt/live/$domain/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$domain/privkey.pem;
+    client_max_body_size 10m;
+
+    location ^~ /.well-known/acme-challenge/ {
+        alias /var/www/certbot/.well-known/acme-challenge/;
+        default_type text/plain;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:$port;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+NGINX
+  nginx -t
+  systemctl reload nginx
+  systemctl enable --now certbot.timer
+  systemctl is-enabled certbot.timer >/dev/null
+  printf 'installed cached certificate lineage for %s\n' "$domain"
+elif [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
   certbot_log="$(mktemp)"
   set +e
   certbot --nginx --non-interactive --agree-tos --email "$certbot_email" -d "$domain" --redirect 2>&1 | tee "$certbot_log"
@@ -240,6 +340,8 @@ if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
     exit "$certbot_status"
   fi
   rm -f "$certbot_log"
+  systemctl enable --now certbot.timer
+  systemctl is-enabled certbot.timer >/dev/null
 fi
 
 systemctl is-active rtk-account-manager.service


### PR DESCRIPTION
## Summary

- add optional Linode certificate cache upload support for Account Manager deploys
- install cached certificates as a certbot lineage with webroot renewal config
- enable and verify `certbot.timer` after cached or newly issued certificates are installed

## Validation

- `bash -n linode_deploy/scripts/deploy-public-vm.sh`
- `go test ./...`
