### PR TITLE
Expose Account Manager Prometheus metrics

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -221,6 +221,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestIntegrationOwnerCanUpdateOrganization`
 - `rtk_account_manager/internal/api`: `TestIntegrationPlatformAdminBrandCloudLifecycle`
 - `rtk_account_manager/internal/api`: `TestIntegrationPlatformAdminCreatesActiveBrandCloudUser`
+- `rtk_account_manager/internal/api`: `TestIntegrationPrometheusMetricsReportsEmptySnapshot`
 - `rtk_account_manager/internal/api`: `TestIntegrationProvisioningEndpoints`
 - `rtk_account_manager/internal/api`: `TestIntegrationProvisioningStateReturnsRegistryOnlyReadiness`
 - `rtk_account_manager/internal/api`: `TestIntegrationQuotaRaiseValidationAndDefaultApproval`
@@ -245,6 +246,8 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestOIDCGroupsFromClaimsShapes/unsupported`
 - `rtk_account_manager/internal/api`: `TestOIDCGroupsFromClaimsShapes`
 - `rtk_account_manager/internal/api`: `TestPaginationClampsAndDefaultsValues`
+- `rtk_account_manager/internal/api`: `TestPrometheusMetricHelpersFormatLabelsDeterministically`
+- `rtk_account_manager/internal/api`: `TestPrometheusMetricsRoute`
 - `rtk_account_manager/internal/api`: `TestReadinessFromProjectionStates/accepted_provisioning_waits_for_activation`
 - `rtk_account_manager/internal/api`: `TestReadinessFromProjectionStates/activation_failure_stays_visible`
 - `rtk_account_manager/internal/api`: `TestReadinessFromProjectionStates/activation_succeeded_and_online_is_ready`
@@ -273,6 +276,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestWriteClaimResolveErrorIncludesRetryability/quota_exceeded`
 - `rtk_account_manager/internal/api`: `TestWriteClaimResolveErrorIncludesRetryability/service_unavailable`
 - `rtk_account_manager/internal/api`: `TestWriteClaimResolveErrorIncludesRetryability`
+- `rtk_account_manager/internal/api`: `TestWriteStatusMetricsSortsStatuses`
 - `rtk_account_manager/internal/auth`: `TestExpiredAndWrongSecretTokensFailParsing`
 - `rtk_account_manager/internal/auth`: `TestOIDCClientAuthorizationURL`
 - `rtk_account_manager/internal/auth`: `TestOIDCClientDiscoverRejectsBadDiscoveryResponses/bad_json`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -290,6 +290,7 @@ func (s *Server) recoveryLogger() gin.HandlerFunc {
 func (s *Server) Router() *gin.Engine {
 	r := gin.New()
 	r.Use(s.requestLogger(), s.recoveryLogger())
+	r.GET("/metrics/prometheus", s.prometheusMetrics)
 
 	v1 := r.Group("/v1")
 	v1.GET("/health", func(c *gin.Context) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -82,6 +82,45 @@ func TestPrometheusMetricsRoute(t *testing.T) {
 	}
 }
 
+func TestPrometheusMetricHelpersFormatLabelsDeterministically(t *testing.T) {
+	var b strings.Builder
+
+	writeMetricHelp(&b, "rtk_account_manager_test_total", "Test metric.")
+	writeMetricType(&b, "rtk_account_manager_test_total", "counter")
+	writeMetric(&b, "rtk_account_manager_test_total", map[string]string{
+		"status": "quoted \"value\"",
+		"queue":  "line\\one\nline two",
+	}, 42)
+
+	want := strings.Join([]string{
+		"# HELP rtk_account_manager_test_total Test metric.",
+		"# TYPE rtk_account_manager_test_total counter",
+		`rtk_account_manager_test_total{queue="line\\one\nline two",status="quoted \"value\""} 42`,
+		"",
+	}, "\n")
+	if got := b.String(); got != want {
+		t.Fatalf("unexpected metric output:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestWriteStatusMetricsSortsStatuses(t *testing.T) {
+	var b strings.Builder
+
+	writeStatusMetrics(&b, "rtk_account_manager_lifecycle_messages", "outbox", map[string]int64{
+		"published": 2,
+		"pending":   1,
+	})
+
+	want := strings.Join([]string{
+		`rtk_account_manager_lifecycle_messages{queue="outbox",status="pending"} 1`,
+		`rtk_account_manager_lifecycle_messages{queue="outbox",status="published"} 2`,
+		"",
+	}, "\n")
+	if got := b.String(); got != want {
+		t.Fatalf("unexpected status metric output:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestHealthRequestEmitsStructuredLog(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core).With(

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -63,6 +63,25 @@ func TestHealthRoute(t *testing.T) {
 	}
 }
 
+func TestPrometheusMetricsRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := New(nil, nil).Router()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics/prometheus", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected metrics 200, got %d: %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); !strings.Contains(got, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", got)
+	}
+	if !strings.Contains(res.Body.String(), "rtk_account_manager_up 1") {
+		t.Fatalf("expected up metric, got:\n%s", res.Body.String())
+	}
+}
+
 func TestHealthRequestEmitsStructuredLog(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core).With(

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -954,6 +955,35 @@ func TestIntegrationAdminMetricsReportsEmptySnapshot(t *testing.T) {
 	}
 	if metricsBody.Lifecycle.Outbox.ByStatus == nil || metricsBody.Lifecycle.Inbox.ByStatus == nil || metricsBody.Lifecycle.Operations.ByStatus == nil {
 		t.Fatalf("expected lifecycle maps in empty metrics response, got %+v", metricsBody.Lifecycle)
+	}
+}
+
+func TestIntegrationPrometheusMetricsReportsEmptySnapshot(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics/prometheus", nil)
+	res := httptest.NewRecorder()
+	env.router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected prometheus metrics 200, got %d: %s", res.Code, res.Body.String())
+	}
+	if got := res.Header().Get("Content-Type"); !strings.Contains(got, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", got)
+	}
+	body := res.Body.String()
+	for _, want := range []string{
+		"rtk_account_manager_up 1\n",
+		`rtk_account_manager_eval_signups_total{tier="evaluation"} 0` + "\n",
+		`rtk_account_manager_eval_signups_total{tier="commercial"} 0` + "\n",
+		"rtk_account_manager_email_verification_completed_total 0\n",
+		`rtk_account_manager_quota_raise_requests{status="pending"} 0` + "\n",
+		`rtk_account_manager_quota_raise_requests{status="approved"} 0` + "\n",
+		`rtk_account_manager_quota_raise_requests{status="declined"} 0` + "\n",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected prometheus body to contain %q, got:\n%s", want, body)
+		}
 	}
 }
 

--- a/internal/api/prometheus_metrics.go
+++ b/internal/api/prometheus_metrics.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) prometheusMetrics(c *gin.Context) {
+	c.Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	var b strings.Builder
+	writeMetricHelp(&b, "rtk_account_manager_up", "Whether the Account Manager app is serving metrics.")
+	writeMetricType(&b, "rtk_account_manager_up", "gauge")
+	writeMetric(&b, "rtk_account_manager_up", nil, 1)
+
+	if s.store == nil {
+		c.String(http.StatusOK, b.String())
+		return
+	}
+
+	ctx := c.Request.Context()
+	evalCreated, commercialCreated, err := s.store.CountEvaluationSignupEvents(ctx)
+	if err != nil {
+		c.String(http.StatusInternalServerError, b.String())
+		return
+	}
+	verificationCompleted, err := s.store.CountEmailVerificationEventsFromSignup(ctx)
+	if err != nil {
+		c.String(http.StatusInternalServerError, b.String())
+		return
+	}
+	pending, approved, declined, err := s.store.CountQuotaRaiseRequestStatuses(ctx)
+	if err != nil {
+		c.String(http.StatusInternalServerError, b.String())
+		return
+	}
+	lifecycleMetrics, err := s.store.GetLifecycleMetrics(ctx)
+	if err != nil {
+		c.String(http.StatusInternalServerError, b.String())
+		return
+	}
+
+	writeMetricHelp(&b, "rtk_account_manager_eval_signups_total", "Account Manager signup events by organization tier.")
+	writeMetricType(&b, "rtk_account_manager_eval_signups_total", "counter")
+	writeMetric(&b, "rtk_account_manager_eval_signups_total", map[string]string{"tier": "evaluation"}, evalCreated)
+	writeMetric(&b, "rtk_account_manager_eval_signups_total", map[string]string{"tier": "commercial"}, commercialCreated)
+
+	writeMetricHelp(&b, "rtk_account_manager_email_verification_completed_total", "Email verification completions for signup flows.")
+	writeMetricType(&b, "rtk_account_manager_email_verification_completed_total", "counter")
+	writeMetric(&b, "rtk_account_manager_email_verification_completed_total", nil, verificationCompleted)
+
+	writeMetricHelp(&b, "rtk_account_manager_quota_raise_requests", "Quota raise requests by status.")
+	writeMetricType(&b, "rtk_account_manager_quota_raise_requests", "gauge")
+	writeMetric(&b, "rtk_account_manager_quota_raise_requests", map[string]string{"status": "pending"}, pending)
+	writeMetric(&b, "rtk_account_manager_quota_raise_requests", map[string]string{"status": "approved"}, approved)
+	writeMetric(&b, "rtk_account_manager_quota_raise_requests", map[string]string{"status": "declined"}, declined)
+
+	writeMetricHelp(&b, "rtk_account_manager_lifecycle_messages", "Lifecycle message counts by queue and status.")
+	writeMetricType(&b, "rtk_account_manager_lifecycle_messages", "gauge")
+	writeStatusMetrics(&b, "rtk_account_manager_lifecycle_messages", "outbox", lifecycleMetrics.Outbox.ByStatus)
+	writeStatusMetrics(&b, "rtk_account_manager_lifecycle_messages", "inbox", lifecycleMetrics.Inbox.ByStatus)
+
+	writeMetricHelp(&b, "rtk_account_manager_lifecycle_operations", "Lifecycle operation counts by type and status.")
+	writeMetricType(&b, "rtk_account_manager_lifecycle_operations", "gauge")
+	for _, count := range lifecycleMetrics.Operations.ByTypeAndStatus {
+		writeMetric(&b, "rtk_account_manager_lifecycle_operations", map[string]string{
+			"type":   count.OperationType,
+			"status": count.Status,
+		}, count.Count)
+	}
+
+	c.String(http.StatusOK, b.String())
+}
+
+func writeStatusMetrics(b *strings.Builder, name, queue string, counts map[string]int64) {
+	statuses := make([]string, 0, len(counts))
+	for status := range counts {
+		statuses = append(statuses, status)
+	}
+	sort.Strings(statuses)
+	for _, status := range statuses {
+		writeMetric(b, name, map[string]string{"queue": queue, "status": status}, counts[status])
+	}
+}
+
+func writeMetricHelp(b *strings.Builder, name, help string) {
+	_, _ = fmt.Fprintf(b, "# HELP %s %s\n", name, help)
+}
+
+func writeMetricType(b *strings.Builder, name, typ string) {
+	_, _ = fmt.Fprintf(b, "# TYPE %s %s\n", name, typ)
+}
+
+func writeMetric(b *strings.Builder, name string, labels map[string]string, value int64) {
+	_, _ = fmt.Fprint(b, name)
+	if len(labels) > 0 {
+		keys := make([]string, 0, len(labels))
+		for key := range labels {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		_, _ = fmt.Fprint(b, "{")
+		for i, key := range keys {
+			if i > 0 {
+				_, _ = fmt.Fprint(b, ",")
+			}
+			_, _ = fmt.Fprintf(b, `%s="%s"`, key, prometheusLabelValue(labels[key]))
+		}
+		_, _ = fmt.Fprint(b, "}")
+	}
+	_, _ = fmt.Fprintf(b, " %d\n", value)
+}
+
+func prometheusLabelValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}

--- a/linode_deploy/README.md
+++ b/linode_deploy/README.md
@@ -20,13 +20,17 @@ See [`docs/RUNBOOK.md`](docs/RUNBOOK.md).
 internet
   -> account-manager.video-cloud-staging.realtekconnect.com:443
   -> nginx on Account Manager VM
-  -> rtk_account_manager on 127.0.0.1:18081
+  -> rtk_account_manager on :18081
   -> local PostgreSQL on 127.0.0.1:5432
+
+Video Cloud Prometheus
+  -> account-manager private VPC IP :18081 /metrics/prometheus
 ```
 
-The Account Manager VM is independent from the `rtk_video_cloud` VPC. It does
-not join the Video Cloud private network and does not use the Video Cloud edge
-VM as a gateway. Other services should call it through public HTTPS.
+The Account Manager VM remains an independently deployed public service for API
+traffic. It also exposes the app port on its private VPC interface for central
+Prometheus scraping; other services should continue to call it through public
+HTTPS unless a specific private integration is documented.
 
 ## Public VM Files
 

--- a/linode_deploy/docs/RUNBOOK.md
+++ b/linode_deploy/docs/RUNBOOK.md
@@ -36,7 +36,8 @@ Remote VM target:
 - install prefix: `/opt/rtk-account-manager`
 - env file: `/etc/rtk-account-manager/account-manager.env`
 - state dir: `/var/lib/rtk-account-manager`
-- API bind: `127.0.0.1:18081` behind nginx
+- API bind: `:18081`; public nginx proxies through loopback and central
+  Prometheus scrapes `/metrics/prometheus` over the private VPC IP
 - PostgreSQL: local database `rtk_account_manager`
 
 ## Deploy
@@ -87,6 +88,14 @@ verifier reads `ACCOUNT_MANAGER_VERIFY_PLATFORM_ADMIN_EMAIL` and
 `ACCOUNT_MANAGER_BOOTSTRAP_PLATFORM_ADMIN_EMAIL` and
 `ACCOUNT_MANAGER_BOOTSTRAP_PLATFORM_ADMIN_PASSWORD` when those are already
 loaded for deployment bootstrap.
+
+## Observability
+
+The API serves Prometheus text metrics at `GET /metrics/prometheus`. This
+endpoint is intended for private Prometheus scraping by the central Video Cloud
+observability stack on the private VPC IP and app port. Public nginx returns
+404 for this path; public verification should continue to use `GET /v1/health`
+and authenticated API smoke checks.
 
 ```sh
 set -a

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -300,6 +300,10 @@ server {
         default_type text/plain;
     }
 
+    location = /metrics/prometheus {
+        return 404;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:$port;
         proxy_http_version 1.1;
@@ -390,6 +394,10 @@ server {
     location ^~ /.well-known/acme-challenge/ {
         alias /var/www/certbot/.well-known/acme-challenge/;
         default_type text/plain;
+    }
+
+    location = /metrics/prometheus {
+        return 404;
     }
 
     location / {

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -62,6 +62,7 @@ if [ -z "$node_exporter_listen_addr" ]; then
     node_exporter_listen_addr="127.0.0.1:9100"
   fi
 fi
+printf '[account-manager-deploy] node exporter listen address: %s\n' "$node_exporter_listen_addr" >&2
 [ -n "$certbot_email" ] || [ "$certbot_enable" = 0 ] || die "ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL is required when certbot is enabled"
 if [ -n "$cert_cache_dir" ]; then
   [ -s "$cert_cache_dir/fullchain.pem" ] || die "cached certificate fullchain not found: $cert_cache_dir/fullchain.pem"
@@ -88,7 +89,7 @@ else
   printf '[account-manager-deploy] building Linux release %s\n' "$release" >&2
   (
     cd "$root_dir"
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 VERSION="$release" make release >/dev/null
+    GOWORK=off GOOS=linux GOARCH=amd64 CGO_ENABLED=0 VERSION="$release" make release >/dev/null
   )
   cp "$root_dir/dist/rtk_account_manager-${release}.tar.gz" "$bundle"
 fi
@@ -271,7 +272,17 @@ systemctl daemon-reload
 systemctl enable --now prometheus-node-exporter
 systemctl restart prometheus-node-exporter
 systemctl is-active prometheus-node-exporter
-ss -lnt | grep "$node_exporter_listen_addr"
+for _ in $(seq 1 10); do
+  if ss -lnt | grep -F "$node_exporter_listen_addr" >/dev/null; then
+    node_exporter_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "${node_exporter_ready:-0}" != "1" ]; then
+  ss -lnt >&2 || true
+  exit 1
+fi
 systemctl start rtk-account-manager-migrate.service
 systemctl enable --now rtk-account-manager-cleanup-tokens.timer
 systemctl enable --now rtk-account-manager.service
@@ -300,8 +311,7 @@ server {
 }
 NGINX
 ln -sf /etc/nginx/sites-available/rtk-account-manager.conf /etc/nginx/sites-enabled/rtk-account-manager.conf
-ln -sf /etc/nginx/sites-available/rtk-account-manager.conf /etc/nginx/conf.d/rtk-account-manager.conf
-rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
+rm -f /etc/nginx/conf.d/rtk-account-manager.conf /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
 nginx -t
 systemctl reload nginx
 

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -26,6 +26,7 @@ certbot_email="${ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL:-}"
 ssh_user="${ACCOUNT_MANAGER_LINODE_SSH_USER:-root}"
 ssh_key="${ACCOUNT_MANAGER_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"
 host="${ACCOUNT_MANAGER_LINODE_HOST:-${ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4:-}}"
+node_exporter_listen_addr="${ACCOUNT_MANAGER_PROMETHEUS_NODE_EXPORTER_LISTEN_ADDR:-}"
 remote_bundle="${ACCOUNT_MANAGER_LINODE_REMOTE_BUNDLE:-/tmp/rtk-account-manager-${release}.tar.gz}"
 artifact_dir="${ACCOUNT_MANAGER_LINODE_ARTIFACT_DIR:-$root_dir/.artifacts/linode-account-manager-deploy/$release}"
 release_bundle="${ACCOUNT_MANAGER_LINODE_RELEASE_BUNDLE:-}"
@@ -54,6 +55,13 @@ need tar
 need openssl
 [ -n "$host" ] || die "ACCOUNT_MANAGER_LINODE_HOST or ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4 is required"
 [ -s "$ssh_key" ] || die "SSH key not found: $ssh_key"
+if [ -z "$node_exporter_listen_addr" ]; then
+  if [ -n "${ACCOUNT_MANAGER_LINODE_PRIVATE_IPV4:-}" ]; then
+    node_exporter_listen_addr="$ACCOUNT_MANAGER_LINODE_PRIVATE_IPV4:9100"
+  else
+    node_exporter_listen_addr="127.0.0.1:9100"
+  fi
+fi
 [ -n "$certbot_email" ] || [ "$certbot_enable" = 0 ] || die "ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL is required when certbot is enabled"
 if [ -n "$cert_cache_dir" ]; then
   [ -s "$cert_cache_dir/fullchain.pem" ] || die "cached certificate fullchain not found: $cert_cache_dir/fullchain.pem"
@@ -145,7 +153,7 @@ if [ -n "$cert_cache_dir" ]; then
 fi
 
 printf '[account-manager-deploy] installing runtime on %s\n' "$remote" >&2
-ssh "${ssh_opts[@]}" "$remote" bash -s -- "$remote_bundle" "$release" "$domain" "$certbot_email" "$certbot_enable" "$http_only" "$port" "$db_name" "$db_user" "$db_password" "$cert_cache_dir" <<'REMOTE'
+ssh "${ssh_opts[@]}" "$remote" bash -s -- "$remote_bundle" "$release" "$domain" "$certbot_email" "$certbot_enable" "$http_only" "$port" "$db_name" "$db_user" "$db_password" "$cert_cache_dir" "$node_exporter_listen_addr" <<'REMOTE'
 set -euo pipefail
 remote_bundle="$1"
 release="$2"
@@ -158,10 +166,12 @@ db_name="$8"
 db_user="$9"
 db_password="${10}"
 cert_cache_dir="${11:-}"
+node_exporter_listen_addr="${12:-127.0.0.1:9100}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y ca-certificates curl gnupg2 lsb-release ubuntu-keyring postgresql postgresql-contrib systemd tar
+apt-get install -y ca-certificates curl gnupg2 lsb-release ubuntu-keyring postgresql postgresql-contrib systemd tar prometheus-node-exporter
+printf 'ARGS="--web.listen-address=%s"\n' "$node_exporter_listen_addr" > /etc/default/prometheus-node-exporter
 curl -fsS https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg.tmp
 mv /usr/share/keyrings/nginx-archive-keyring.gpg.tmp /usr/share/keyrings/nginx-archive-keyring.gpg
 printf 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu %s nginx\n' "$(lsb_release -cs)" > /etc/apt/sources.list.d/nginx-org.list
@@ -258,6 +268,10 @@ cp /tmp/rtk-account-manager-deploy/account-manager.env /tmp/rtk-account-manager-
 install -m 0600 -o root -g root /tmp/rtk-account-manager-deploy/account-manager.env /etc/rtk-account-manager/account-manager.env
 
 systemctl daemon-reload
+systemctl enable --now prometheus-node-exporter
+systemctl restart prometheus-node-exporter
+systemctl is-active prometheus-node-exporter
+ss -lnt | grep "$node_exporter_listen_addr"
 systemctl start rtk-account-manager-migrate.service
 systemctl enable --now rtk-account-manager-cleanup-tokens.timer
 systemctl enable --now rtk-account-manager.service


### PR DESCRIPTION
## Summary
- add /metrics/prometheus for Account Manager runtime metrics
- deny the metrics path on the public nginx surface
- update Linode deployment docs and runbook

## Validation
- GOWORK=off go test ./...