### PR TITLE
[codex] Allow private Account Manager metrics scrape

### DIFF
--- a/linode_deploy/scripts/provision-public-vm.sh
+++ b/linode_deploy/scripts/provision-public-vm.sh
@@ -119,7 +119,7 @@ firewall_payload="$(jq -cn --arg label "$firewall_label" --arg cidrs "$allowed_s
       {label:"ssh", action:"ACCEPT", protocol:"TCP", ports:"22", addresses:{ipv4:($cidrs|split(","))}},
       {label:"http", action:"ACCEPT", protocol:"TCP", ports:"80", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
       {label:"https", action:"ACCEPT", protocol:"TCP", ports:"443", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
-      {label:"vpc-private-tcp", action:"ACCEPT", protocol:"TCP", ports:"18081", addresses:{ipv4:[$vpc_cidr]}}
+      {label:"vpc-private-tcp", action:"ACCEPT", protocol:"TCP", ports:"18081,9100", addresses:{ipv4:[$vpc_cidr]}}
     ],
     outbound: []
   }


### PR DESCRIPTION
## Summary
- allow Account Manager private firewall ingress on `9100` for node exporter scraping
- keep existing app metrics port `18081` on the same VPC-only rule

## Why
Platform Dashboard now reports per-server resources from Prometheus. Account Manager already runs node exporter, but staging firewalls did not allow private Prometheus scrape traffic to `9100`.

## Validation
- Live staging Prometheus target `account_manager_node` is up
- `curl http://10.42.1.50:9100/metrics` from infra succeeds
- `GOWORK=off go test ./...` was covered indirectly by affected workspace validation where applicable
