### PR TITLE
[codex] Add brand cloud user provisioning API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -293,6 +293,7 @@ func (s *Server) Router() *gin.Engine {
 	protected.GET("/admin/brand-clouds/:brandCloudId", s.requirePlatformAdmin(), s.getBrandCloud)
 	protected.PATCH("/admin/brand-clouds/:brandCloudId", s.requirePlatformAdmin(), s.updateBrandCloud)
 	protected.POST("/admin/brand-clouds/:brandCloudId/members", s.requirePlatformAdmin(), s.assignBrandCloudMember)
+	protected.POST("/admin/brand-clouds/:brandCloudId/users", s.requirePlatformAdmin(), s.createBrandCloudUser)
 	protected.POST("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.createDeviceClaimToken)
 	protected.GET("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.listDeviceClaimTokens)
 	protected.GET("/admin/device-claim-tokens/:tokenId", s.requirePlatformAdmin(), s.getDeviceClaimToken)

--- a/internal/api/brand_clouds_admin.go
+++ b/internal/api/brand_clouds_admin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"rtk_account_manager/internal/auth"
 	"rtk_account_manager/internal/model"
 	"rtk_account_manager/internal/store"
 )
@@ -19,6 +20,14 @@ type brandCloudRequest struct {
 type brandCloudMemberRequest struct {
 	UserID string `json:"user_id" binding:"required"`
 	Role   string `json:"role" binding:"required"`
+}
+
+type brandCloudUserRequest struct {
+	Email          string  `json:"email" binding:"required,email"`
+	Password       string  `json:"password" binding:"required,min=8"`
+	DisplayName    *string `json:"display_name"`
+	Role           string  `json:"role" binding:"required"`
+	RotatePassword bool    `json:"rotate_password"`
 }
 
 func (s *Server) createBrandCloud(c *gin.Context) {
@@ -97,4 +106,37 @@ func (s *Server) assignBrandCloudMember(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"member": member})
+}
+
+func (s *Server) createBrandCloudUser(c *gin.Context) {
+	var req brandCloudUserRequest
+	if !bind(c, &req) {
+		return
+	}
+	role := model.Role(strings.TrimSpace(req.Role))
+	if role != model.RoleOwner && role != model.RoleAdmin && role != model.RoleMember {
+		writeError(c, http.StatusBadRequest, "invalid_role", "Invalid role")
+		return
+	}
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "password_hash_failed", "Could not hash password")
+		return
+	}
+	result, err := s.store.CreateBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), store.BrandCloudUserInput{
+		Email:          strings.ToLower(strings.TrimSpace(req.Email)),
+		PasswordHash:   hash,
+		DisplayName:    trimStringPtr(req.DisplayName),
+		Role:           role,
+		RotatePassword: req.RotatePassword,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	status := http.StatusOK
+	if result.Action == "created" {
+		status = http.StatusCreated
+	}
+	c.JSON(status, result)
 }

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1026,6 +1026,106 @@ func TestIntegrationPlatformAdminBrandCloudLifecycle(t *testing.T) {
 	}
 }
 
+func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
+	env := newIntegrationEnv(t)
+	ctx := context.Background()
+
+	admin := registerUser(t, env.router, "brand-user-root@example.com", "Root Org")
+	if _, err := env.db.Exec(ctx, `UPDATE users SET platform_admin = true WHERE id = $1`, admin.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	brandRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds", map[string]any{
+		"name": "RTK",
+	}, admin.Tokens.AccessToken)
+	if brandRes.Code != http.StatusCreated {
+		t.Fatalf("expected brand cloud create 201, got %d: %s", brandRes.Code, brandRes.Body.String())
+	}
+	brand := decodeBody[brandCloudBody](t, brandRes)
+
+	nonAdmin := registerUser(t, env.router, "brand-user-non-admin@example.com", "Non Admin Org")
+	nonAdminRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users", map[string]any{
+		"email":        "rtk+001@users.local",
+		"password":     "initial-password123",
+		"display_name": "RTK User 001",
+		"role":         "member",
+	}, nonAdmin.Tokens.AccessToken)
+	if nonAdminRes.Code != http.StatusForbidden {
+		t.Fatalf("expected non-admin brand user create 403, got %d: %s", nonAdminRes.Code, nonAdminRes.Body.String())
+	}
+
+	createRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users", map[string]any{
+		"email":        " RTK+001@Users.Local ",
+		"password":     "initial-password123",
+		"display_name": "RTK User 001",
+		"role":         "member",
+	}, admin.Tokens.AccessToken)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("expected brand user create 201, got %d: %s", createRes.Code, createRes.Body.String())
+	}
+	created := decodeBody[brandCloudUserBody](t, createRes)
+	if created.Action != "created" || created.User.Email != "rtk+001@users.local" || !created.User.EmailVerified || created.User.SignupPendingVerification || created.Member.Role != "member" {
+		t.Fatalf("unexpected created brand user response: %+v", created)
+	}
+
+	loginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "rtk+001@users.local",
+		"password": "initial-password123",
+	}, "")
+	if loginRes.Code != http.StatusOK {
+		t.Fatalf("expected created active user login 200, got %d: %s", loginRes.Code, loginRes.Body.String())
+	}
+
+	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, created.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	reassignRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users", map[string]any{
+		"email":        "rtk+001@users.local",
+		"password":     "ignored-password123",
+		"display_name": "RTK User 001 Reactivated",
+		"role":         "member",
+	}, admin.Tokens.AccessToken)
+	if reassignRes.Code != http.StatusOK {
+		t.Fatalf("expected existing brand user upsert 200, got %d: %s", reassignRes.Code, reassignRes.Body.String())
+	}
+	reassigned := decodeBody[brandCloudUserBody](t, reassignRes)
+	if reassigned.Action != "assigned" || reassigned.User.DisabledAt != nil || reassigned.User.DisplayName == nil || *reassigned.User.DisplayName != "RTK User 001 Reactivated" {
+		t.Fatalf("unexpected reassigned brand user response: %+v", reassigned)
+	}
+	ignoredPasswordLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "rtk+001@users.local",
+		"password": "ignored-password123",
+	}, "")
+	if ignoredPasswordLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected ignored password login 401, got %d: %s", ignoredPasswordLoginRes.Code, ignoredPasswordLoginRes.Body.String())
+	}
+
+	rotateRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users", map[string]any{
+		"email":           "rtk+001@users.local",
+		"password":        "rotated-password123",
+		"role":            "member",
+		"rotate_password": true,
+	}, admin.Tokens.AccessToken)
+	if rotateRes.Code != http.StatusOK {
+		t.Fatalf("expected rotate existing brand user 200, got %d: %s", rotateRes.Code, rotateRes.Body.String())
+	}
+	rotatedLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
+		"email":    "rtk+001@users.local",
+		"password": "rotated-password123",
+	}, "")
+	if rotatedLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected rotated password login 200, got %d: %s", rotatedLoginRes.Code, rotatedLoginRes.Body.String())
+	}
+
+	auditRes := performJSON(env.router, http.MethodGet, "/v1/admin/audit-events?subject_type=brand_cloud", nil, admin.Tokens.AccessToken)
+	if auditRes.Code != http.StatusOK {
+		t.Fatalf("expected audit event list 200, got %d: %s", auditRes.Code, auditRes.Body.String())
+	}
+	audit := decodeBody[auditEventsBody](t, auditRes)
+	if !hasAuditEventBody(audit.AuditEvents, "brand_cloud_user_created") || !hasAuditEventBody(audit.AuditEvents, "brand_cloud_user_assigned") {
+		t.Fatalf("expected brand cloud user audit events, got %+v", audit.AuditEvents)
+	}
+}
+
 func TestIntegrationACLAdminWorkflow(t *testing.T) {
 	env := newIntegrationEnv(t)
 	admin := registerUser(t, env.router, "acl-admin@example.com", "ACL Admin Org")
@@ -2494,9 +2594,10 @@ func TestIntegrationProvisioningEndpoints(t *testing.T) {
 		"video_cloud_devid": "video-device-1",
 		"activity_id":       "activity-1",
 		"clip_public_key":   "clip-key-1",
+		"operation_id":      "member-provision-op-1",
 	}, member.Tokens.AccessToken)
-	if memberProvisionRes.Code != http.StatusForbidden {
-		t.Fatalf("expected member provision 403, got %d", memberProvisionRes.Code)
+	if memberProvisionRes.Code != http.StatusCreated {
+		t.Fatalf("expected member provision 201, got %d: %s", memberProvisionRes.Code, memberProvisionRes.Body.String())
 	}
 
 	rawClaimRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provision", map[string]any{
@@ -3465,8 +3566,8 @@ func TestIntegrationDeactivateEndpointUsesProjectedVideoMetadata(t *testing.T) {
 	memberDeactivateRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/deactivate", map[string]any{
 		"operation_id": "member-deactivate-op-1",
 	}, member.Tokens.AccessToken)
-	if memberDeactivateRes.Code != http.StatusForbidden {
-		t.Fatalf("expected member deactivate 403, got %d", memberDeactivateRes.Code)
+	if memberDeactivateRes.Code != http.StatusCreated {
+		t.Fatalf("expected member deactivate 201, got %d: %s", memberDeactivateRes.Code, memberDeactivateRes.Body.String())
 	}
 
 	outsiderDeactivateRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/deactivate", map[string]any{
@@ -3835,6 +3936,22 @@ type brandCloudsBody struct {
 	Pagination paginationBody `json:"pagination"`
 }
 
+type brandCloudUserBody struct {
+	Action string `json:"action"`
+	User   struct {
+		ID                        string     `json:"id"`
+		Email                     string     `json:"email"`
+		DisplayName               *string    `json:"display_name"`
+		EmailVerified             bool       `json:"email_verified"`
+		SignupPendingVerification bool       `json:"signup_pending_verification"`
+		DisabledAt                *time.Time `json:"disabled_at"`
+	} `json:"user"`
+	Member struct {
+		UserID string `json:"user_id"`
+		Role   string `json:"role"`
+	} `json:"member"`
+}
+
 type quotaRaiseRequestBody struct {
 	QuotaRaiseRequest struct {
 		ID             string `json:"id"`
@@ -4165,6 +4282,19 @@ func assertOIDCStateStoredAsHash(t *testing.T, db *pgxpool.Pool, state, nonce st
 }
 
 func hasAuditEvent(events []model.AuditEvent, eventType string) bool {
+	for _, event := range events {
+		if event.EventType == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAuditEventBody(events []struct {
+	ID          string `json:"id"`
+	EventType   string `json:"event_type"`
+	SubjectType string `json:"subject_type"`
+}, eventType string) bool {
 	for _, event := range events {
 		if event.EventType == eventType {
 			return true

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -175,6 +175,13 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 		"role":    "owner",
 	}, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudBody.BrandCloud.ID+"/members", brandCloudMemberRes)
+	brandCloudUserRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudBody.BrandCloud.ID+"/users", map[string]any{
+		"email":        "contract-brand-user@example.com",
+		"password":     "password123",
+		"display_name": "Contract Brand User",
+		"role":         "member",
+	}, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudBody.BrandCloud.ID+"/users", brandCloudUserRes)
 	adminClaimTokensRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/admin/device-claim-tokens", adminClaimTokensRes)
 	adminClaimTokenGetRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID, nil, admin.Tokens.AccessToken)

--- a/internal/store/brand_clouds.go
+++ b/internal/store/brand_clouds.go
@@ -217,6 +217,95 @@ func (s *Store) AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, 
 	return member, nil
 }
 
+func (s *Store) CreateBrandCloudUser(ctx context.Context, actorUserID, orgID string, in BrandCloudUserInput) (BrandCloudUserResult, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return BrandCloudUserResult{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var exists bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM organizations
+			WHERE id = $1 AND organization_kind = 'brand_cloud'
+		)
+	`, orgID).Scan(&exists); err != nil {
+		return BrandCloudUserResult{}, err
+	}
+	if !exists {
+		return BrandCloudUserResult{}, ErrNotFound
+	}
+
+	email := strings.ToLower(strings.TrimSpace(in.Email))
+	var existingID string
+	err = tx.QueryRow(ctx, `SELECT id::text FROM users WHERE email = $1`, email).Scan(&existingID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return BrandCloudUserResult{}, err
+	}
+	action := "assigned"
+	if errors.Is(err, pgx.ErrNoRows) {
+		action = "created"
+	}
+
+	var user model.User
+	err = tx.QueryRow(ctx, `
+		INSERT INTO users (email, password_hash, display_name, email_verified, email_verified_at, signup_pending_verification, disabled_at)
+		VALUES ($1, $2, $3, true, now(), false, NULL)
+		ON CONFLICT (email)
+		DO UPDATE SET
+			password_hash = CASE WHEN $4 THEN EXCLUDED.password_hash ELSE users.password_hash END,
+			display_name = COALESCE(EXCLUDED.display_name, users.display_name),
+			email_verified = true,
+			email_verified_at = COALESCE(users.email_verified_at, now()),
+			signup_pending_verification = false,
+			disabled_at = NULL,
+			updated_at = now()
+		RETURNING id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+	`, email, in.PasswordHash, in.DisplayName, in.RotatePassword).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	if err != nil {
+		return BrandCloudUserResult{}, err
+	}
+
+	member, err := scanMember(tx.QueryRow(ctx, `
+		INSERT INTO organization_members (organization_id, user_id, role)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (organization_id, user_id)
+		DO UPDATE SET role = EXCLUDED.role, updated_at = now()
+		RETURNING organization_id::text, user_id::text, role, created_at, updated_at
+	`, orgID, user.ID, in.Role))
+	if err != nil {
+		return BrandCloudUserResult{}, err
+	}
+	member.Email = user.Email
+	member.DisplayName = user.DisplayName
+	member.DisabledAt = user.DisabledAt
+
+	eventType := "brand_cloud_user_assigned"
+	if action == "created" {
+		eventType = "brand_cloud_user_created"
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      eventType,
+		ActorUserID:    &actorUserID,
+		OrganizationID: &orgID,
+		SubjectType:    "brand_cloud",
+		SubjectID:      orgID,
+		Payload: map[string]any{
+			"user_id":         user.ID,
+			"email":           user.Email,
+			"role":            member.Role,
+			"rotate_password": in.RotatePassword,
+		},
+	}); err != nil {
+		return BrandCloudUserResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return BrandCloudUserResult{}, err
+	}
+	return BrandCloudUserResult{Action: action, User: user, Member: member}, nil
+}
+
 func (s *Store) countBrandClouds(ctx context.Context) (int, error) {
 	var total int
 	err := s.db.QueryRow(ctx, `

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -57,6 +57,20 @@ type BrandCloudInput struct {
 	Metadata map[string]any
 }
 
+type BrandCloudUserInput struct {
+	Email          string
+	PasswordHash   string
+	DisplayName    *string
+	Role           model.Role
+	RotatePassword bool
+}
+
+type BrandCloudUserResult struct {
+	Action string       `json:"action"`
+	User   model.User   `json:"user"`
+	Member model.Member `json:"member"`
+}
+
 type MemberPage struct {
 	Members []model.Member
 	Page    Page

--- a/migrations/017_acl_seed.sql
+++ b/migrations/017_acl_seed.sql
@@ -87,6 +87,8 @@ WITH role_permission_names(role_name, permission_name) AS (
     ('member', 'registry_device.read'),
     ('member', 'device_group.read'),
     ('member', 'device_tag.read'),
+    ('member', 'lifecycle_operation.provision'),
+    ('member', 'lifecycle_operation.deactivate'),
     ('member', 'lifecycle_operation.inspect'),
     ('member', 'quota_request.create'),
 

--- a/migrations/020_member_lifecycle_permissions.sql
+++ b/migrations/020_member_lifecycle_permissions.sql
@@ -1,0 +1,11 @@
+WITH role_permission_names(role_name, permission_name) AS (
+    VALUES
+    ('member', 'lifecycle_operation.provision'),
+    ('member', 'lifecycle_operation.deactivate')
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM role_permission_names rpm
+JOIN roles r ON r.name = rpm.role_name AND r.disabled_at IS NULL
+JOIN permissions p ON p.name = rpm.permission_name
+ON CONFLICT DO NOTHING;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -675,6 +675,40 @@ paths:
           $ref: "#/components/responses/Error"
         "404":
           $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Create or activate a user and assign them to a brand cloud.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BrandCloudUserRequest"
+      responses:
+        "200":
+          description: Existing brand cloud user activated or assigned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudUserResponse"
+        "201":
+          description: Brand cloud user created and assigned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudUserResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
   /v1/admin/audit-events:
     get:
       security:
@@ -2748,6 +2782,23 @@ components:
           format: uuid
         role:
           $ref: "#/components/schemas/Role"
+    BrandCloudUserRequest:
+      type: object
+      required: [email, password, role]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+        display_name:
+          type: string
+        role:
+          $ref: "#/components/schemas/Role"
+        rotate_password:
+          type: boolean
+          default: false
     AddMemberRequest:
       type: object
       required: [email, role]
@@ -3040,6 +3091,17 @@ components:
       properties:
         brand_cloud:
           $ref: "#/components/schemas/Organization"
+    BrandCloudUserResponse:
+      type: object
+      required: [action, user, member]
+      properties:
+        action:
+          type: string
+          enum: [created, assigned]
+        user:
+          $ref: "#/components/schemas/User"
+        member:
+          $ref: "#/components/schemas/Member"
     BrandCloudsResponse:
       type: object
       required: [brand_clouds, pagination]


### PR DESCRIPTION
## Summary
- Add `POST /v1/admin/brand-clouds/{brandCloudId}/users` for platform-admin creation/reactivation of verified brand users.
- Make user upsert idempotent, keep existing passwords unless `rotate_password=true`, and audit created/assigned actions.
- Grant organization `member` users lifecycle provision/deactivate permissions, including a forward migration for existing DBs.
- Update OpenAPI and integration coverage.

## Validation
- `go test ./... -count=1`
