### PR TITLE
Fix staging app cert and direct provisioning bridge

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -216,6 +216,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestIntegrationEmailVerificationAndPasswordRecovery`
 - `rtk_account_manager/internal/api`: `TestIntegrationFleetGroupsAndTags`
 - `rtk_account_manager/internal/api`: `TestIntegrationInternalAppTokenAuthorization`
+- `rtk_account_manager/internal/api`: `TestIntegrationInternalDeviceProvisioningResult`
 - `rtk_account_manager/internal/api`: `TestIntegrationLastOwnerCannotBeRemovedOrDowngraded`
 - `rtk_account_manager/internal/api`: `TestIntegrationListPaginationMetadata`
 - `rtk_account_manager/internal/api`: `TestIntegrationLoginAppCertificateCSRRequired`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -320,6 +320,7 @@ func (s *Server) Router() *gin.Engine {
 	v1.POST("/brand-clouds/:tenantSlug/auth/login", s.brandCloudLogin)
 	v1.POST("/brand-clouds/:tenantSlug/auth/refresh", s.brandCloudRefresh)
 	v1.POST("/internal/app-token-authorizations", s.handleInternalAppTokenAuthorization)
+	v1.POST("/internal/device-provisioning-results", s.handleInternalDeviceProvisioningResult)
 
 	protected := v1.Group("")
 	protected.Use(s.requireAuth())

--- a/internal/api/brand_cloud_auth.go
+++ b/internal/api/brand_cloud_auth.go
@@ -24,11 +24,18 @@ func (s *Server) brandCloudLogin(c *gin.Context) {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
 		return
 	}
+	appCert, err := s.appCertificateForLogin(c.Request.Context(), result.User.ID, req.AppCSRPem)
+	if err != nil {
+		writeAppCertificateError(c, err)
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"brand_cloud":        result.BrandCloud,
 		"brand_cloud_user":   result.BrandCloudUser,
 		"brand_cloud_member": result.Member,
+		"user":               result.User,
 		"tokens":             tokens,
+		"app_certificate":    appCert,
 	})
 }
 

--- a/internal/api/brand_cloud_auth.go
+++ b/internal/api/brand_cloud_auth.go
@@ -19,7 +19,7 @@ func (s *Server) brandCloudLogin(c *gin.Context) {
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
 		return
 	}
-	tokens, err := s.issueBrandCloudTokens(c, result.BrandCloudUser.ID, result.BrandCloud.ID, valueOrEmpty(result.BrandCloud.TenantSlug))
+	tokens, err := s.issueBrandCloudTokens(c, result.User.ID, result.BrandCloudUser.ID, result.BrandCloud.ID, valueOrEmpty(result.BrandCloud.TenantSlug))
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
 		return
@@ -48,7 +48,7 @@ func (s *Server) brandCloudRefresh(c *gin.Context) {
 		return
 	}
 	claims, err := s.auth.ParseRefreshToken(req.RefreshToken)
-	if err != nil || claims.SubjectType != auth.SubjectTypeBrandCloudUser || claims.BrandCloudUserID == "" || claims.BrandCloudID == "" {
+	if err != nil || claims.SubjectType != auth.SubjectTypeBrandCloudUser || claims.UserID == "" || claims.BrandCloudUserID == "" || claims.BrandCloudID == "" {
 		writeError(c, http.StatusUnauthorized, "invalid_refresh_token", "Invalid refresh token")
 		return
 	}
@@ -56,12 +56,12 @@ func (s *Server) brandCloudRefresh(c *gin.Context) {
 		writeError(c, http.StatusUnauthorized, "invalid_refresh_token", "Invalid refresh token")
 		return
 	}
-	accessToken, accessExpiresAt, err := s.auth.IssueBrandCloudAccessToken(claims.BrandCloudUserID, claims.BrandCloudID, claims.TenantSlug)
+	accessToken, accessExpiresAt, err := s.auth.IssueBrandCloudAccessToken(claims.UserID, claims.BrandCloudUserID, claims.BrandCloudID, claims.TenantSlug)
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
 		return
 	}
-	refreshToken, refreshExpiresAt, err := s.auth.IssueBrandCloudRefreshToken(claims.BrandCloudUserID, claims.BrandCloudID, claims.TenantSlug)
+	refreshToken, refreshExpiresAt, err := s.auth.IssueBrandCloudRefreshToken(claims.UserID, claims.BrandCloudUserID, claims.BrandCloudID, claims.TenantSlug)
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
 		return
@@ -120,12 +120,12 @@ func (s *Server) brandCloudMe(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"brand_cloud": brandCloud, "brand_cloud_user": user, "brand_cloud_member": member})
 }
 
-func (s *Server) issueBrandCloudTokens(c *gin.Context, brandCloudUserID, brandCloudID, tenantSlug string) (tokenResponse, error) {
-	accessToken, accessExpiresAt, err := s.auth.IssueBrandCloudAccessToken(brandCloudUserID, brandCloudID, tenantSlug)
+func (s *Server) issueBrandCloudTokens(c *gin.Context, userID, brandCloudUserID, brandCloudID, tenantSlug string) (tokenResponse, error) {
+	accessToken, accessExpiresAt, err := s.auth.IssueBrandCloudAccessToken(userID, brandCloudUserID, brandCloudID, tenantSlug)
 	if err != nil {
 		return tokenResponse{}, err
 	}
-	refreshToken, refreshExpiresAt, err := s.auth.IssueBrandCloudRefreshToken(brandCloudUserID, brandCloudID, tenantSlug)
+	refreshToken, refreshExpiresAt, err := s.auth.IssueBrandCloudRefreshToken(userID, brandCloudUserID, brandCloudID, tenantSlug)
 	if err != nil {
 		return tokenResponse{}, err
 	}

--- a/internal/api/brand_cloud_auth_test.go
+++ b/internal/api/brand_cloud_auth_test.go
@@ -77,7 +77,7 @@ func TestBrandCloudRefreshRejectsPlatformAndWrongTenantTokens(t *testing.T) {
 		t.Fatalf("expected platform refresh token to be rejected with 401, got %d", recorder.Code)
 	}
 
-	brandRefresh, _, err := authService.IssueBrandCloudRefreshToken("brand-user-1", "brand-cloud-1", "other")
+	brandRefresh, _, err := authService.IssueBrandCloudRefreshToken("user-1", "brand-user-1", "brand-cloud-1", "other")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -399,8 +399,8 @@ func TestIntegrationInternalDeviceProvisioningResult(t *testing.T) {
 	if state.Operation == nil || state.Operation.Status != model.DeviceOperationStatusSucceeded {
 		t.Fatalf("expected succeeded operation, got %+v", state.Operation)
 	}
-	if state.Readiness.State != model.DeviceReadinessStateReady || state.Readiness.ProductState != model.ProductReadinessStateActivated {
-		t.Fatalf("expected ready activated state, got %+v", state.Readiness)
+	if state.Readiness.State != model.DeviceReadinessStateTransportPending || state.Readiness.ProductState != model.ProductReadinessStateActivated {
+		t.Fatalf("expected transport-pending activated state, got %+v", state.Readiness)
 	}
 	if got := state.VideoMetadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusActivated) {
 		t.Fatalf("expected activated metadata, got %+v", state.VideoMetadata)
@@ -415,6 +415,38 @@ func TestIntegrationInternalDeviceProvisioningResult(t *testing.T) {
 	}, "wrong-token")
 	if unauthorizedRes.Code != http.StatusUnauthorized {
 		t.Fatalf("expected wrong token 401, got %d: %s", unauthorizedRes.Code, unauthorizedRes.Body.String())
+	}
+
+	mismatchRes := performJSON(env.router, http.MethodPost, "/v1/internal/device-provisioning-results", map[string]any{
+		"operation_id":      "internal-provision-op-1",
+		"org_id":            owner.Organization.ID,
+		"account_device_id": "00000000-0000-0000-0000-000000000000",
+		"video_cloud_devid": "video-internal-provision-1",
+		"activity_id":       "activity-internal-provision-1",
+	}, "internal-provision-token")
+	if mismatchRes.Code != http.StatusConflict {
+		t.Fatalf("expected mismatch 409, got %d: %s", mismatchRes.Code, mismatchRes.Body.String())
+	}
+
+	missingOperationRes := performJSON(env.router, http.MethodPost, "/v1/internal/device-provisioning-results", map[string]any{
+		"operation_id":      "missing-internal-provision-op",
+		"org_id":            owner.Organization.ID,
+		"account_device_id": device.Device.ID,
+		"video_cloud_devid": "video-internal-provision-1",
+		"activity_id":       "activity-internal-provision-1",
+	}, "internal-provision-token")
+	if missingOperationRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing operation 404, got %d: %s", missingOperationRes.Code, missingOperationRes.Body.String())
+	}
+
+	invalidRes := performJSON(env.router, http.MethodPost, "/v1/internal/device-provisioning-results", map[string]any{
+		"operation_id":      "internal-provision-op-1",
+		"org_id":            owner.Organization.ID,
+		"account_device_id": device.Device.ID,
+		"video_cloud_devid": "video-internal-provision-1",
+	}, "internal-provision-token")
+	if invalidRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid payload 400, got %d: %s", invalidRes.Code, invalidRes.Body.String())
 	}
 }
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1488,6 +1488,24 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 	if brandLoginRes.Code != http.StatusOK {
 		t.Fatalf("expected brand-cloud login 200, got %d: %s", brandLoginRes.Code, brandLoginRes.Body.String())
 	}
+	brandLogin := decodeBody[tokenBody](t, brandLoginRes)
+	if brandLogin.AppCertificate.Status != "csr_required" {
+		t.Fatalf("brand-cloud app certificate status = %q", brandLogin.AppCertificate.Status)
+	}
+	issuer := &fakeAppCertificateIssuer{}
+	env.server.ConfigureAppCertificateIssuer(issuer)
+	brandCSRRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":       "rtk+001@users.example.com",
+		"password":    "initial-password123",
+		"app_csr_pem": generateTestCSR(t, "app-user:"+created.User.ID),
+	}, "")
+	if brandCSRRes.Code != http.StatusOK {
+		t.Fatalf("expected brand-cloud csr login 200, got %d: %s", brandCSRRes.Code, brandCSRRes.Body.String())
+	}
+	brandCSR := decodeBody[tokenBody](t, brandCSRRes)
+	if brandCSR.AppCertificate.Status != "issued" || brandCSR.AppCertificate.FingerprintSHA256 == "" {
+		t.Fatalf("brand-cloud app certificate response = %+v", brandCSR.AppCertificate)
+	}
 
 	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, created.User.ID); err != nil {
 		t.Fatal(err)

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1632,7 +1632,7 @@ func TestIntegrationBrandScopedUsersLoginAndAuthorizeByTenantSlug(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if acmeClaims.SubjectType != auth.SubjectTypeBrandCloudUser || acmeClaims.BrandCloudID != acme.BrandCloud.ID || acmeClaims.TenantSlug != "acme" || acmeClaims.BrandCloudUserID == "" {
+	if acmeClaims.SubjectType != auth.SubjectTypeBrandCloudUser || acmeClaims.UserID != acmeLogin.User.ID || acmeClaims.BrandCloudID != acme.BrandCloud.ID || acmeClaims.TenantSlug != "acme" || acmeClaims.BrandCloudUserID == "" {
 		t.Fatalf("unexpected acme access token claims: %+v", acmeClaims)
 	}
 
@@ -1648,7 +1648,7 @@ func TestIntegrationBrandScopedUsersLoginAndAuthorizeByTenantSlug(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if contosoClaims.BrandCloudUserID == acmeClaims.BrandCloudUserID || contosoClaims.BrandCloudID != contoso.BrandCloud.ID || contosoClaims.TenantSlug != "contoso" {
+	if contosoClaims.UserID != contosoLogin.User.ID || contosoClaims.BrandCloudUserID == acmeClaims.BrandCloudUserID || contosoClaims.BrandCloudID != contoso.BrandCloud.ID || contosoClaims.TenantSlug != "contoso" {
 		t.Fatalf("expected distinct contoso subject, acme=%+v contoso=%+v", acmeClaims, contosoClaims)
 	}
 
@@ -4860,6 +4860,9 @@ type brandCloudUserBody struct {
 }
 
 type brandCloudLoginBody struct {
+	User struct {
+		ID string `json:"id"`
+	} `json:"user"`
 	BrandCloudUser struct {
 		ID                        string     `json:"id"`
 		BrandCloudID              string     `json:"brand_cloud_id"`

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -357,6 +357,67 @@ func TestIntegrationInternalAppTokenAuthorization(t *testing.T) {
 	}
 }
 
+func TestIntegrationInternalDeviceProvisioningResult(t *testing.T) {
+	env := newIntegrationEnv(t)
+	env.server.ConfigureInternalAuthToken("internal-provision-token")
+	owner := registerUser(t, env.router, "internal-provision-owner@example.com", "Internal Provision Org")
+
+	deviceRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices", devicePayload("internal-provision-device", "INTERNAL-PROVISION-001"), owner.Tokens.AccessToken)
+	if deviceRes.Code != http.StatusCreated {
+		t.Fatalf("expected device create 201, got %d: %s", deviceRes.Code, deviceRes.Body.String())
+	}
+	device := decodeBody[deviceBody](t, deviceRes)
+
+	provisionRes := performJSON(env.router, http.MethodPost, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provision", map[string]any{
+		"video_cloud_devid": "video-internal-provision-1",
+		"activity_id":       "activity-internal-provision-1",
+		"clip_public_key":   "clip-internal-provision-1",
+		"operation_id":      "internal-provision-op-1",
+	}, owner.Tokens.AccessToken)
+	if provisionRes.Code != http.StatusCreated {
+		t.Fatalf("expected provision 201, got %d: %s", provisionRes.Code, provisionRes.Body.String())
+	}
+
+	activatedAt := time.Now().UTC().Truncate(time.Second)
+	resultRes := performJSON(env.router, http.MethodPost, "/v1/internal/device-provisioning-results", map[string]any{
+		"operation_id":      "internal-provision-op-1",
+		"org_id":            owner.Organization.ID,
+		"account_device_id": device.Device.ID,
+		"video_cloud_devid": "video-internal-provision-1",
+		"activity_id":       "activity-internal-provision-1",
+		"activated_at":      activatedAt.Format(time.RFC3339),
+	}, "internal-provision-token")
+	if resultRes.Code != http.StatusOK {
+		t.Fatalf("expected internal provisioning result 200, got %d: %s", resultRes.Code, resultRes.Body.String())
+	}
+
+	stateRes := performJSON(env.router, http.MethodGet, "/v1/orgs/"+owner.Organization.ID+"/devices/"+device.Device.ID+"/provisioning", nil, owner.Tokens.AccessToken)
+	if stateRes.Code != http.StatusOK {
+		t.Fatalf("expected provisioning state 200, got %d: %s", stateRes.Code, stateRes.Body.String())
+	}
+	state := decodeBody[provisioningBody](t, stateRes)
+	if state.Operation == nil || state.Operation.Status != model.DeviceOperationStatusSucceeded {
+		t.Fatalf("expected succeeded operation, got %+v", state.Operation)
+	}
+	if state.Readiness.State != model.DeviceReadinessStateReady || state.Readiness.ProductState != model.ProductReadinessStateActivated {
+		t.Fatalf("expected ready activated state, got %+v", state.Readiness)
+	}
+	if got := state.VideoMetadata[model.DeviceMetadataVideoCloudActivationStatus]; got != string(model.VideoCloudActivationStatusActivated) {
+		t.Fatalf("expected activated metadata, got %+v", state.VideoMetadata)
+	}
+
+	unauthorizedRes := performJSON(env.router, http.MethodPost, "/v1/internal/device-provisioning-results", map[string]any{
+		"operation_id":      "internal-provision-op-1",
+		"org_id":            owner.Organization.ID,
+		"account_device_id": device.Device.ID,
+		"video_cloud_devid": "video-internal-provision-1",
+		"activity_id":       "activity-internal-provision-1",
+	}, "wrong-token")
+	if unauthorizedRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected wrong token 401, got %d: %s", unauthorizedRes.Code, unauthorizedRes.Body.String())
+	}
+}
+
 func TestIntegrationOIDCProviderLoginAndCallback(t *testing.T) {
 	env := newIntegrationEnv(t)
 	fake := newAPIOIDCTestServer(t)

--- a/internal/api/internal_app_authorization.go
+++ b/internal/api/internal_app_authorization.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"strings"
@@ -16,12 +17,7 @@ type internalAppTokenAuthorizationRequest struct {
 }
 
 func (s *Server) handleInternalAppTokenAuthorization(c *gin.Context) {
-	if s.internalAuthToken == "" {
-		writeError(c, http.StatusServiceUnavailable, "internal_auth_unconfigured", "Internal authorization is not configured")
-		return
-	}
-	if !strings.EqualFold(strings.TrimSpace(c.GetHeader("Authorization")), "Bearer "+s.internalAuthToken) {
-		writeError(c, http.StatusUnauthorized, "unauthorized", "Unauthorized")
+	if !s.requireInternalAuthToken(c) {
 		return
 	}
 	var req internalAppTokenAuthorizationRequest
@@ -38,4 +34,18 @@ func (s *Server) handleInternalAppTokenAuthorization(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"authorized": true})
+}
+
+func (s *Server) requireInternalAuthToken(c *gin.Context) bool {
+	if s.internalAuthToken == "" {
+		writeError(c, http.StatusServiceUnavailable, "internal_auth_unconfigured", "Internal authorization is not configured")
+		return false
+	}
+	header := strings.TrimSpace(c.GetHeader("Authorization"))
+	expected := "Bearer " + s.internalAuthToken
+	if subtle.ConstantTimeCompare([]byte(header), []byte(expected)) != 1 {
+		writeError(c, http.StatusUnauthorized, "unauthorized", "Unauthorized")
+		return false
+	}
+	return true
 }

--- a/internal/api/internal_device_provisioning.go
+++ b/internal/api/internal_device_provisioning.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"rtk_account_manager/internal/channel"
+	"rtk_account_manager/internal/model"
+	"rtk_account_manager/internal/store"
+)
+
+type internalDeviceProvisioningResultRequest struct {
+	OperationID     string     `json:"operation_id" binding:"required"`
+	MessageID       string     `json:"message_id"`
+	CorrelationID   string     `json:"correlation_id"`
+	OrgID           string     `json:"org_id" binding:"required"`
+	AccountDeviceID string     `json:"account_device_id" binding:"required"`
+	VideoCloudDevid string     `json:"video_cloud_devid" binding:"required"`
+	ActivityID      string     `json:"activity_id" binding:"required"`
+	ActivatedAt     *time.Time `json:"activated_at"`
+}
+
+func (s *Server) handleInternalDeviceProvisioningResult(c *gin.Context) {
+	if !s.requireInternalAuthToken(c) {
+		return
+	}
+	var req internalDeviceProvisioningResultRequest
+	if !bind(c, &req) {
+		return
+	}
+	req.OperationID = strings.TrimSpace(req.OperationID)
+	req.OrgID = strings.TrimSpace(req.OrgID)
+	req.AccountDeviceID = strings.TrimSpace(req.AccountDeviceID)
+	req.VideoCloudDevid = strings.TrimSpace(req.VideoCloudDevid)
+	req.ActivityID = strings.TrimSpace(req.ActivityID)
+	req.MessageID = strings.TrimSpace(req.MessageID)
+	req.CorrelationID = strings.TrimSpace(req.CorrelationID)
+
+	operation, err := s.store.GetDeviceOperation(c.Request.Context(), req.OperationID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(c, http.StatusNotFound, "operation_not_found", "Provisioning operation was not found")
+			return
+		}
+		writeStoreError(c, err)
+		return
+	}
+	if operation.OrganizationID != req.OrgID || operation.DeviceID != req.AccountDeviceID || operation.OperationType != model.DeviceOperationTypeProvision {
+		writeError(c, http.StatusConflict, "operation_mismatch", "Provisioning result does not match operation")
+		return
+	}
+	if req.CorrelationID == "" {
+		req.CorrelationID = operation.CorrelationID
+	}
+	if req.MessageID == "" {
+		req.MessageID = "video-provision-succeeded-" + req.OperationID
+	}
+	activatedAt := time.Now().UTC()
+	if req.ActivatedAt != nil {
+		activatedAt = req.ActivatedAt.UTC()
+	}
+
+	payload := channel.DeviceProvisionSucceededPayload{
+		OrgID:           req.OrgID,
+		AccountDeviceID: req.AccountDeviceID,
+		VideoCloudDevid: req.VideoCloudDevid,
+		ActivityID:      req.ActivityID,
+		ActivatedAt:     activatedAt,
+	}
+	if err := payload.Validate(); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_provisioning_result", err.Error())
+		return
+	}
+
+	if _, _, err := s.store.CreateOrGetInboxMessage(c.Request.Context(), store.DeviceMessageInboxCreateInput{
+		MessageID:     req.MessageID,
+		OperationID:   req.OperationID,
+		CorrelationID: req.CorrelationID,
+		Stream:        string(channel.StreamVideoAccountEvents),
+		MessageType:   string(channel.MessageTypeDeviceProvisionSucceeded),
+		SchemaVersion: "1.0",
+		PartitionKey:  req.AccountDeviceID,
+		Payload: map[string]any{
+			"org_id":            payload.OrgID,
+			"account_device_id": payload.AccountDeviceID,
+			"video_cloud_devid": payload.VideoCloudDevid,
+			"activity_id":       payload.ActivityID,
+			"activated_at":      payload.ActivatedAt,
+		},
+		Status:     model.DeviceMessageInboxStatusRetrying,
+		ReceivedAt: time.Now().UTC(),
+	}); err != nil {
+		writeStoreError(c, err)
+		return
+	}
+
+	processedAt := time.Now().UTC()
+	status := model.DeviceOperationStatusSucceeded
+	projection := store.ProvisionSucceededProjection(payload)
+	result, err := s.store.RecordInboxProcessTransition(c.Request.Context(), store.InboxProcessTransitionInput{
+		MessageID:            req.MessageID,
+		MessageStatus:        model.DeviceMessageInboxStatusProcessed,
+		AttemptCount:         1,
+		ProcessedAt:          &processedAt,
+		OperationStatus:      &status,
+		OperationResult:      map[string]any{"video_cloud_devid": payload.VideoCloudDevid, "activity_id": payload.ActivityID, "activated_at": payload.ActivatedAt},
+		OperationCompletedAt: &activatedAt,
+		OrganizationID:       payload.OrgID,
+		DeviceID:             payload.AccountDeviceID,
+		Projection:           &projection,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":            "ok",
+		"operation_id":      req.OperationID,
+		"message_id":        result.Message.MessageID,
+		"org_id":            payload.OrgID,
+		"account_device_id": payload.AccountDeviceID,
+		"video_cloud_devid": payload.VideoCloudDevid,
+	})
+}

--- a/internal/api/persistence.go
+++ b/internal/api/persistence.go
@@ -109,6 +109,8 @@ type provisioningPersistence interface {
 	GetDeviceOperation(ctx context.Context, operationID string) (model.DeviceOperation, error)
 	GetLatestDeviceOperationByType(ctx context.Context, orgID, deviceID string, operationType model.DeviceOperationType) (model.DeviceOperation, error)
 	GetLatestOutboxMessageByOperationID(ctx context.Context, operationID string) (model.DeviceMessageOutbox, error)
+	CreateOrGetInboxMessage(ctx context.Context, in store.DeviceMessageInboxCreateInput) (model.DeviceMessageInbox, bool, error)
+	RecordInboxProcessTransition(ctx context.Context, in store.InboxProcessTransitionInput) (store.InboxProcessTransitionResult, error)
 	UnprovisionDevice(ctx context.Context, in store.DeviceUnprovisionInput) (store.DeviceUnprovisionResult, error)
 }
 

--- a/internal/api/provisioning.go
+++ b/internal/api/provisioning.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	"rtk_account_manager/internal/auth"
 	"rtk_account_manager/internal/channel"
@@ -234,6 +235,13 @@ func (s *Server) resolveDeviceClaim(c *gin.Context) {
 		Now:            time.Now().UTC(),
 	})
 	if err != nil {
+		s.logger.Error("device claim resolve failed",
+			zap.String("org_id", c.Param("orgId")),
+			zap.String("actor_user_id", currentUserID(c)),
+			zap.String("brand_cloud_user_id", currentBrandCloudUserID(c)),
+			zap.String("subject_type", string(currentSubjectType(c))),
+			zap.Error(err),
+		)
 		writeClaimResolveError(c, err)
 		return
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -108,12 +108,12 @@ func (s *Service) IssueRefreshToken(userID string) (string, time.Time, error) {
 	return s.issuePlatformUser(userID, TokenKindRefresh, s.refreshSecret, s.refreshSigner, s.refreshTTL)
 }
 
-func (s *Service) IssueBrandCloudAccessToken(brandCloudUserID, brandCloudID, tenantSlug string) (string, time.Time, error) {
-	return s.issueBrandCloudUser(brandCloudUserID, brandCloudID, tenantSlug, TokenKindAccess, s.accessSecret, s.accessSigner, s.accessTTL)
+func (s *Service) IssueBrandCloudAccessToken(userID, brandCloudUserID, brandCloudID, tenantSlug string) (string, time.Time, error) {
+	return s.issueBrandCloudUser(userID, brandCloudUserID, brandCloudID, tenantSlug, TokenKindAccess, s.accessSecret, s.accessSigner, s.accessTTL)
 }
 
-func (s *Service) IssueBrandCloudRefreshToken(brandCloudUserID, brandCloudID, tenantSlug string) (string, time.Time, error) {
-	return s.issueBrandCloudUser(brandCloudUserID, brandCloudID, tenantSlug, TokenKindRefresh, s.refreshSecret, s.refreshSigner, s.refreshTTL)
+func (s *Service) IssueBrandCloudRefreshToken(userID, brandCloudUserID, brandCloudID, tenantSlug string) (string, time.Time, error) {
+	return s.issueBrandCloudUser(userID, brandCloudUserID, brandCloudID, tenantSlug, TokenKindRefresh, s.refreshSecret, s.refreshSigner, s.refreshTTL)
 }
 
 func (s *Service) ParseAccessToken(tokenString string) (*Claims, error) {
@@ -131,8 +131,9 @@ func (s *Service) issuePlatformUser(userID string, kind TokenKind, secret []byte
 	}, userID, kind, secret, signer, ttl)
 }
 
-func (s *Service) issueBrandCloudUser(brandCloudUserID, brandCloudID, tenantSlug string, kind TokenKind, secret []byte, signer TokenSigner, ttl time.Duration) (string, time.Time, error) {
+func (s *Service) issueBrandCloudUser(userID, brandCloudUserID, brandCloudID, tenantSlug string, kind TokenKind, secret []byte, signer TokenSigner, ttl time.Duration) (string, time.Time, error) {
 	return s.issue(Claims{
+		UserID:           userID,
 		SubjectType:      SubjectTypeBrandCloudUser,
 		BrandCloudUserID: brandCloudUserID,
 		BrandCloudID:     brandCloudID,

--- a/internal/auth/brand_cloud_tokens_test.go
+++ b/internal/auth/brand_cloud_tokens_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrandCloudTokenClaimsCarryScopedSubject(t *testing.T) {
 	service := NewService("access-secret", "refresh-secret", time.Minute, time.Hour)
 
-	accessToken, accessExpiresAt, err := service.IssueBrandCloudAccessToken("brand-user-1", "brand-cloud-1", "acme")
+	accessToken, accessExpiresAt, err := service.IssueBrandCloudAccessToken("user-1", "brand-user-1", "brand-cloud-1", "acme")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,12 +23,12 @@ func TestBrandCloudTokenClaimsCarryScopedSubject(t *testing.T) {
 		accessClaims.BrandCloudUserID != "brand-user-1" ||
 		accessClaims.BrandCloudID != "brand-cloud-1" ||
 		accessClaims.TenantSlug != "acme" ||
-		accessClaims.UserID != "" ||
+		accessClaims.UserID != "user-1" ||
 		accessClaims.Subject != "brand_cloud_user:brand-user-1" {
 		t.Fatalf("unexpected access claims: %+v", accessClaims)
 	}
 
-	refreshToken, refreshExpiresAt, err := service.IssueBrandCloudRefreshToken("brand-user-1", "brand-cloud-1", "acme")
+	refreshToken, refreshExpiresAt, err := service.IssueBrandCloudRefreshToken("user-1", "brand-user-1", "brand-cloud-1", "acme")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestBrandCloudTokenClaimsCarryScopedSubject(t *testing.T) {
 		refreshClaims.BrandCloudUserID != "brand-user-1" ||
 		refreshClaims.BrandCloudID != "brand-cloud-1" ||
 		refreshClaims.TenantSlug != "acme" ||
-		refreshClaims.UserID != "" ||
+		refreshClaims.UserID != "user-1" ||
 		refreshClaims.Subject != "brand_cloud_user:brand-user-1" {
 		t.Fatalf("unexpected refresh claims: %+v", refreshClaims)
 	}

--- a/internal/store/brand_clouds.go
+++ b/internal/store/brand_clouds.go
@@ -392,15 +392,18 @@ func (s *Store) GetBrandCloudUserPassword(ctx context.Context, tenantSlug, email
 		SELECT
 		    o.id::text, o.name, o.tenant_slug, ''::text, o.organization_kind, o.status, o.tier, o.evaluation_device_quota, o.metadata, o.created_at, o.updated_at,
 		    bcu.id::text, bcu.brand_cloud_id::text, bcu.email, bcu.password_hash, bcu.display_name, bcu.email_verified, bcu.email_verified_at, bcu.signup_pending_verification, bcu.created_at, bcu.updated_at, bcu.disabled_at,
-		    bcm.role, bcm.created_at, bcm.updated_at
+		    bcm.role, bcm.created_at, bcm.updated_at,
+		    u.id::text, u.email, u.display_name, u.email_verified, u.email_verified_at, u.signup_pending_verification, u.created_at, u.updated_at, u.disabled_at
 		FROM organizations o
 		JOIN brand_cloud_users bcu ON bcu.brand_cloud_id = o.id
 		JOIN brand_cloud_memberships bcm ON bcm.brand_cloud_id = o.id AND bcm.brand_cloud_user_id = bcu.id
+		JOIN users u ON u.email = bcu.email
 		WHERE o.organization_kind = 'brand_cloud'
 		  AND o.status = 'active'
 		  AND o.tenant_slug = $1
 		  AND bcu.email = $2
 		  AND bcu.disabled_at IS NULL
+		  AND u.disabled_at IS NULL
 	`, normalizeTenantSlug(tenantSlug), strings.ToLower(strings.TrimSpace(email))).Scan(
 		&result.BrandCloud.ID,
 		&result.BrandCloud.Name,
@@ -427,6 +430,15 @@ func (s *Store) GetBrandCloudUserPassword(ctx context.Context, tenantSlug, email
 		&result.Member.Role,
 		&result.Member.CreatedAt,
 		&result.Member.UpdatedAt,
+		&result.User.ID,
+		&result.User.Email,
+		&result.User.DisplayName,
+		&result.User.EmailVerified,
+		&result.User.EmailVerifiedAt,
+		&result.User.SignupPendingVerification,
+		&result.User.CreatedAt,
+		&result.User.UpdatedAt,
+		&result.User.DisabledAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return BrandCloudLoginResult{}, ErrNotFound

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -79,6 +79,7 @@ type BrandCloudUserResult struct {
 
 type BrandCloudLoginResult struct {
 	BrandCloud     model.Organization     `json:"brand_cloud"`
+	User           model.User             `json:"user"`
 	BrandCloudUser model.BrandCloudUser   `json:"brand_cloud_user"`
 	Member         model.BrandCloudMember `json:"brand_cloud_member"`
 	PasswordHash   string                 `json:"-"`

--- a/linode_deploy/scripts/backup-public-postgres.sh
+++ b/linode_deploy/scripts/backup-public-postgres.sh
@@ -29,7 +29,7 @@ local_archive="$backup_dir/rtk-account-manager-db-$stamp.dump"
 [ -n "$host" ] || { echo "ACCOUNT_MANAGER_LINODE_HOST or ACCOUNT_MANAGER_LINODE_PUBLIC_IPV4 is required" >&2; exit 1; }
 [ -s "$ssh_key" ] || { echo "SSH key not found: $ssh_key" >&2; exit 1; }
 mkdir -p "$backup_dir"
-ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null)
 remote="$ssh_user@$host"
 
 ssh "${ssh_opts[@]}" "$remote" "sudo -u postgres pg_dump -Fc '$db_name' > '$remote_archive'"

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -108,7 +108,7 @@ else
   cp "$root_dir/dist/rtk_account_manager-${release}.tar.gz" "$bundle"
 fi
 
-ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null)
 remote="$ssh_user@$host"
 
 tmp_env="$(mktemp)"


### PR DESCRIPTION
## Summary
- issue brand-cloud app certificates with the global actor user id
- add an internal provisioning-result endpoint for staging without NATS
- keep contracts-doc submodule updated

## Validation
- GOWORK=off go test ./...
