### PR TITLE
Refactor API persistence boundary

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -246,6 +246,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestOIDCGroupsFromClaimsShapes/unsupported`
 - `rtk_account_manager/internal/api`: `TestOIDCGroupsFromClaimsShapes`
 - `rtk_account_manager/internal/api`: `TestPaginationClampsAndDefaultsValues`
+- `rtk_account_manager/internal/api`: `TestPostgresStoreSatisfiesAPIPersistenceBoundaries`
 - `rtk_account_manager/internal/api`: `TestPrometheusMetricHelpersFormatLabelsDeterministically`
 - `rtk_account_manager/internal/api`: `TestPrometheusMetricsRoute`
 - `rtk_account_manager/internal/api`: `TestReadinessFromProjectionStates/accepted_provisioning_waits_for_activation`
@@ -496,6 +497,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestStartDeviceLifecycleOperationPersistsPendingProvisionMetadata`
 - `rtk_account_manager/internal/store`: `TestUserIdentityStoreEnforcesUniquenessAndListsByUser`
 - `rtk_account_manager/internal/store`: `TestValidatePartitionKeyMatchesOperationSkipsBlankValues`
+- `rtk_account_manager/internal/worker/inbox`: `TestPostgresStoreSatisfiesInboxMessageStore`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceDeadLettersInvalidMessages`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceDeadLettersInvalidPartitionKeysAfterPersistingInboxRow/blank_partition_key_is_normalized_for_storage_and_dead-lettered`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceDeadLettersInvalidPartitionKeysAfterPersistingInboxRow/nonblank_mismatched_partition_key_dead-letters`
@@ -525,6 +527,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceSkipsPreviouslyProcessedDuplicates`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunOnceUsesWorkerClockWhenEnvelopeTimeIsMissing`
 - `rtk_account_manager/internal/worker/inbox`: `TestRunRetriesTransientReceiveErrors`
+- `rtk_account_manager/internal/worker/outbox`: `TestPostgresStoreSatisfiesOutboxMessageStore`
 - `rtk_account_manager/internal/worker/outbox`: `TestRunOnceDeadLettersExhaustedPublishFailures`
 - `rtk_account_manager/internal/worker/outbox`: `TestRunOnceDeadLettersInvalidOutboxPayload`
 - `rtk_account_manager/internal/worker/outbox`: `TestRunOnceIgnoresConflictWhenRetryLosesToPublished`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Server struct {
-	store                      *store.Store
+	store                      Store
 	auth                       *auth.Service
 	authTokenSink              AuthTokenSink
 	quotaRaiseNotificationSink QuotaRaiseNotificationSink
@@ -38,7 +38,7 @@ type Server struct {
 
 var ErrAuthTokenSinkUnavailable = errors.New("auth token sink unavailable")
 
-func newServer(store *store.Store, authService *auth.Service, sink AuthTokenSink) *Server {
+func newServer(store Store, authService *auth.Service, sink AuthTokenSink) *Server {
 	return &Server{
 		store:         store,
 		auth:          authService,
@@ -49,7 +49,7 @@ func newServer(store *store.Store, authService *auth.Service, sink AuthTokenSink
 	}
 }
 
-func New(store *store.Store, authService *auth.Service) *Server {
+func New(store Store, authService *auth.Service) *Server {
 	return newServer(store, authService, nil)
 }
 
@@ -117,7 +117,7 @@ func (s LogAuthTokenSink) DeliverAuthToken(_ context.Context, delivery AuthToken
 	return nil
 }
 
-func NewWithAuthTokenSink(store *store.Store, authService *auth.Service, sink AuthTokenSink) *Server {
+func NewWithAuthTokenSink(store Store, authService *auth.Service, sink AuthTokenSink) *Server {
 	return newServer(store, authService, sink)
 }
 
@@ -223,7 +223,7 @@ func buildSMTPMessage(from, to, subject, body string) []byte {
 	return b.Bytes()
 }
 
-func NewWithAuthTokenAndNotificationSink(store *store.Store, authService *auth.Service, authSink AuthTokenSink, notificationSink QuotaRaiseNotificationSink) *Server {
+func NewWithAuthTokenAndNotificationSink(store Store, authService *auth.Service, authSink AuthTokenSink, notificationSink QuotaRaiseNotificationSink) *Server {
 	server := newServer(store, authService, authSink)
 	server.quotaRaiseNotificationSink = notificationSink
 	return server

--- a/internal/api/persistence.go
+++ b/internal/api/persistence.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type Store interface {
+	authPersistence
+	userPersistence
+	organizationPersistence
+	memberPersistence
+	devicePersistence
+	deviceGroupPersistence
+	deviceTagPersistence
+	provisioningPersistence
+	deviceClaimPersistence
+	metricsPersistence
+	evaluationPersistence
+	aclPersistence
+	identityProviderPersistence
+	brandCloudPersistence
+	auditPersistence
+}
+
+type authPersistence interface {
+	Register(context.Context, store.RegisterInput) (store.RegisterResult, error)
+	GetUserPassword(ctx context.Context, email string) (model.User, string, error)
+	GetUserPasswordByID(ctx context.Context, userID string) (model.User, string, error)
+	CreateEmailVerificationToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
+	CreatePasswordResetToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
+	CreatePasswordResetTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error)
+	CreateEmailVerificationTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error)
+	VerifyEmailToken(ctx context.Context, tokenHash string) (model.User, error)
+	ResetPasswordWithToken(ctx context.Context, tokenHash, passwordHash string) error
+	UpdateUserPassword(ctx context.Context, userID, passwordHash string) error
+	SaveRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
+	RotateRefreshToken(ctx context.Context, oldTokenHash, newTokenHash, userID string, newExpiresAt time.Time) error
+	RevokeRefreshToken(ctx context.Context, tokenHash string) error
+}
+
+type userPersistence interface {
+	GetUser(ctx context.Context, userID string) (model.User, error)
+	GetUserByEmail(ctx context.Context, email string) (model.User, error)
+	DisableCurrentUser(ctx context.Context, userID string) error
+}
+
+type organizationPersistence interface {
+	ListOrganizations(ctx context.Context, userID string, limit, offset int) (store.OrganizationPage, error)
+	CreateOrganization(ctx context.Context, userID, name string) (model.Organization, error)
+	GetOrganization(ctx context.Context, orgID, userID string) (model.Organization, error)
+	UpdateOrganization(ctx context.Context, orgID, userID, name string) (model.Organization, error)
+}
+
+type memberPersistence interface {
+	GetRole(ctx context.Context, orgID, userID string) (model.Role, error)
+	ListMembers(ctx context.Context, orgID string, limit, offset int) (store.MemberPage, error)
+	AddMember(ctx context.Context, orgID, email string, role model.Role) (model.Member, error)
+	UpdateMemberRole(ctx context.Context, orgID, userID string, role model.Role) (model.Member, error)
+	DisableMemberUser(ctx context.Context, orgID, userID string) (model.Member, error)
+	EnableMemberUser(ctx context.Context, orgID, userID string) (model.Member, error)
+	RemoveMember(ctx context.Context, orgID, userID string) error
+}
+
+type devicePersistence interface {
+	CreateDevice(ctx context.Context, orgID string, in store.DeviceInput) (model.Device, error)
+	ListDevices(ctx context.Context, orgID string, limit, offset int) (store.DevicePage, error)
+	GetDevice(ctx context.Context, orgID, deviceID string) (model.Device, error)
+	UpdateDevice(ctx context.Context, orgID, deviceID string, in store.DeviceInput) (model.Device, error)
+	DeleteDevice(ctx context.Context, orgID, deviceID string) error
+	UpdateDeviceStatus(ctx context.Context, orgID, deviceID string, status model.DeviceStatus, lastSeenAt *time.Time) (model.Device, error)
+}
+
+type deviceGroupPersistence interface {
+	CreateDeviceGroup(ctx context.Context, orgID string, in store.DeviceGroupInput) (model.DeviceGroup, error)
+	ListDeviceGroups(ctx context.Context, orgID string, limit, offset int) (store.DeviceGroupPage, error)
+	GetDeviceGroup(ctx context.Context, orgID, groupID string) (model.DeviceGroup, error)
+	UpdateDeviceGroup(ctx context.Context, orgID, groupID string, in store.DeviceGroupInput) (model.DeviceGroup, error)
+	DeleteDeviceGroup(ctx context.Context, orgID, groupID string) error
+	AddDeviceToGroup(ctx context.Context, orgID, groupID, deviceID string) error
+	RemoveDeviceFromGroup(ctx context.Context, orgID, groupID, deviceID string) error
+	ListDeviceGroupDevices(ctx context.Context, orgID, groupID string, limit, offset int) (store.DevicePage, error)
+}
+
+type deviceTagPersistence interface {
+	AddDeviceTag(ctx context.Context, orgID, deviceID, tag string) (model.DeviceTag, error)
+	DeleteDeviceTag(ctx context.Context, orgID, deviceID, tag string) error
+	ListDeviceTags(ctx context.Context, orgID, deviceID string, limit, offset int) (store.DeviceTagPage, error)
+}
+
+type provisioningPersistence interface {
+	StartDeviceLifecycleOperation(ctx context.Context, in store.DeviceLifecycleOperationInput) (store.DeviceLifecycleOperationResult, error)
+	StartDeviceDeactivationOperation(ctx context.Context, in store.DeviceDeactivationOperationInput) (store.DeviceLifecycleOperationResult, error)
+	GetDeviceOperation(ctx context.Context, operationID string) (model.DeviceOperation, error)
+	GetLatestDeviceOperationByType(ctx context.Context, orgID, deviceID string, operationType model.DeviceOperationType) (model.DeviceOperation, error)
+	GetLatestOutboxMessageByOperationID(ctx context.Context, operationID string) (model.DeviceMessageOutbox, error)
+	UnprovisionDevice(ctx context.Context, in store.DeviceUnprovisionInput) (store.DeviceUnprovisionResult, error)
+}
+
+type deviceClaimPersistence interface {
+	CreateDeviceClaimToken(ctx context.Context, in store.DeviceClaimTokenCreateInput) (model.DeviceClaimToken, error)
+	ListDeviceClaimTokens(ctx context.Context, in store.DeviceClaimTokenListFilter) (store.DeviceClaimTokenPage, error)
+	GetDeviceClaimToken(ctx context.Context, tokenID string) (model.DeviceClaimToken, error)
+	RevokeDeviceClaimToken(ctx context.Context, tokenID string, now time.Time) (model.DeviceClaimToken, error)
+	ResolveDeviceClaimToken(ctx context.Context, in store.DeviceClaimResolveInput) (store.DeviceClaimResolveResult, error)
+	TransferDeviceClaim(ctx context.Context, in store.DeviceClaimTransferInput) (store.DeviceClaimOverrideResult, error)
+	ReclaimDeviceClaimToken(ctx context.Context, in store.DeviceClaimReclaimInput) (store.DeviceClaimOverrideResult, error)
+}
+
+type metricsPersistence interface {
+	CountEvaluationSignupEvents(ctx context.Context) (evaluation int64, commercial int64, err error)
+	CountEmailVerificationEventsFromSignup(ctx context.Context) (int64, error)
+	CountQuotaRaiseRequestStatuses(ctx context.Context) (pending, approved, declined int64, err error)
+	ListEvaluationQuotaUsage(ctx context.Context) ([]store.EvaluationQuotaUsage, error)
+	GetLifecycleMetrics(ctx context.Context) (store.LifecycleMetrics, error)
+}
+
+type evaluationPersistence interface {
+	IsPlatformAdmin(ctx context.Context, userID string) (bool, error)
+	CreateQuotaRaiseRequest(ctx context.Context, in store.QuotaRaiseRequestInput) (model.QuotaRaiseRequest, error)
+	GetQuotaRaiseRequest(ctx context.Context, requestID string) (model.QuotaRaiseRequest, error)
+	ListQuotaRaiseRequests(ctx context.Context, in store.QuotaRaiseRequestListFilter) (store.QuotaRaiseRequestPage, error)
+	DecideQuotaRaiseRequest(ctx context.Context, in store.QuotaRaiseDecisionInput) (model.QuotaRaiseRequest, model.Organization, model.User, error)
+}
+
+type aclPersistence interface {
+	HasPermission(ctx context.Context, userID, orgID, permission string) (bool, error)
+	ListPermissions(ctx context.Context, limit, offset int) (store.PermissionPage, error)
+	GetRoleByName(ctx context.Context, name string) (model.ProductRole, error)
+	UpdateRole(ctx context.Context, in store.RoleUpdateInput) (model.ProductRole, error)
+	DisableRole(ctx context.Context, name string, actorUserID *string) error
+	ListRoles(ctx context.Context, limit, offset int) (store.ProductRolePage, error)
+	CreateRole(ctx context.Context, in store.RoleCreateInput) (model.ProductRole, error)
+	BindRolePermission(ctx context.Context, roleName, permissionName string, actorUserID *string) error
+	CreateRoleAssignment(ctx context.Context, in store.RoleAssignmentCreateInput) (model.RoleAssignment, error)
+	ListRoleAssignments(ctx context.Context, limit, offset int) (store.RoleAssignmentPage, error)
+	DisableRoleAssignment(ctx context.Context, assignmentID string, actorUserID *string) error
+	CreateExternalGroupMapping(ctx context.Context, in store.ExternalGroupMappingCreateInput) (model.ExternalGroupMapping, error)
+	ListExternalGroupMappings(ctx context.Context, limit, offset int) (store.ExternalGroupMappingPage, error)
+	DisableExternalGroupMapping(ctx context.Context, mappingID string, actorUserID *string) error
+	ApplyExternalGroupMappings(ctx context.Context, userID, providerID string, groups []string, now time.Time) error
+	ListACLAuditEvents(ctx context.Context, in store.ACLAuditEventListFilter) (store.ACLAuditEventPage, error)
+}
+
+type identityProviderPersistence interface {
+	CreateIdentityProvider(ctx context.Context, in store.IdentityProviderCreateInput) (model.IdentityProvider, error)
+	ListIdentityProviders(ctx context.Context, in store.IdentityProviderListFilter) (store.IdentityProviderPage, error)
+	GetIdentityProviderByProviderID(ctx context.Context, providerID string) (model.IdentityProvider, error)
+	GetEnabledIdentityProvider(ctx context.Context) (model.IdentityProvider, error)
+	UpdateIdentityProvider(ctx context.Context, in store.IdentityProviderUpdateInput) (model.IdentityProvider, error)
+	DisableIdentityProvider(ctx context.Context, providerID string, now time.Time) (model.IdentityProvider, error)
+	CreateUserIdentity(ctx context.Context, in store.UserIdentityCreateInput) (model.UserIdentity, error)
+	ListUserIdentities(ctx context.Context, userID string) ([]model.UserIdentity, error)
+	GetUserIdentityByProviderSubject(ctx context.Context, providerID, subject string) (model.UserIdentity, error)
+	UpdateUserIdentityLastLogin(ctx context.Context, identityID string, lastLoginAt time.Time) (model.UserIdentity, error)
+	DeleteUserIdentity(ctx context.Context, userID, identityID string) error
+	CreateOIDCLoginState(ctx context.Context, in store.OIDCLoginStateCreateInput) (model.OIDCLoginState, error)
+	ConsumeOIDCLoginState(ctx context.Context, stateHash string, now time.Time) (model.OIDCLoginState, error)
+}
+
+type brandCloudPersistence interface {
+	CreateBrandCloud(ctx context.Context, actorUserID string, in store.BrandCloudInput) (model.Organization, error)
+	ListBrandClouds(ctx context.Context, limit, offset int) (store.OrganizationPage, error)
+	GetBrandCloud(ctx context.Context, orgID string) (model.Organization, error)
+	UpdateBrandCloud(ctx context.Context, actorUserID, orgID string, in store.BrandCloudInput) (model.Organization, error)
+	AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, userID string, role model.Role) (model.Member, error)
+	CreateBrandCloudUser(ctx context.Context, actorUserID, orgID string, in store.BrandCloudUserInput) (store.BrandCloudUserResult, error)
+}
+
+type auditPersistence interface {
+	CreateAuditEvent(ctx context.Context, in store.AuditEventInput) error
+	ListAuditEvents(ctx context.Context, in store.AuditEventListFilter) (store.AuditEventPage, error)
+}

--- a/internal/api/persistence_test.go
+++ b/internal/api/persistence_test.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"testing"
+
+	"rtk_account_manager/internal/store"
+)
+
+func TestPostgresStoreSatisfiesAPIPersistenceBoundaries(t *testing.T) {
+	var _ Store = (*store.Store)(nil)
+}

--- a/internal/worker/inbox/persistence_test.go
+++ b/internal/worker/inbox/persistence_test.go
@@ -1,0 +1,11 @@
+package inbox
+
+import (
+	"testing"
+
+	"rtk_account_manager/internal/store"
+)
+
+func TestPostgresStoreSatisfiesInboxMessageStore(t *testing.T) {
+	var _ messageStore = (*store.Store)(nil)
+}

--- a/internal/worker/outbox/persistence_test.go
+++ b/internal/worker/outbox/persistence_test.go
@@ -1,0 +1,11 @@
+package outbox
+
+import (
+	"testing"
+
+	"rtk_account_manager/internal/store"
+)
+
+func TestPostgresStoreSatisfiesOutboxMessageStore(t *testing.T) {
+	var _ messageStore = (*store.Store)(nil)
+}


### PR DESCRIPTION
## Summary
- Add API-owned persistence interfaces grouped by auth/session, users/orgs, devices, provisioning, metrics, ACL, OIDC/admin, brand-cloud, and audit surfaces.
- Change API server constructors to accept the API persistence interface instead of concrete `*store.Store` while keeping `internal/store.Store` as the durable Postgres adapter.
- Add compile-time checks that `*store.Store` satisfies the API boundary and the existing inbox/outbox worker message-store interfaces.

Closes #201

## Verification
- `go test ./internal/api ./internal/auth ./internal/worker/inbox ./internal/worker/outbox`
- `go test ./...`
- `make build`
- `TEST_DATABASE_URL='postgres://rtk:rtk_password@localhost:55432/rtk_account_manager?sslmode=disable' go test ./...`

Note: `make db-up` on the default port failed because an existing `rtk-ci-fix-account-manager-postgres-1` container already owns `localhost:5432`. Running against that existing database exposed stale schema constraints for unprovision message types despite `schema_migrations` recording migration 022. A clean throwaway Postgres on port 55432 passed the full database-backed suite.
