### PR TITLE
[codex] Remove NATS staging firewall access

### DIFF
--- a/linode_deploy/configs/account-manager-staging.yaml
+++ b/linode_deploy/configs/account-manager-staging.yaml
@@ -49,11 +49,10 @@ firewalls:
     public_tcp: ["22", "80", "443"]
     private_tcp: ["18081"]
   infra:
-    private_tcp: ["22", "5432", "4222"]
+    private_tcp: ["22", "5432"]
   account-manager:
     private_tcp: ["22", "18081"]
     private_egress_tcp: ["5432"]
-    optional_private_egress_tcp: ["4222"]
 
 deploy:
   release: v0.1.0


### PR DESCRIPTION
## Summary
- remove stale `4222` private firewall/egress entries from the Account Manager Linode staging manifest

## Why
Account Manager staging uses the local `log` broker and should not keep NATS-specific network access after NATS removal.

## Validation
- `GOWORK=off go test ./linode_deploy/internal/manifest ./linode_deploy/internal/render`
- live Account Manager was redeployed and verified with `CROSS_SERVICE_BROKER=log` and no `CROSS_SERVICE_NATS_*` env entries
