### PR TITLE
Document device user unprovision API semantics

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -698,6 +698,7 @@ All endpoints are versioned under `/v1`.
 | `POST` | `/v1/admin/device-claim-tokens/:tokenId/revoke` | Yes | Platform admin | Revoke an unused or already claimed Claim Token. |
 | `POST` | `/v1/admin/device-claim-tokens/:tokenId/reclaim` | Yes | Platform admin | Reclaim a claimed token/device after support or factory-reset evidence. |
 | `POST` | `/v1/admin/device-claims/:claimId/transfer` | Yes | Platform admin | Transfer a resolved claim/token/device to another organization after operator evidence. |
+| `POST` | `/v1/admin/devices/:deviceId/unprovision` | Yes | Platform admin | Planned support override to release a normal device from its current user/org binding after reason, evidence, and audit. |
 | `POST` | `/v1/admin/identity-providers` | Yes | Platform admin | Create an OIDC identity provider configuration without exposing raw secrets. |
 | `GET` | `/v1/admin/identity-providers` | Yes | Platform admin | List OIDC identity provider configurations without raw secrets. |
 | `GET` | `/v1/admin/identity-providers/:providerId` | Yes | Platform admin | Show one OIDC identity provider configuration without raw secrets. |
@@ -747,6 +748,7 @@ Fleet registry APIs are selection primitives only. Account manager owns group, t
 | `POST` | `/v1/orgs/:orgId/devices/:deviceId/provision` | Yes | `owner`, `admin`, `member` | Create or reuse a provisioning operation and enqueue `DeviceProvisionRequested`. |
 | `GET` | `/v1/orgs/:orgId/devices/:deviceId/provisioning` | Yes | `owner`, `admin`, `member` | Return latest provisioning operation, account-side readiness projection, and projected video metadata. |
 | `POST` | `/v1/orgs/:orgId/devices/:deviceId/deactivate` | Yes | `owner`, `admin`, `member` | Create or reuse a deactivation operation and enqueue `DeviceDeactivateRequested`. |
+| `POST` | `/v1/orgs/:orgId/devices/:deviceId/unprovision` | Yes | `owner`, `admin`, `member` | Planned user-facing release of a normal device from the current user/org binding for resale or re-onboarding. |
 | `POST` | `/v1/orgs/:orgId/devices/claim/resolve` | Yes | `owner`, `admin`, `member` | Resolve an opaque Claim Token into an organization-owned registry device and provisioning input. |
 
 Provision request body:
@@ -886,6 +888,50 @@ Ownership consequences:
   does not transfer ownership, factory-reset the product, or enqueue product
   teardown.
 
+User unprovision / factory-ready resale policy:
+
+User unprovision is a planned self-service lifecycle distinct from
+deactivation, soft-disable, transfer, and reclaim. Account manager owns the
+user/org/device binding release policy. The normal user-facing endpoint is:
+
+```http
+POST /v1/orgs/:orgId/devices/:deviceId/unprovision
+```
+
+`owner`, `admin`, and `member` users may request unprovision for a device in
+their own active organization scope. The endpoint validates organization
+membership, device ownership, and the `device:unprovision` or equivalent
+permission before releasing the current user/org binding. After success, the
+previous user must no longer be able to list, inspect, provision, deactivate,
+command, stream, or otherwise operate that device through the released
+organization scope.
+
+Unprovision keeps the factory identity, factory certificate, canonical
+`service_options`, and entitlement facts intact. It does not revoke or denylist
+the device, does not imply compromise, and does not authorize service access for
+the next owner until that owner completes possession proof, claim/bind, and a
+new device activation/provisioning flow.
+
+The platform-admin support override endpoint is planned as:
+
+```http
+POST /v1/admin/devices/:deviceId/unprovision
+```
+
+This override is for support, return, repair, dispute, or customer-care cases.
+It must require `platform_admin`, an explicit `reason`, non-empty `evidence`,
+actor attribution, before/after ownership facts, and an audit event. It must
+not expose raw Claim Token values, raw claim material, device private material,
+or any secret that lets an operator impersonate the device or the next owner.
+
+Existing lifecycle routes must not be used as unprovision substitutes:
+
+- `POST .../deactivate` is for security, hardware failure, compromise,
+  intrusion, or product teardown paths that remove device cloud-service access.
+- `DELETE /v1/orgs/:orgId/devices/:deviceId` is account-registry
+  soft-disable only. It does not release factory identity, claim ownership, or
+  user/org binding for resale.
+
 Claim transfer, reclaim, and factory-reset policy:
 
 - Already-claimed Claim Tokens remain rejected by `POST
@@ -1005,6 +1051,9 @@ Provisioning rules:
 - Registry soft-delete does not transfer ownership, release claim material, or
   prove product-level deactivation. Product teardown requires `POST
   .../deactivate` and a terminal video-side deactivation result.
+- User unprovision is a separate planned lifecycle. It releases the current
+  user/org binding for a normal resale or re-onboarding path, and it must not be
+  implemented by `POST .../deactivate` or `DELETE /devices/:deviceId`.
 - Omitting the deactivation `reason` defaults the outbox payload to `account_device_disabled`.
 - Reusing an explicit `operation_id` returns the existing operation when the normalized request matches and returns `409 Conflict` when it does not.
 - Operation responses may also include `error_code`, `error_message`, `retryable`, and `completed_at` once the inbox projection records a terminal result.
@@ -1152,7 +1201,10 @@ vocabulary as follows:
 
 The shared states `claim_pending` and `local_onboarding_pending` remain outside
 the current account-manager projection until this repository owns durable
-source facts for those phases.
+source facts for those phases. A future user-unprovision implementation should
+add an explicit resale or factory-ready state rather than overloading
+`deactivated`, because unprovision does not remove factory identity, revoke the
+device certificate, or denylist device cloud access.
 
 Account-side readiness states:
 
@@ -1416,6 +1468,7 @@ Current verified behavior:
 Remaining post-v2 follow-up items:
 
 - Implement the documented transfer, reclaim, and factory-reset policy for already-claimed devices.
+- Implement the documented user unprovision lifecycle with org-scoped member/admin/owner API, platform-admin override API, `device:unprovision` permissions, audit events, and readiness/product-state projection that does not reuse `deactivated`.
 - Retry and dead-letter rows are inspectable in Postgres, and `cmd/lifecycle-admin` exposes list, inspect, and safe requeue workflows for operators. A future operational visibility surface should summarize queue health, dead-letter counts, and latency without requiring direct SQL.
 - Account registry soft-delete and product-level video deactivation remain separate. Product teardown requires explicit `POST /deactivate`; `DELETE /devices/:deviceId` only disables the account-side registry record.
 - Account manager exposes an account-side readiness projection on `GET /provisioning`, but it still does not own a final cross-service "product ready" boolean. Any future unified readiness surface must compose account record, device activation, service-options ACL enforcement, subject-bound token issuance, device info/config, and transport ownership across service boundaries.


### PR DESCRIPTION
## Summary
- document planned user-facing and platform-admin unprovision APIs
- define Account Manager ownership of user/org/device binding release policy
- state that deactivate and DELETE device are not valid unprovision substitutes
- update contracts submodule to hkt999rtk/rtk_cloud_contracts_doc#46

## Verification
- git diff --check HEAD~1..HEAD

Depends on hkt999rtk/rtk_cloud_contracts_doc#46