### PR TITLE
[codex] Publish Account Manager release bundles on main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release Bundle
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- run the Account Manager Release Bundle workflow on `main` pushes as well as tags/manual dispatch
- keep the existing `ci-*` version selection path for non-tag builds

## Why
Staging deploy selects Account Manager bundles from Linode Object Storage. Main CI validated release bundles but did not publish a deployable object unless the release workflow was manually dispatched, so staging could remain on an older release even after main was green.

## Validation
- inspected Release Bundle runs and Object Storage artifact naming
- paired workspace governance coverage in the dependent workspace PR
