### PR TITLE
[codex] Remove GitHub artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,22 +89,6 @@ jobs:
       - name: Check report candidate scripts
         run: make check-report-candidates
 
-      - name: Upload raw test artifacts
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-report-raw
-          path: |
-            reports/
-
-      - name: Upload test report candidate
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-report-candidate
-          path: .artifacts/report-candidates/docs/TEST_REPORT.md
-          if-no-files-found: error
-
   deep-test:
     runs-on: [self-hosted, account-manager-ci]
     timeout-minutes: 20
@@ -128,10 +112,3 @@ jobs:
 
       - name: Run fuzz smoke
         run: make fuzz-smoke
-
-      - name: Upload deep test artifacts
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: deep-test-report
-          path: reports/

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -340,21 +340,3 @@ jobs:
           OUTPUT=.artifacts/report-candidates/docs/READINESS_TEST_REPORT.md \
             EVIDENCE_DIR=deployment-evidence \
             ./scripts/generate-readiness-report-candidate.sh
-
-      - name: Upload deployment evidence
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: account-manager-deployment-evidence-${{ steps.version.outputs.version }}
-          path: |
-            deployment-evidence/*
-            .artifacts/report-candidates/docs/READINESS_TEST_REPORT.md
-          if-no-files-found: warn
-
-      - name: Upload readiness test report candidate
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: readiness-test-report-candidate-${{ steps.version.outputs.version }}
-          path: .artifacts/report-candidates/docs/READINESS_TEST_REPORT.md
-          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,25 +118,6 @@ jobs:
             CONTRACTS_COMMIT="$contracts_commit" \
             ./scripts/generate-release-report-candidate.sh
 
-      - name: Upload workflow artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: rtk_account_manager-${{ steps.version.outputs.version }}
-          path: |
-            dist/rtk_account_manager-${{ steps.version.outputs.version }}
-            dist/rtk_account_manager-${{ steps.version.outputs.version }}.tar.gz
-            dist/${{ steps.version.outputs.version }}.tar.gz
-            dist/${{ steps.version.outputs.version }}.tar.gz.sha256
-            dist/manifest.json
-          if-no-files-found: error
-
-      - name: Upload release test report candidate
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-test-report-candidate-${{ steps.version.outputs.version }}
-          path: .artifacts/report-candidates/docs/RELEASE_TEST_REPORT.md
-          if-no-files-found: error
-
       - name: Publish GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
## Summary

- remove every `actions/upload-artifact` step from GitHub Actions workflows
- keep release bundle publication on Linode Object Storage as the authoritative artifact path
- avoid GitHub artifact quota affecting CI/release outcomes

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts f }'`
- `git diff --check`
- workspace-wide `rg "actions/upload-artifact|upload-artifact"` returned no matches
