### PR TITLE
[codex] Wire Account Manager log level deploy env

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -429,16 +429,16 @@ func TestHTTPAppCertificateIssuerIssuesAndReportsErrors(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "issuer_down"}})
 			return
 		}
-		_ = json.NewEncoder(w).Encode(AppCertificateIssueResponse{
-			RequestID:           req["request_id"].(string),
-			UserID:              req["user_id"].(string),
-			Subject:             "app-user:" + req["user_id"].(string),
-			SerialNumber:        "42",
-			NotBefore:           now,
-			NotAfter:            now.Add(time.Hour),
-			CertificatePEM:      generateTestCertificate("app-user:"+req["user_id"].(string), now, now.Add(time.Hour)),
-			CertificateChainPEM: "chain",
-			IssuedAt:            now,
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"request_id":            req["request_id"].(string),
+			"user_id":               req["user_id"].(string),
+			"subject":               "app-user:" + req["user_id"].(string),
+			"serial_number":         "42",
+			"not_before":            now,
+			"not_after":             now.Add(time.Hour),
+			"certificate_pem":       generateTestCertificate("app-user:"+req["user_id"].(string), now, now.Add(time.Hour)),
+			"certificate_chain_pem": "chain",
+			"issued_at":             now,
 		})
 	}))
 	defer server.Close()

--- a/internal/api/app_certificates.go
+++ b/internal/api/app_certificates.go
@@ -30,15 +30,15 @@ type AppCertificateIssueRequest struct {
 }
 
 type AppCertificateIssueResponse struct {
-	RequestID           string
-	UserID              string
-	Subject             string
-	SerialNumber        string
-	NotBefore           time.Time
-	NotAfter            time.Time
-	CertificatePEM      string
-	CertificateChainPEM string
-	IssuedAt            time.Time
+	RequestID           string    `json:"request_id"`
+	UserID              string    `json:"user_id"`
+	Subject             string    `json:"subject"`
+	SerialNumber        string    `json:"serial_number"`
+	NotBefore           time.Time `json:"not_before"`
+	NotAfter            time.Time `json:"not_after"`
+	CertificatePEM      string    `json:"certificate_pem"`
+	CertificateChainPEM string    `json:"certificate_chain_pem"`
+	IssuedAt            time.Time `json:"issued_at"`
 }
 
 type appCertificateResponse struct {

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -38,6 +38,13 @@ port="${ACCOUNT_MANAGER_PORT:-18081}"
 db_name="${ACCOUNT_MANAGER_POSTGRES_DB:-rtk_account_manager}"
 db_user="${ACCOUNT_MANAGER_POSTGRES_USER:-rtk_account_manager}"
 db_password="${ACCOUNT_MANAGER_POSTGRES_PASSWORD:-}"
+app_cert_issuer_base_url="${APP_CERT_ISSUER_BASE_URL:-}"
+app_cert_issuer_client_cert="${APP_CERT_ISSUER_CLIENT_CERT:-/etc/rtk-account-manager/certissuer-client.pem}"
+app_cert_issuer_client_key="${APP_CERT_ISSUER_CLIENT_KEY:-/etc/rtk-account-manager/certissuer-client-key.pem}"
+app_cert_issuer_ca_file="${APP_CERT_ISSUER_CA_FILE:-/etc/rtk-account-manager/certissuer-ca.pem}"
+app_cert_issuer_client_cert_source="${APP_CERT_ISSUER_CLIENT_CERT_SOURCE:-}"
+app_cert_issuer_client_key_source="${APP_CERT_ISSUER_CLIENT_KEY_SOURCE:-}"
+app_cert_issuer_ca_source="${APP_CERT_ISSUER_CA_SOURCE:-}"
 
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required"; }
@@ -77,6 +84,11 @@ fi
 if [ -z "$db_password" ]; then
   db_password="$(openssl rand -hex 32)"
   printf '[account-manager-deploy] generated local PostgreSQL password for this deploy\n' >&2
+fi
+if [ -n "$app_cert_issuer_base_url" ]; then
+  [ -s "$app_cert_issuer_client_cert_source" ] || die "APP_CERT_ISSUER_CLIENT_CERT_SOURCE is required when APP_CERT_ISSUER_BASE_URL is set"
+  [ -s "$app_cert_issuer_client_key_source" ] || die "APP_CERT_ISSUER_CLIENT_KEY_SOURCE is required when APP_CERT_ISSUER_BASE_URL is set"
+  [ -s "$app_cert_issuer_ca_source" ] || die "APP_CERT_ISSUER_CA_SOURCE is required when APP_CERT_ISSUER_BASE_URL is set"
 fi
 
 database_url="postgres://${db_user}:${db_password}@127.0.0.1:5432/${db_name}?sslmode=disable"
@@ -139,6 +151,11 @@ trap cleanup EXIT
   printf 'CROSS_SERVICE_POLL_INTERVAL=%s\n' "${CROSS_SERVICE_POLL_INTERVAL:-5s}"
   printf 'AZURE_EVENTHUB_CONNECTION_STRING=%s\n' "${AZURE_EVENTHUB_CONNECTION_STRING:-}"
   printf 'AZURE_EVENTHUB_CHECKPOINT_FILE=%s\n' "${AZURE_EVENTHUB_CHECKPOINT_FILE:-/var/lib/rtk-account-manager/azure_eventhubs_checkpoint.json}"
+  printf 'APP_CERT_ISSUER_BASE_URL=%s\n' "$app_cert_issuer_base_url"
+  printf 'APP_CERT_ISSUER_CLIENT_CERT=%s\n' "$app_cert_issuer_client_cert"
+  printf 'APP_CERT_ISSUER_CLIENT_KEY=%s\n' "$app_cert_issuer_client_key"
+  printf 'APP_CERT_ISSUER_CA_FILE=%s\n' "$app_cert_issuer_ca_file"
+  printf 'APP_CERT_ISSUER_TIMEOUT=%s\n' "${APP_CERT_ISSUER_TIMEOUT:-10s}"
 } > "$tmp_env"
 chmod 0600 "$tmp_env"
 
@@ -151,6 +168,13 @@ if [ -n "$cert_cache_dir" ]; then
   ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy/cert-cache"
   scp "${ssh_opts[@]}" "$cert_cache_dir/fullchain.pem" "$remote:/tmp/rtk-account-manager-deploy/cert-cache/fullchain.pem"
   scp "${ssh_opts[@]}" "$cert_cache_dir/privkey.pem" "$remote:/tmp/rtk-account-manager-deploy/cert-cache/privkey.pem"
+fi
+if [ -n "$app_cert_issuer_base_url" ]; then
+  printf '[account-manager-deploy] uploading app certissuer client credentials\n' >&2
+  ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy/app-cert-issuer"
+  scp "${ssh_opts[@]}" "$app_cert_issuer_client_cert_source" "$remote:/tmp/rtk-account-manager-deploy/app-cert-issuer/client.pem"
+  scp "${ssh_opts[@]}" "$app_cert_issuer_client_key_source" "$remote:/tmp/rtk-account-manager-deploy/app-cert-issuer/client-key.pem"
+  scp "${ssh_opts[@]}" "$app_cert_issuer_ca_source" "$remote:/tmp/rtk-account-manager-deploy/app-cert-issuer/ca.pem"
 fi
 
 printf '[account-manager-deploy] installing runtime on %s\n' "$remote" >&2
@@ -267,6 +291,13 @@ tar --warning=no-unknown-keyword -xzf "$remote_bundle" -C /tmp/rtk-account-manag
 cp /tmp/rtk-account-manager-deploy/account-manager.env /tmp/rtk-account-manager-release/deploy/account-manager.env.example
 (cd /tmp/rtk-account-manager-release && ./deploy/install.sh)
 install -m 0600 -o root -g root /tmp/rtk-account-manager-deploy/account-manager.env /etc/rtk-account-manager/account-manager.env
+if [ -d /tmp/rtk-account-manager-deploy/app-cert-issuer ]; then
+  chgrp rtk-account-manager /etc/rtk-account-manager
+  chmod 0750 /etc/rtk-account-manager
+  install -m 0644 -o root -g root /tmp/rtk-account-manager-deploy/app-cert-issuer/client.pem /etc/rtk-account-manager/certissuer-client.pem
+  install -m 0640 -o root -g rtk-account-manager /tmp/rtk-account-manager-deploy/app-cert-issuer/client-key.pem /etc/rtk-account-manager/certissuer-client-key.pem
+  install -m 0644 -o root -g root /tmp/rtk-account-manager-deploy/app-cert-issuer/ca.pem /etc/rtk-account-manager/certissuer-ca.pem
+fi
 
 systemctl daemon-reload
 systemctl enable --now prometheus-node-exporter

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -117,6 +117,8 @@ trap cleanup EXIT
   write_env JWT_ACCESS_SECRET
   write_env JWT_REFRESH_SECRET
   printf 'PORT=%s\n' "$port"
+  printf 'ACCOUNT_MANAGER_LOG_LEVEL=%s\n' "${ACCOUNT_MANAGER_LOG_LEVEL:-info}"
+  printf 'ACCOUNT_MANAGER_LOG_DEVELOPMENT=%s\n' "${ACCOUNT_MANAGER_LOG_DEVELOPMENT:-false}"
   printf 'ACCESS_TOKEN_TTL=%s\n' "${ACCESS_TOKEN_TTL:-15m}"
   printf 'REFRESH_TOKEN_TTL=%s\n' "${REFRESH_TOKEN_TTL:-720h}"
   printf 'AUTH_TOKEN_DELIVERY=%s\n' "${AUTH_TOKEN_DELIVERY:-log}"

--- a/linode_deploy/scripts/provision-public-vm-test.sh
+++ b/linode_deploy/scripts/provision-public-vm-test.sh
@@ -26,6 +26,8 @@ set -euo pipefail
 method="GET"
 data=""
 url=""
+output=""
+write_out=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -X)
@@ -39,6 +41,14 @@ while [ "$#" -gt 0 ]; do
       data="$2"
       shift 2
       ;;
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -w)
+      write_out="$2"
+      shift 2
+      ;;
     -*)
       shift
       ;;
@@ -50,30 +60,40 @@ while [ "$#" -gt 0 ]; do
 done
 
 mkdir -p "$RTK_TEST_CAPTURE_DIR"
+body=""
+status="200"
 case "$url" in
   */linode/instances?page_size=500)
-    printf '{"data":[]}'
+    body='{"data":[]}'
     ;;
   */networking/firewalls?page_size=500)
-    printf '{"data":[]}'
+    body='{"data":[]}'
     ;;
   */linode/instances)
     printf '%s' "$data" > "$RTK_TEST_CAPTURE_DIR/linode-create.json"
-    printf '{"id":12345,"ipv4":["203.0.113.20"]}'
+    body='{"id":12345,"ipv4":["203.0.113.20"]}'
     ;;
   */networking/firewalls)
     printf '%s' "$data" > "$RTK_TEST_CAPTURE_DIR/firewall-create.json"
-    printf '{"id":67890}'
+    body='{"id":67890}'
     ;;
   */networking/firewalls/67890/devices)
     printf '%s' "$data" > "$RTK_TEST_CAPTURE_DIR/firewall-device.json"
-    printf '{"id":67890}'
+    body='{"id":67890}'
     ;;
   *)
     printf 'unexpected curl url: %s\n' "$url" >&2
     exit 22
     ;;
 esac
+if [ -n "$output" ]; then
+  printf '%s' "$body" > "$output"
+else
+  printf '%s' "$body"
+fi
+if [ -n "$write_out" ]; then
+  printf '%s' "${write_out//\%\{http_code\}/$status}"
+fi
 FAKE_CURL
 chmod +x "$fake_bin/curl"
 

--- a/linode_deploy/scripts/provision-public-vm.sh
+++ b/linode_deploy/scripts/provision-public-vm.sh
@@ -34,16 +34,28 @@ die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required"; }
 api() {
   local method="$1" path="$2" data="${3:-}"
+  local body status tmp
+  tmp="$(mktemp)"
   if [ -n "$data" ]; then
-    curl -fsS -X "$method" "$api_base$path" \
+    status="$(curl -sS -o "$tmp" -w '%{http_code}' -X "$method" "$api_base$path" \
       -H "Authorization: Bearer $LINODE_TOKEN" \
       -H 'Content-Type: application/json' \
-      --data-binary "$data"
+      --data-binary "$data")"
   else
-    curl -fsS -X "$method" "$api_base$path" \
+    status="$(curl -sS -o "$tmp" -w '%{http_code}' -X "$method" "$api_base$path" \
       -H "Authorization: Bearer $LINODE_TOKEN" \
-      -H 'Content-Type: application/json'
+      -H 'Content-Type: application/json')"
   fi
+  body="$(cat "$tmp")"
+  rm -f "$tmp"
+  case "$status" in
+    2*) printf '%s' "$body" ;;
+    *)
+      printf 'linode api %s %s failed with HTTP %s\n' "$method" "$path" "$status" >&2
+      printf '%s\n' "$body" >&2
+      return 22
+      ;;
+  esac
 }
 
 need curl


### PR DESCRIPTION
## Summary

- write `ACCOUNT_MANAGER_LOG_LEVEL` and `ACCOUNT_MANAGER_LOG_DEVELOPMENT` into the Linode runtime env during public VM deploy
- preserve the existing runtime defaults when staging does not provide overrides

## Validation

- `GOWORK=off go test ./internal/config ./internal/logging`
- `git diff --check`
