### PR TITLE
Use Account Manager release bundles for deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version. Defaults to the git ref name or short SHA."
+        description: "Release version. Defaults to the git ref name or timestamped short SHA."
         required: false
         type: string
 
@@ -39,7 +39,7 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             version="${GITHUB_REF_NAME}"
           else
-            version="${GITHUB_SHA::12}"
+            version="ci-$(date -u +%Y%m%d-%H%M%S)-${GITHUB_SHA::12}"
           fi
           case "$version" in
             *[!A-Za-z0-9._-]* | "" | .* | *..*)

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -28,7 +28,8 @@ ssh_key="${ACCOUNT_MANAGER_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"
 host="${ACCOUNT_MANAGER_LINODE_HOST:-${ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4:-}}"
 remote_bundle="${ACCOUNT_MANAGER_LINODE_REMOTE_BUNDLE:-/tmp/rtk-account-manager-${release}.tar.gz}"
 artifact_dir="${ACCOUNT_MANAGER_LINODE_ARTIFACT_DIR:-$root_dir/.artifacts/linode-account-manager-deploy/$release}"
-bundle="$artifact_dir/rtk_account_manager-${release}.tar.gz"
+release_bundle="${ACCOUNT_MANAGER_LINODE_RELEASE_BUNDLE:-}"
+bundle="${release_bundle:-$artifact_dir/rtk_account_manager-${release}.tar.gz}"
 certbot_enable="${ACCOUNT_MANAGER_LINODE_CERTBOT_ENABLE:-1}"
 cert_cache_dir="${ACCOUNT_MANAGER_LINODE_CERT_CACHE_DIR:-}"
 http_only="${ACCOUNT_MANAGER_LINODE_HTTP_ONLY:-0}"
@@ -70,12 +71,17 @@ fi
 database_url="postgres://${db_user}:${db_password}@127.0.0.1:5432/${db_name}?sslmode=disable"
 mkdir -p "$artifact_dir"
 
-printf '[account-manager-deploy] building Linux release %s\n' "$release" >&2
-(
-  cd "$root_dir"
-  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 VERSION="$release" make release >/dev/null
-)
-cp "$root_dir/dist/rtk_account_manager-${release}.tar.gz" "$bundle"
+if [ -n "$release_bundle" ]; then
+  [ -s "$release_bundle" ] || die "ACCOUNT_MANAGER_LINODE_RELEASE_BUNDLE not found: $release_bundle"
+  printf '[account-manager-deploy] using release bundle %s\n' "$release_bundle" >&2
+else
+  printf '[account-manager-deploy] building Linux release %s\n' "$release" >&2
+  (
+    cd "$root_dir"
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 VERSION="$release" make release >/dev/null
+  )
+  cp "$root_dir/dist/rtk_account_manager-${release}.tar.gz" "$bundle"
+fi
 
 ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
 remote="$ssh_user@$host"


### PR DESCRIPTION
## Summary
- make workflow-dispatch Account Manager release versions timestamped like the other cloud services
- allow Linode deploy to consume a prebuilt release bundle instead of always building from the checked-out repo

## Verification
- bash -n linode_deploy/scripts/deploy-public-vm.sh
- triggered Release Bundle workflow on this branch: https://github.com/hkt999rtk/rtk_account_manager/actions/runs/26616498148
- verified Linode Object Storage objects exist for ci-20260529-033939-f4fc18e15c58:
  - releases/rtk_account_manager-ci-20260529-033939-f4fc18e15c58/manifest.json
  - releases/rtk_account_manager-ci-20260529-033939-f4fc18e15c58/ci-20260529-033939-f4fc18e15c58.tar.gz
  - releases/rtk_account_manager-ci-20260529-033939-f4fc18e15c58/ci-20260529-033939-f4fc18e15c58.tar.gz.sha256
- downloaded bundle and verified sha256 a1fe5efa46e5309d27e127bcbb71ecd785c12f434bfd54b1377e103f8340003b matches manifest