### PR TITLE
feat: add email login activation flow

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -174,6 +174,57 @@ This scope does not:
 - Auto-link an arbitrary external identity to a local user without the configured
   account-manager policy allowing that link.
 
+## 2.4 Email Sign-In And Password Recovery
+
+Account Manager supports an email activation lifecycle for Admin Console login
+and password recovery. The API is backend-only; `rtk_cloud_admin` owns the
+browser routes, local session cookie, and display states.
+
+Console user sign-in is split into two steps:
+
+1. `POST /v1/auth/sign-in` accepts an email address and, when the user is an
+   eligible platform/customer console user, creates a one-time
+   `login_activation` token.
+2. `POST /v1/auth/login/activate` consumes the one-time token and issues the
+   same access/refresh token response shape as password login.
+
+Brand-cloud users use tenant-scoped equivalents:
+
+1. `POST /v1/brand-clouds/:tenantSlug/auth/sign-in`
+2. `POST /v1/brand-clouds/:tenantSlug/auth/login/activate`
+
+The tenant slug is part of the brand-cloud authentication namespace. A brand
+activation token must succeed only for the tenant where the email has an active
+brand-cloud user and membership.
+
+Enumeration safety is mandatory. Sign-in and forgot-password request endpoints
+return `202 Accepted` for syntactically valid requests whether the email is
+unknown, disabled, pending activation, rate limited, or eligible. Raw tokens are
+never returned in HTTP responses. Delivery is handled only through the
+configured `AuthTokenSink`; the first implementation may use the existing log
+sink until SMTP or another email sink is configured. The log sink is an
+operator-only delivery adapter and records the raw token in server logs; those
+logs must be treated as sensitive operational material.
+
+`auth_tokens` stores only token hashes. Tenant-scoped login tokens also carry a
+server-side `scope` value such as `brand_cloud:<tenantSlug>`; console login,
+email verification, and password reset use the empty scope. Token purposes are:
+
+- `email_verification`: signup verification.
+- `login_activation`: email sign-in activation.
+- `password_reset`: forgot-password/reset-password activation.
+
+Forgot password uses the same email activation lifecycle:
+
+1. `POST /v1/auth/forgot-password` creates a `password_reset` token when
+   applicable and still returns `202 Accepted` for non-eligible emails.
+2. `POST /v1/auth/reset-password` consumes the token, writes the new password
+   hash, and revokes active refresh tokens.
+
+Password login remains available as a migration fallback for platform,
+customer, and brand-cloud console users. APP end users are explicitly out of
+scope for this first version and keep using `/v1/app/end-users/*`.
+
 ## 3. Core Concepts
 
 ### Organization
@@ -1377,6 +1428,11 @@ All endpoints are versioned under `/v1`.
 | `PATCH` | `/v1/admin/brand-clouds/:brandCloudId` | Yes | Platform admin | Update brand cloud name, tenant slug, status, or metadata. |
 | `POST` | `/v1/admin/brand-clouds/:brandCloudId/members` | Yes | Platform admin | Assign/update a brand-cloud membership by `brand_cloud_user_id`; legacy `user_id` is accepted only during migration. |
 | `POST` | `/v1/admin/brand-clouds/:brandCloudId/users` | Yes | Platform admin | Create/reactivate a brand-scoped user and membership; response includes legacy aliases during migration. |
+| `GET` | `/v1/admin/brand-clouds/:brandCloudId/users` | Yes | Platform admin | List brand-scoped users, including active, pending-verification, and disabled states. |
+| `POST` | `/v1/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/approve` | Yes | Platform admin | Approve a pending brand-cloud user activation and mark the brand-scoped user verified. |
+| `POST` | `/v1/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/disable` | Yes | Platform admin | Disable brand-cloud access and revoke active brand-cloud refresh tokens. |
+| `POST` | `/v1/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/enable` | Yes | Platform admin | Re-enable a disabled brand-cloud user without changing tenant scope. |
+| `DELETE` | `/v1/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId` | Yes | Platform admin | Soft-delete brand-cloud access by disabling the brand-scoped user. |
 | `POST` | `/v1/admin/quota-raise-requests/:requestId/approve` | Yes | Platform admin | Approve a pending quota raise request and apply the approved evaluation quota. |
 | `POST` | `/v1/admin/quota-raise-requests/:requestId/decline` | Yes | Platform admin | Decline a pending quota raise request with an optional decision reason. |
 | `GET` | `/v1/admin/metrics` | Yes | Platform admin | Return evaluation signup, verification, quota request, and quota utilization metrics. |
@@ -2170,6 +2226,11 @@ The brand-cloud user namespace implementation is acceptable when:
   accounts; the same email in N brand clouds becomes N brand-scoped user rows.
 - Platform-admin provisioning dual-writes to brand-cloud tables and legacy
   `users`/`organization_members` compatibility rows.
+- Platform-admin user management lists pending activation state and provides
+  explicit approve, disable, enable, and soft-delete lifecycle actions. Disable
+  and soft-delete revoke brand-cloud refresh tokens; approve clears
+  `signup_pending_verification`, sets `email_verified=true`, and keeps the
+  action auditable.
 - `/v1/auth/*` remains platform-user-only while `/v1/brand-clouds/:tenantSlug/*`
   handles brand-cloud sessions.
 - Automated tests and OpenAPI contract checks cover the new brand-cloud auth

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -215,6 +215,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestIntegrationDeviceUserUnprovisionWorkflow`
 - `rtk_account_manager/internal/api`: `TestIntegrationDisabledUserCannotManageOIDCIdentities`
 - `rtk_account_manager/internal/api`: `TestIntegrationDisabledUserCannotUseExistingTokens`
+- `rtk_account_manager/internal/api`: `TestIntegrationEmailSignInValidationPaths`
 - `rtk_account_manager/internal/api`: `TestIntegrationEmailVerificationAndPasswordRecovery`
 - `rtk_account_manager/internal/api`: `TestIntegrationFleetGroupsAndTags`
 - `rtk_account_manager/internal/api`: `TestIntegrationInternalAppTokenAuthorization`
@@ -481,6 +482,8 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestACLSeedPermissionCatalogAndSystemRoles`
 - `rtk_account_manager/internal/store`: `TestAppCertificateCreateRotatesActiveCertificate`
 - `rtk_account_manager/internal/store`: `TestApplyProjectionMetadataPreservesExistingFieldsAndClearsNil`
+- `rtk_account_manager/internal/store`: `TestBrandCloudLoginActivationTokenIsTenantScoped`
+- `rtk_account_manager/internal/store`: `TestBrandCloudStoreCRUDAndErrorPaths`
 - `rtk_account_manager/internal/store`: `TestClaimOutboxMessagesReadyLeasesRows`
 - `rtk_account_manager/internal/store`: `TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshotWithLossyUTF8`
 - `rtk_account_manager/internal/store`: `TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshot`
@@ -509,6 +512,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestListAuditEventsReturnsRecordedLifecycleEvents`
 - `rtk_account_manager/internal/store`: `TestListInboxMessagesByStatusAndShowDetail`
 - `rtk_account_manager/internal/store`: `TestListOutboxMessagesByStatusFiltersLifecycleRows`
+- `rtk_account_manager/internal/store`: `TestLoginActivationTokenLifecycleAndScope`
 - `rtk_account_manager/internal/store`: `TestMergeDeviceMetadataPreservesUnrelatedFields`
 - `rtk_account_manager/internal/store`: `TestMetadataChangedProjectionFiltersNonVideoCloudKeys`
 - `rtk_account_manager/internal/store`: `TestNormalizeTenantSlug/empty_after_normalization`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -113,8 +113,8 @@ func (s LogAuthTokenSink) DeliverAuthToken(_ context.Context, delivery AuthToken
 		"auth token delivery",
 		zap.String("purpose", delivery.Purpose),
 		zap.String("email", delivery.Email),
+		zap.String("token", delivery.Token),
 		zap.Time("expires_at", delivery.ExpiresAt.UTC()),
-		zap.Bool("token_redacted", strings.TrimSpace(delivery.Token) != ""),
 	)
 	return nil
 }
@@ -309,6 +309,8 @@ func (s *Server) Router() *gin.Engine {
 	v1.POST("/auth/register", s.register)
 	v1.POST("/auth/signup", s.signup)
 	v1.POST("/auth/login", s.login)
+	v1.POST("/auth/sign-in", s.signIn)
+	v1.POST("/auth/login/activate", s.activateLogin)
 	v1.POST("/auth/refresh", s.refresh)
 	v1.POST("/auth/verify-email", s.verifyEmail)
 	v1.POST("/auth/resend-verification", s.resendVerification)
@@ -318,6 +320,8 @@ func (s *Server) Router() *gin.Engine {
 	v1.GET("/auth/oidc/:providerId/login", s.startOIDCLogin)
 	v1.GET("/auth/oidc/:providerId/callback", s.handleOIDCCallback)
 	v1.POST("/brand-clouds/:tenantSlug/auth/login", s.brandCloudLogin)
+	v1.POST("/brand-clouds/:tenantSlug/auth/sign-in", s.brandCloudSignIn)
+	v1.POST("/brand-clouds/:tenantSlug/auth/login/activate", s.brandCloudActivateLogin)
 	v1.POST("/brand-clouds/:tenantSlug/auth/refresh", s.brandCloudRefresh)
 	v1.POST("/app/end-users/auth/login", s.appEndUserLogin)
 	v1.POST("/app/end-users/auth/refresh", s.appEndUserRefresh)
@@ -388,6 +392,11 @@ func (s *Server) Router() *gin.Engine {
 	protected.POST("/admin/brand-clouds/:brandCloudId/device-item-profiles/:profileId/disable", s.requirePlatformAdmin(), s.disableDeviceItemProfile)
 	protected.POST("/admin/brand-clouds/:brandCloudId/members", s.requirePlatformAdmin(), s.assignBrandCloudMember)
 	protected.POST("/admin/brand-clouds/:brandCloudId/users", s.requirePlatformAdmin(), s.createBrandCloudUser)
+	protected.GET("/admin/brand-clouds/:brandCloudId/users", s.requirePlatformAdmin(), s.listBrandCloudUsers)
+	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/disable", s.requirePlatformAdmin(), s.disableBrandCloudUser)
+	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/enable", s.requirePlatformAdmin(), s.enableBrandCloudUser)
+	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/approve", s.requirePlatformAdmin(), s.approveBrandCloudUser)
+	protected.DELETE("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId", s.requirePlatformAdmin(), s.deleteBrandCloudUser)
 	protected.POST("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.createDeviceClaimToken)
 	protected.GET("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.listDeviceClaimTokens)
 	protected.GET("/admin/device-claim-tokens/:tokenId", s.requirePlatformAdmin(), s.getDeviceClaimToken)
@@ -489,6 +498,58 @@ func (s *Server) login(c *gin.Context) {
 	}
 	if user.SignupPendingVerification {
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
+		return
+	}
+	tokens, err := s.issueTokens(c, user.ID)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
+		return
+	}
+	response, err := s.loginResponse(c.Request.Context(), user, tokens, req.AppCSRPem)
+	if err != nil {
+		writeAppCertificateError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func (s *Server) signIn(c *gin.Context) {
+	var req emailRequest
+	if !bind(c, &req) {
+		return
+	}
+	token, expiresAt, err := s.newAuthToken()
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue login token")
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	created, err := s.store.CreateLoginActivationTokenForEmail(c.Request.Context(), email, auth.HashToken(token), expiresAt)
+	if err != nil {
+		if errors.Is(err, store.ErrRateLimited) {
+			c.Status(http.StatusAccepted)
+			return
+		}
+		writeAuthTokenStoreError(c, err, "Could not issue login token")
+		return
+	}
+	if created {
+		_ = s.deliverAuthToken(c, email, "login_activation", token, expiresAt)
+	}
+	c.Status(http.StatusAccepted)
+}
+
+func (s *Server) activateLogin(c *gin.Context) {
+	var req authTokenRequest
+	if !bind(c, &req) {
+		return
+	}
+	if !requireNonBlank(c, "token", req.Token) {
+		return
+	}
+	user, err := s.store.ActivateLoginToken(c.Request.Context(), auth.HashToken(req.Token))
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_token", "Invalid or expired login token")
 		return
 	}
 	tokens, err := s.issueTokens(c, user.ID)
@@ -858,7 +919,8 @@ func (s *Server) refresh(c *gin.Context) {
 }
 
 type authTokenRequest struct {
-	Token string `json:"token" binding:"required"`
+	Token     string `json:"token" binding:"required"`
+	AppCSRPem string `json:"app_csr_pem,omitempty"`
 }
 
 func (s *Server) verifyEmail(c *gin.Context) {
@@ -969,6 +1031,8 @@ func (s *Server) createAuthToken(c *gin.Context, userID, purpose string) (string
 		return token, expiresAt, s.store.CreateEmailVerificationToken(c.Request.Context(), userID, tokenHash, expiresAt)
 	case "password_reset":
 		return token, expiresAt, s.store.CreatePasswordResetToken(c.Request.Context(), userID, tokenHash, expiresAt)
+	case "login_activation":
+		return token, expiresAt, s.store.CreateLoginActivationToken(c.Request.Context(), userID, tokenHash, expiresAt)
 	default:
 		return "", time.Time{}, errors.New("unsupported token purpose")
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -309,11 +309,8 @@ func TestLogAuthTokenSinkWritesDelivery(t *testing.T) {
 	if fields["purpose"] != "password_reset" || fields["email"] != "user@example.com" {
 		t.Fatalf("unexpected auth token log fields: %+v", fields)
 	}
-	if _, ok := fields["token"]; ok {
-		t.Fatalf("auth token log must not expose raw token: %+v", fields)
-	}
-	if fields["token_redacted"] != true {
-		t.Fatalf("expected token_redacted marker, got %+v", fields)
+	if fields["token"] != "reset-token" {
+		t.Fatalf("expected auth token log delivery token, got %+v", fields)
 	}
 }
 

--- a/internal/api/brand_cloud_auth.go
+++ b/internal/api/brand_cloud_auth.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 
 	"rtk_account_manager/internal/auth"
+	"rtk_account_manager/internal/store"
 )
 
 func (s *Server) brandCloudLogin(c *gin.Context) {
@@ -19,12 +21,58 @@ func (s *Server) brandCloudLogin(c *gin.Context) {
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
 		return
 	}
+	s.writeBrandCloudLoginResponse(c, req.AppCSRPem, result)
+}
+
+func (s *Server) brandCloudSignIn(c *gin.Context) {
+	var req emailRequest
+	if !bind(c, &req) {
+		return
+	}
+	token, expiresAt, err := s.newAuthToken()
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue login token")
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	created, err := s.store.CreateBrandCloudLoginActivationTokenForEmail(c.Request.Context(), c.Param("tenantSlug"), email, auth.HashToken(token), expiresAt)
+	if err != nil {
+		if errors.Is(err, store.ErrRateLimited) {
+			c.Status(http.StatusAccepted)
+			return
+		}
+		writeAuthTokenStoreError(c, err, "Could not issue login token")
+		return
+	}
+	if created {
+		_ = s.deliverAuthToken(c, email, "login_activation", token, expiresAt)
+	}
+	c.Status(http.StatusAccepted)
+}
+
+func (s *Server) brandCloudActivateLogin(c *gin.Context) {
+	var req authTokenRequest
+	if !bind(c, &req) {
+		return
+	}
+	if !requireNonBlank(c, "token", req.Token) {
+		return
+	}
+	result, err := s.store.ActivateBrandCloudLoginToken(c.Request.Context(), c.Param("tenantSlug"), auth.HashToken(req.Token))
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_token", "Invalid or expired login token")
+		return
+	}
+	s.writeBrandCloudLoginResponse(c, req.AppCSRPem, result)
+}
+
+func (s *Server) writeBrandCloudLoginResponse(c *gin.Context, appCSRPem string, result store.BrandCloudLoginResult) {
 	tokens, err := s.issueBrandCloudTokens(c, result.User.ID, result.BrandCloudUser.ID, result.BrandCloud.ID, valueOrEmpty(result.BrandCloud.TenantSlug))
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
 		return
 	}
-	appCert, err := s.appCertificateForLogin(c.Request.Context(), result.User.ID, req.AppCSRPem)
+	appCert, err := s.appCertificateForLogin(c.Request.Context(), result.User.ID, appCSRPem)
 	if err != nil {
 		writeAppCertificateError(c, err)
 		return

--- a/internal/api/brand_clouds_admin.go
+++ b/internal/api/brand_clouds_admin.go
@@ -57,6 +57,15 @@ type deviceItemProfilesResponse struct {
 	Pagination         store.Page                `json:"pagination"`
 }
 
+type brandCloudUsersResponse struct {
+	BrandCloudUsers []model.BrandCloudUser `json:"brand_cloud_users"`
+	Pagination      store.Page             `json:"pagination"`
+}
+
+type brandCloudUserResponse struct {
+	BrandCloudUser model.BrandCloudUser `json:"brand_cloud_user"`
+}
+
 func (s *Server) createBrandCloud(c *gin.Context) {
 	var req brandCloudRequest
 	if !bind(c, &req) {
@@ -322,4 +331,60 @@ func (s *Server) createBrandCloudUser(c *gin.Context) {
 		status = http.StatusCreated
 	}
 	c.JSON(status, result)
+}
+
+func (s *Server) listBrandCloudUsers(c *gin.Context) {
+	limit, offset := pagination(c)
+	status := strings.TrimSpace(c.Query("status"))
+	if status != "" && status != "active" && status != "pending_verification" && status != "disabled" {
+		writeError(c, http.StatusBadRequest, "invalid_status", "status must be active, pending_verification, or disabled")
+		return
+	}
+	page, err := s.store.ListBrandCloudUsers(c.Request.Context(), store.BrandCloudUserListFilter{
+		BrandCloudID: c.Param("brandCloudId"),
+		Status:       status,
+		Query:        c.Query("q"),
+		Limit:        limit,
+		Offset:       offset,
+	})
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, brandCloudUsersResponse{BrandCloudUsers: page.Users, Pagination: page.Page})
+}
+
+func (s *Server) disableBrandCloudUser(c *gin.Context) {
+	user, err := s.store.DisableBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), c.Param("brandCloudUserId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, brandCloudUserResponse{BrandCloudUser: user})
+}
+
+func (s *Server) enableBrandCloudUser(c *gin.Context) {
+	user, err := s.store.EnableBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), c.Param("brandCloudUserId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, brandCloudUserResponse{BrandCloudUser: user})
+}
+
+func (s *Server) approveBrandCloudUser(c *gin.Context) {
+	user, err := s.store.ApproveBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), c.Param("brandCloudUserId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, brandCloudUserResponse{BrandCloudUser: user})
+}
+
+func (s *Server) deleteBrandCloudUser(c *gin.Context) {
+	if err := s.store.DeleteBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), c.Param("brandCloudUserId")); err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -940,6 +940,53 @@ func TestIntegrationEmailVerificationAndPasswordRecovery(t *testing.T) {
 		t.Fatalf("expected resend-verification throttling to remain enumeration-safe 202, got %d", resendRateLimitedRes.Code)
 	}
 
+	signInUnknownRes := performJSON(env.router, http.MethodPost, "/v1/auth/sign-in", map[string]any{
+		"email": "unknown-signin@example.com",
+	}, "")
+	if signInUnknownRes.Code != http.StatusAccepted {
+		t.Fatalf("expected unknown sign-in to stay enumeration-safe 202, got %d", signInUnknownRes.Code)
+	}
+	createdUnknownLogin, err := accountStore.CreateLoginActivationTokenForEmail(context.Background(), "missing-login@example.com", auth.HashToken("missing-login"), time.Now().Add(30*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createdUnknownLogin {
+		t.Fatal("expected unknown login email not to create a token")
+	}
+	signInRes := performJSON(env.router, http.MethodPost, "/v1/auth/sign-in", map[string]any{
+		"email": "verify@example.com",
+	}, "")
+	if signInRes.Code != http.StatusAccepted {
+		t.Fatalf("expected sign-in 202, got %d: %s", signInRes.Code, signInRes.Body.String())
+	}
+	loginActivationToken := latestAuthToken(t, env.tokenSink, "verify@example.com", "login_activation")
+	activateLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login/activate", map[string]any{
+		"token": loginActivationToken,
+	}, "")
+	if activateLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected login activation 200, got %d: %s", activateLoginRes.Code, activateLoginRes.Body.String())
+	}
+	activatedLogin := decodeBody[tokenBody](t, activateLoginRes)
+	if activatedLogin.Tokens.AccessToken == "" || activatedLogin.Tokens.RefreshToken == "" {
+		t.Fatalf("expected login activation tokens, got %+v", activatedLogin.Tokens)
+	}
+	replayLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login/activate", map[string]any{
+		"token": loginActivationToken,
+	}, "")
+	if replayLoginRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected replayed login token 400, got %d", replayLoginRes.Code)
+	}
+	expiredLoginToken := "expired-login-token"
+	if err := accountStore.CreateLoginActivationToken(context.Background(), registered.User.ID, auth.HashToken(expiredLoginToken), time.Now().Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	expiredLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login/activate", map[string]any{
+		"token": expiredLoginToken,
+	}, "")
+	if expiredLoginRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected expired login token 400, got %d", expiredLoginRes.Code)
+	}
+
 	expiredResetUser := registerUser(t, env.router, "expired-reset@example.com", "Expired Reset Org")
 	expiredResetToken := "expired-reset-token"
 	if err := accountStore.CreatePasswordResetToken(context.Background(), expiredResetUser.User.ID, auth.HashToken(expiredResetToken), time.Now().Add(-time.Minute)); err != nil {
@@ -1668,6 +1715,112 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 		t.Fatalf("expected rotated brand-cloud password login 200, got %d: %s", rotatedLoginRes.Code, rotatedLoginRes.Body.String())
 	}
 
+	listRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users?q=rtk%2B001", nil, admin.Tokens.AccessToken)
+	if listRes.Code != http.StatusOK {
+		t.Fatalf("expected brand user list 200, got %d: %s", listRes.Code, listRes.Body.String())
+	}
+	listed := decodeBody[brandCloudUsersBody](t, listRes)
+	if listed.Pagination.Total != 1 || len(listed.BrandCloudUsers) != 1 || listed.BrandCloudUsers[0].ID != created.BrandCloudUser.ID {
+		t.Fatalf("expected created brand user in list, got %+v", listed)
+	}
+
+	if _, err := env.db.Exec(ctx, `
+		UPDATE brand_cloud_users
+		SET email_verified = false, email_verified_at = NULL, signup_pending_verification = true, updated_at = now()
+		WHERE id = $1
+	`, created.BrandCloudUser.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.db.Exec(ctx, `
+		UPDATE users
+		SET email_verified = false, email_verified_at = NULL, signup_pending_verification = true, updated_at = now()
+		WHERE id = $1
+	`, created.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	pendingLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "rotated-password123",
+	}, "")
+	if pendingLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected pending brand-cloud user login 401, got %d: %s", pendingLoginRes.Code, pendingLoginRes.Body.String())
+	}
+	pendingListRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users?status=pending_verification", nil, admin.Tokens.AccessToken)
+	if pendingListRes.Code != http.StatusOK {
+		t.Fatalf("expected pending brand user list 200, got %d: %s", pendingListRes.Code, pendingListRes.Body.String())
+	}
+	pendingList := decodeBody[brandCloudUsersBody](t, pendingListRes)
+	if pendingList.Pagination.Total != 1 || len(pendingList.BrandCloudUsers) != 1 || !pendingList.BrandCloudUsers[0].SignupPendingVerification {
+		t.Fatalf("expected pending brand user in list, got %+v", pendingList)
+	}
+	approveRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users/"+created.BrandCloudUser.ID+"/approve", nil, admin.Tokens.AccessToken)
+	if approveRes.Code != http.StatusOK {
+		t.Fatalf("expected brand user approve 200, got %d: %s", approveRes.Code, approveRes.Body.String())
+	}
+	approved := decodeBody[brandCloudUserStateBody](t, approveRes)
+	if !approved.BrandCloudUser.EmailVerified || approved.BrandCloudUser.SignupPendingVerification || approved.BrandCloudUser.DisabledAt != nil {
+		t.Fatalf("expected approved brand user, got %+v", approved.BrandCloudUser)
+	}
+	approvedLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "rotated-password123",
+	}, "")
+	if approvedLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected approved brand-cloud user login 200, got %d: %s", approvedLoginRes.Code, approvedLoginRes.Body.String())
+	}
+
+	disableRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users/"+created.BrandCloudUser.ID+"/disable", nil, admin.Tokens.AccessToken)
+	if disableRes.Code != http.StatusOK {
+		t.Fatalf("expected brand user disable 200, got %d: %s", disableRes.Code, disableRes.Body.String())
+	}
+	disabled := decodeBody[brandCloudUserStateBody](t, disableRes)
+	if disabled.BrandCloudUser.DisabledAt == nil {
+		t.Fatalf("expected disabled brand user, got %+v", disabled.BrandCloudUser)
+	}
+	disabledLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "rotated-password123",
+	}, "")
+	if disabledLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected disabled brand-cloud user login 401, got %d: %s", disabledLoginRes.Code, disabledLoginRes.Body.String())
+	}
+	disabledListRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users?status=disabled", nil, admin.Tokens.AccessToken)
+	if disabledListRes.Code != http.StatusOK {
+		t.Fatalf("expected disabled brand user list 200, got %d: %s", disabledListRes.Code, disabledListRes.Body.String())
+	}
+	disabledList := decodeBody[brandCloudUsersBody](t, disabledListRes)
+	if disabledList.Pagination.Total != 1 || len(disabledList.BrandCloudUsers) != 1 || disabledList.BrandCloudUsers[0].DisabledAt == nil {
+		t.Fatalf("expected disabled brand user in disabled list, got %+v", disabledList)
+	}
+
+	enableRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users/"+created.BrandCloudUser.ID+"/enable", nil, admin.Tokens.AccessToken)
+	if enableRes.Code != http.StatusOK {
+		t.Fatalf("expected brand user enable 200, got %d: %s", enableRes.Code, enableRes.Body.String())
+	}
+	enabled := decodeBody[brandCloudUserStateBody](t, enableRes)
+	if enabled.BrandCloudUser.DisabledAt != nil {
+		t.Fatalf("expected enabled brand user, got %+v", enabled.BrandCloudUser)
+	}
+	enabledLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "rotated-password123",
+	}, "")
+	if enabledLoginRes.Code != http.StatusOK {
+		t.Fatalf("expected enabled brand-cloud user login 200, got %d: %s", enabledLoginRes.Code, enabledLoginRes.Body.String())
+	}
+
+	deleteRes := performJSON(env.router, http.MethodDelete, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users/"+created.BrandCloudUser.ID, nil, admin.Tokens.AccessToken)
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("expected brand user delete 204, got %d: %s", deleteRes.Code, deleteRes.Body.String())
+	}
+	deletedLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "rotated-password123",
+	}, "")
+	if deletedLoginRes.Code != http.StatusUnauthorized {
+		t.Fatalf("expected soft-deleted brand-cloud user login 401, got %d: %s", deletedLoginRes.Code, deletedLoginRes.Body.String())
+	}
+
 	auditRes := performJSON(env.router, http.MethodGet, "/v1/admin/audit-events?subject_type=brand_cloud", nil, admin.Tokens.AccessToken)
 	if auditRes.Code != http.StatusOK {
 		t.Fatalf("expected audit event list 200, got %d: %s", auditRes.Code, auditRes.Body.String())
@@ -1675,6 +1828,14 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 	audit := decodeBody[auditEventsBody](t, auditRes)
 	if !hasAuditEventBody(audit.AuditEvents, "brand_cloud_user_created") || !hasAuditEventBody(audit.AuditEvents, "brand_cloud_user_assigned") {
 		t.Fatalf("expected brand cloud user audit events, got %+v", audit.AuditEvents)
+	}
+	userAuditRes := performJSON(env.router, http.MethodGet, "/v1/admin/audit-events?subject_type=brand_cloud_user", nil, admin.Tokens.AccessToken)
+	if userAuditRes.Code != http.StatusOK {
+		t.Fatalf("expected brand cloud user audit event list 200, got %d: %s", userAuditRes.Code, userAuditRes.Body.String())
+	}
+	userAudit := decodeBody[auditEventsBody](t, userAuditRes)
+	if !hasAuditEventBody(userAudit.AuditEvents, "brand_cloud_user_approved") || !hasAuditEventBody(userAudit.AuditEvents, "brand_cloud_user_disabled") || !hasAuditEventBody(userAudit.AuditEvents, "brand_cloud_user_enabled") || !hasAuditEventBody(userAudit.AuditEvents, "brand_cloud_user_deleted") {
+		t.Fatalf("expected brand cloud user lifecycle audit events, got %+v", userAudit.AuditEvents)
 	}
 }
 
@@ -1754,6 +1915,40 @@ func TestIntegrationBrandScopedUsersLoginAndAuthorizeByTenantSlug(t *testing.T) 
 	}
 	if acmeClaims.SubjectType != auth.SubjectTypeBrandCloudUser || acmeClaims.UserID != acmeLogin.User.ID || acmeClaims.BrandCloudID != acme.BrandCloud.ID || acmeClaims.TenantSlug != "acme" || acmeClaims.BrandCloudUserID == "" {
 		t.Fatalf("unexpected acme access token claims: %+v", acmeClaims)
+	}
+
+	acmeSignInRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/acme/auth/sign-in", map[string]any{
+		"email": "shared@users.example.com",
+	}, "")
+	if acmeSignInRes.Code != http.StatusAccepted {
+		t.Fatalf("expected acme sign-in 202, got %d: %s", acmeSignInRes.Code, acmeSignInRes.Body.String())
+	}
+	acmeLoginActivationToken := latestAuthToken(t, env.tokenSink, "shared@users.example.com", "login_activation")
+	tenantMismatchRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/contoso/auth/login/activate", map[string]any{
+		"token": acmeLoginActivationToken,
+	}, "")
+	if tenantMismatchRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected tenant-mismatched login activation 400, got %d: %s", tenantMismatchRes.Code, tenantMismatchRes.Body.String())
+	}
+	acmeActivateRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/acme/auth/login/activate", map[string]any{
+		"token": acmeLoginActivationToken,
+	}, "")
+	if acmeActivateRes.Code != http.StatusOK {
+		t.Fatalf("expected acme login activation 200 after mismatch attempt, got %d: %s", acmeActivateRes.Code, acmeActivateRes.Body.String())
+	}
+	acmeActivated := decodeBody[brandCloudLoginBody](t, acmeActivateRes)
+	acmeActivatedClaims, err := env.server.auth.ParseAccessToken(acmeActivated.Tokens.AccessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acmeActivatedClaims.SubjectType != auth.SubjectTypeBrandCloudUser || acmeActivatedClaims.TenantSlug != "acme" || acmeActivatedClaims.BrandCloudID != acme.BrandCloud.ID {
+		t.Fatalf("unexpected acme activation claims: %+v", acmeActivatedClaims)
+	}
+	replayBrandActivationRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/acme/auth/login/activate", map[string]any{
+		"token": acmeLoginActivationToken,
+	}, "")
+	if replayBrandActivationRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected replayed brand activation token 400, got %d", replayBrandActivationRes.Code)
 	}
 
 	contosoLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/contoso/auth/login", map[string]any{
@@ -5262,6 +5457,31 @@ type brandCloudUserBody struct {
 		BrandCloudUserID string `json:"brand_cloud_user_id"`
 		Role             string `json:"role"`
 	} `json:"brand_cloud_member"`
+}
+
+type brandCloudUsersBody struct {
+	BrandCloudUsers []struct {
+		ID                        string     `json:"id"`
+		BrandCloudID              string     `json:"brand_cloud_id"`
+		Email                     string     `json:"email"`
+		DisplayName               *string    `json:"display_name"`
+		EmailVerified             bool       `json:"email_verified"`
+		SignupPendingVerification bool       `json:"signup_pending_verification"`
+		DisabledAt                *time.Time `json:"disabled_at"`
+	} `json:"brand_cloud_users"`
+	Pagination paginationBody `json:"pagination"`
+}
+
+type brandCloudUserStateBody struct {
+	BrandCloudUser struct {
+		ID                        string     `json:"id"`
+		BrandCloudID              string     `json:"brand_cloud_id"`
+		Email                     string     `json:"email"`
+		DisplayName               *string    `json:"display_name"`
+		EmailVerified             bool       `json:"email_verified"`
+		SignupPendingVerification bool       `json:"signup_pending_verification"`
+		DisabledAt                *time.Time `json:"disabled_at"`
+	} `json:"brand_cloud_user"`
 }
 
 type brandCloudLoginBody struct {

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -81,7 +81,7 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-				TRUNCATE acl_audit_events, external_group_mappings, role_assignments, oidc_login_states, user_identities, identity_providers, auth_tokens, quota_raise_requests, device_user_bindings, brand_cloud_end_users, end_user_refresh_tokens, end_user_identities, device_claims, device_claim_tokens, device_item_profiles, app_certificates, brand_cloud_refresh_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, brand_cloud_memberships, organization_members, brand_cloud_users, end_users, organizations, users
+				TRUNCATE acl_audit_events, external_group_mappings, role_assignments, oidc_login_states, user_identities, identity_providers, auth_tokens, quota_raise_requests, device_user_bindings, brand_cloud_end_users, end_user_refresh_tokens, end_user_identities, device_claims, device_claim_tokens, device_item_profiles, device_message_inbox, device_message_outbox, device_operations, app_certificates, brand_cloud_refresh_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, brand_cloud_memberships, organization_members, brand_cloud_users, end_users, organizations, users
 		RESTART IDENTITY CASCADE
 	`); err != nil {
 		t.Fatal(err)
@@ -1073,6 +1073,56 @@ func TestIntegrationEmailVerificationAndPasswordRecovery(t *testing.T) {
 	}
 }
 
+func TestIntegrationEmailSignInValidationPaths(t *testing.T) {
+	env := newIntegrationEnv(t)
+	accountStore := store.New(env.db)
+	ctx := context.Background()
+
+	malformedSignInRes := performJSON(env.router, http.MethodPost, "/v1/auth/sign-in", "not-json", "")
+	if malformedSignInRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected malformed sign-in 400, got %d: %s", malformedSignInRes.Code, malformedSignInRes.Body.String())
+	}
+	missingActivationTokenRes := performJSON(env.router, http.MethodPost, "/v1/auth/login/activate", map[string]any{
+		"token": "   ",
+	}, "")
+	if missingActivationTokenRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected blank login activation token 400, got %d: %s", missingActivationTokenRes.Code, missingActivationTokenRes.Body.String())
+	}
+	invalidActivationTokenRes := performJSON(env.router, http.MethodPost, "/v1/auth/login/activate", map[string]any{
+		"token": "not-a-valid-login-token",
+	}, "")
+	if invalidActivationTokenRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid login activation token 400, got %d: %s", invalidActivationTokenRes.Code, invalidActivationTokenRes.Body.String())
+	}
+
+	malformedBrandSignInRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/missing/auth/sign-in", "not-json", "")
+	if malformedBrandSignInRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected malformed brand sign-in 400, got %d: %s", malformedBrandSignInRes.Code, malformedBrandSignInRes.Body.String())
+	}
+	invalidBrandActivationTokenRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/missing/auth/login/activate", map[string]any{
+		"token": "not-a-valid-brand-token",
+	}, "")
+	if invalidBrandActivationTokenRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid brand activation token 400, got %d: %s", invalidBrandActivationTokenRes.Code, invalidBrandActivationTokenRes.Body.String())
+	}
+
+	rateLimited := registerUser(t, env.router, "signin-rate-limit@example.com", "Sign In Rate Limit Org")
+	if _, err := env.db.Exec(ctx, `UPDATE users SET email_verified = true, email_verified_at = now(), signup_pending_verification = false WHERE id = $1`, rateLimited.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := accountStore.CreateLoginActivationToken(ctx, rateLimited.User.ID, auth.HashToken("signin-rate-limit-"+strconv.Itoa(i)), time.Now().Add(30*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rateLimitedSignInRes := performJSON(env.router, http.MethodPost, "/v1/auth/sign-in", map[string]any{
+		"email": "signin-rate-limit@example.com",
+	}, "")
+	if rateLimitedSignInRes.Code != http.StatusAccepted {
+		t.Fatalf("expected rate-limited sign-in to stay enumeration-safe 202, got %d", rateLimitedSignInRes.Code)
+	}
+}
+
 func TestIntegrationSignupEvaluationQuotaAndRaiseWorkflow(t *testing.T) {
 	env := newIntegrationEnv(t)
 
@@ -1372,6 +1422,23 @@ func TestIntegrationPlatformAdminBrandCloudLifecycle(t *testing.T) {
 		t.Fatalf("unexpected brand cloud response: %+v", created.BrandCloud)
 	}
 
+	nonAdminGetRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+created.BrandCloud.ID, nil, nonAdmin.Tokens.AccessToken)
+	if nonAdminGetRes.Code != http.StatusForbidden {
+		t.Fatalf("expected non-admin brand cloud get 403, got %d: %s", nonAdminGetRes.Code, nonAdminGetRes.Body.String())
+	}
+	getRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+created.BrandCloud.ID, nil, admin.Tokens.AccessToken)
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("expected brand cloud get 200, got %d: %s", getRes.Code, getRes.Body.String())
+	}
+	got := decodeBody[brandCloudBody](t, getRes)
+	if got.BrandCloud.ID != created.BrandCloud.ID || got.BrandCloud.TenantSlug == "" {
+		t.Fatalf("unexpected brand cloud get response: %+v", got.BrandCloud)
+	}
+	missingGetRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/00000000-0000-0000-0000-000000000000", nil, admin.Tokens.AccessToken)
+	if missingGetRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing brand cloud get 404, got %d: %s", missingGetRes.Code, missingGetRes.Body.String())
+	}
+
 	patchRes := performJSON(env.router, http.MethodPatch, "/v1/admin/brand-clouds/"+created.BrandCloud.ID, map[string]any{
 		"name":   "Realtek Connect Plus",
 		"status": "disabled",
@@ -1383,6 +1450,12 @@ func TestIntegrationPlatformAdminBrandCloudLifecycle(t *testing.T) {
 	if patched.BrandCloud.Name != "Realtek Connect Plus" || patched.BrandCloud.Status != "disabled" {
 		t.Fatalf("unexpected patched brand cloud: %+v", patched.BrandCloud)
 	}
+	missingPatchRes := performJSON(env.router, http.MethodPatch, "/v1/admin/brand-clouds/00000000-0000-0000-0000-000000000000", map[string]any{
+		"name": "Missing Brand Cloud",
+	}, admin.Tokens.AccessToken)
+	if missingPatchRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing brand cloud patch 404, got %d: %s", missingPatchRes.Code, missingPatchRes.Body.String())
+	}
 
 	memberRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+created.BrandCloud.ID+"/members", map[string]any{
 		"user_id": owner.User.ID,
@@ -1390,6 +1463,13 @@ func TestIntegrationPlatformAdminBrandCloudLifecycle(t *testing.T) {
 	}, admin.Tokens.AccessToken)
 	if memberRes.Code != http.StatusCreated {
 		t.Fatalf("expected brand cloud member assignment 201, got %d: %s", memberRes.Code, memberRes.Body.String())
+	}
+	missingMemberRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/00000000-0000-0000-0000-000000000000/members", map[string]any{
+		"user_id": owner.User.ID,
+		"role":    "member",
+	}, admin.Tokens.AccessToken)
+	if missingMemberRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing brand cloud member assignment 404, got %d: %s", missingMemberRes.Code, missingMemberRes.Body.String())
 	}
 
 	listRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds", nil, admin.Tokens.AccessToken)

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -254,6 +254,9 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 		"role":         "member",
 	}, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", brandCloudUserRes)
+	brandCloudUserBody := decodeBody[brandCloudUserBody](t, brandCloudUserRes)
+	brandCloudUsersRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodGet, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", brandCloudUsersRes)
 	brandCloudReactivateRes := performJSON(env.router, http.MethodPatch, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID, map[string]any{
 		"status": "active",
 	}, admin.Tokens.AccessToken)
@@ -278,6 +281,14 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 		"refresh_token": brandRefreshBody.Tokens.RefreshToken,
 	}, brandRefreshBody.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/brand-clouds/"+brandCloudResp.BrandCloud.TenantSlug+"/auth/logout", brandLogoutRes)
+	brandCloudUserDisableRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID+"/disable", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID+"/disable", brandCloudUserDisableRes)
+	brandCloudUserEnableRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID+"/enable", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID+"/enable", brandCloudUserEnableRes)
+	brandCloudUserApproveRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID+"/approve", nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID+"/approve", brandCloudUserApproveRes)
+	brandCloudUserDeleteRes := performJSON(env.router, http.MethodDelete, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID, nil, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodDelete, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users/"+brandCloudUserBody.BrandCloudUser.ID, brandCloudUserDeleteRes)
 	adminClaimTokensRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/admin/device-claim-tokens", adminClaimTokensRes)
 	adminClaimTokenGetRes := performJSON(env.router, http.MethodGet, "/v1/admin/device-claim-tokens/"+adminClaimTokenBody.DeviceClaimToken.ID, nil, admin.Tokens.AccessToken)

--- a/internal/api/persistence.go
+++ b/internal/api/persistence.go
@@ -33,15 +33,20 @@ type authPersistence interface {
 	GetUserPasswordByID(ctx context.Context, userID string) (model.User, string, error)
 	CreateEmailVerificationToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
 	CreatePasswordResetToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
+	CreateLoginActivationToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
 	CreatePasswordResetTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error)
 	CreateEmailVerificationTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error)
+	CreateLoginActivationTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error)
 	VerifyEmailToken(ctx context.Context, tokenHash string) (model.User, error)
+	ActivateLoginToken(ctx context.Context, tokenHash string) (model.User, error)
 	ResetPasswordWithToken(ctx context.Context, tokenHash, passwordHash string) error
 	UpdateUserPassword(ctx context.Context, userID, passwordHash string) error
 	SaveRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
 	RotateRefreshToken(ctx context.Context, oldTokenHash, newTokenHash, userID string, newExpiresAt time.Time) error
 	RevokeRefreshToken(ctx context.Context, tokenHash string) error
 	GetBrandCloudUserPassword(ctx context.Context, tenantSlug, email string) (store.BrandCloudLoginResult, error)
+	CreateBrandCloudLoginActivationTokenForEmail(ctx context.Context, tenantSlug, email, tokenHash string, expiresAt time.Time) (bool, error)
+	ActivateBrandCloudLoginToken(ctx context.Context, tenantSlug, tokenHash string) (store.BrandCloudLoginResult, error)
 	GetBrandCloudUser(ctx context.Context, brandCloudUserID string) (model.BrandCloudUser, error)
 	GetBrandCloudMember(ctx context.Context, brandCloudID, brandCloudUserID string) (model.BrandCloudMember, error)
 	SaveBrandCloudRefreshToken(ctx context.Context, brandCloudUserID, brandCloudID, tokenHash string, expiresAt time.Time) error
@@ -194,6 +199,11 @@ type brandCloudPersistence interface {
 	UpdateBrandCloud(ctx context.Context, actorUserID, orgID string, in store.BrandCloudInput) (model.Organization, error)
 	AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, userID string, role model.Role) (model.Member, error)
 	CreateBrandCloudUser(ctx context.Context, actorUserID, orgID string, in store.BrandCloudUserInput) (store.BrandCloudUserResult, error)
+	ListBrandCloudUsers(ctx context.Context, in store.BrandCloudUserListFilter) (store.BrandCloudUserPage, error)
+	DisableBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error)
+	EnableBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error)
+	ApproveBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error)
+	DeleteBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) error
 	CreateDeviceItemProfile(ctx context.Context, in store.DeviceItemProfileCreateInput) (model.DeviceItemProfile, error)
 	ListDeviceItemProfiles(ctx context.Context, in store.DeviceItemProfileListFilter) (store.DeviceItemProfilePage, error)
 	GetDeviceItemProfile(ctx context.Context, brandCloudID, profileID string) (model.DeviceItemProfile, error)

--- a/internal/store/auth_tokens_integration_test.go
+++ b/internal/store/auth_tokens_integration_test.go
@@ -1,0 +1,216 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"rtk_account_manager/internal/model"
+)
+
+func TestLoginActivationTokenLifecycleAndScope(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+
+	registered, err := env.store.Register(ctx, RegisterInput{
+		Email:            "activation-user@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Activation Org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := env.store.CreateLoginActivationTokenForEmail(ctx, " activation-user@example.com ", "console-token-hash", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected console login activation token to be created")
+	}
+
+	activated, err := env.store.ActivateLoginToken(ctx, "console-token-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if activated.ID != registered.User.ID || activated.Email != registered.User.Email {
+		t.Fatalf("unexpected activated user: %+v", activated)
+	}
+	if _, err := env.store.ActivateLoginToken(ctx, "console-token-hash"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected consumed console activation token to reject replay, got %v", err)
+	}
+
+	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, registered.User.ID); err != nil {
+		t.Fatal(err)
+	}
+	disabledCreated, err := env.store.CreateLoginActivationTokenForEmail(ctx, registered.User.Email, "disabled-token-hash", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabledCreated {
+		t.Fatal("disabled users must not get login activation tokens")
+	}
+}
+
+func TestBrandCloudLoginActivationTokenIsTenantScoped(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+
+	admin, err := env.store.Register(ctx, RegisterInput{
+		Email:            "brand-activation-admin@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Brand Activation Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	acme, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Acme", TenantSlug: "acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contoso, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Contoso", TenantSlug: "contoso"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdUser, err := env.store.CreateBrandCloudUser(ctx, admin.User.ID, acme.ID, BrandCloudUserInput{
+		Email:        "shared-brand-user@example.com",
+		PasswordHash: "hash",
+		DisplayName:  stringPtr("Shared Brand User"),
+		Role:         "member",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := env.store.CreateBrandCloudLoginActivationTokenForEmail(ctx, "acme", "shared-brand-user@example.com", "brand-token-hash", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected tenant-scoped login activation token")
+	}
+	if _, err := env.store.ActivateBrandCloudLoginToken(ctx, "contoso", "brand-token-hash"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected tenant mismatch to reject activation token, got %v", err)
+	}
+
+	activated, err := env.store.ActivateBrandCloudLoginToken(ctx, "acme", "brand-token-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if activated.BrandCloud.ID != acme.ID || activated.BrandCloud.ID == contoso.ID || activated.BrandCloudUser.ID != createdUser.BrandCloudUser.ID {
+		t.Fatalf("unexpected activated brand-cloud user: %+v", activated)
+	}
+	if _, err := env.store.ActivateBrandCloudLoginToken(ctx, "acme", "brand-token-hash"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected consumed brand activation token to reject replay, got %v", err)
+	}
+
+	pending, err := env.store.CreateBrandCloudUser(ctx, admin.User.ID, acme.ID, BrandCloudUserInput{
+		Email:        "pending-brand-user@example.com",
+		PasswordHash: "hash",
+		DisplayName:  stringPtr("Pending Brand User"),
+		Role:         "member",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.db.Exec(ctx, `
+		UPDATE brand_cloud_users
+		SET signup_pending_verification = true
+		WHERE id = $1
+	`, pending.BrandCloudUser.ID); err != nil {
+		t.Fatal(err)
+	}
+	pendingCreated, err := env.store.CreateBrandCloudLoginActivationTokenForEmail(ctx, "acme", pending.BrandCloudUser.Email, "pending-token-hash", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pendingCreated {
+		t.Fatal("pending brand-cloud users must not get login activation tokens")
+	}
+}
+
+func TestBrandCloudStoreCRUDAndErrorPaths(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+
+	admin, err := env.store.Register(ctx, RegisterInput{
+		Email:            "brand-crud-admin@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Brand CRUD Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := env.store.Register(ctx, RegisterInput{
+		Email:            "brand-crud-member@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Brand CRUD Member",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Invalid Slug", TenantSlug: "!!!"}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected invalid tenant slug conflict, got %v", err)
+	}
+	acme, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{
+		Name:       "Acme Cameras",
+		TenantSlug: "acme-crud",
+		Metadata:   map[string]any{"region": "tw"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Duplicate", TenantSlug: "acme-crud"}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected duplicate tenant slug conflict, got %v", err)
+	}
+	contoso, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Contoso Cameras", TenantSlug: "contoso-crud"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPage, err := env.store.ListBrandClouds(ctx, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstPage.Page.Total != 2 || len(firstPage.Organizations) != 1 || firstPage.Organizations[0].ID != acme.ID {
+		t.Fatalf("unexpected first brand-cloud page: %+v", firstPage)
+	}
+	secondPage, err := env.store.ListBrandClouds(ctx, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondPage.Page.Total != 2 || len(secondPage.Organizations) != 1 || secondPage.Organizations[0].ID != contoso.ID {
+		t.Fatalf("unexpected second brand-cloud page: %+v", secondPage)
+	}
+
+	updated, err := env.store.UpdateBrandCloud(ctx, admin.User.ID, acme.ID, BrandCloudInput{
+		Name:     "Acme Cameras Pro",
+		Status:   model.OrganizationStatusDisabled,
+		Metadata: map[string]any{"region": "us"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "Acme Cameras Pro" || updated.Status != model.OrganizationStatusDisabled || updated.Metadata["region"] != "us" {
+		t.Fatalf("unexpected updated brand cloud: %+v", updated)
+	}
+	if _, err := env.store.GetBrandCloud(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing brand cloud not found, got %v", err)
+	}
+	if _, err := env.store.UpdateBrandCloud(ctx, admin.User.ID, "00000000-0000-0000-0000-000000000000", BrandCloudInput{Name: "Missing"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing brand cloud update not found, got %v", err)
+	}
+
+	assigned, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, acme.ID, member.User.ID, model.RoleAdmin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assigned.UserID != member.User.ID || assigned.Role != model.RoleAdmin {
+		t.Fatalf("unexpected assigned brand-cloud member: %+v", assigned)
+	}
+	if _, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, "00000000-0000-0000-0000-000000000000", member.User.ID, model.RoleMember); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing brand cloud member assignment not found, got %v", err)
+	}
+}

--- a/internal/store/brand_clouds.go
+++ b/internal/store/brand_clouds.go
@@ -17,6 +17,10 @@ import (
 
 var slugUnsafePattern = regexp.MustCompile(`[^a-z0-9]+`)
 
+type rowQuerier interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
 func (s *Store) CreateBrandCloud(ctx context.Context, actorUserID string, in BrandCloudInput) (model.Organization, error) {
 	metadata, err := json.Marshal(defaultMetadata(in.Metadata))
 	if err != nil {
@@ -373,6 +377,126 @@ func (s *Store) CreateBrandCloudUser(ctx context.Context, actorUserID, orgID str
 	return BrandCloudUserResult{Action: action, User: user, Member: member, BrandCloudUser: brandCloudUser, BrandCloudMember: brandCloudMember}, nil
 }
 
+func (s *Store) ListBrandCloudUsers(ctx context.Context, in BrandCloudUserListFilter) (BrandCloudUserPage, error) {
+	exists, err := s.brandCloudExists(ctx, in.BrandCloudID)
+	if err != nil {
+		return BrandCloudUserPage{}, err
+	}
+	if !exists {
+		return BrandCloudUserPage{}, ErrNotFound
+	}
+
+	status := strings.TrimSpace(in.Status)
+	query := strings.ToLower(strings.TrimSpace(in.Query))
+	total, err := s.countBrandCloudUsers(ctx, in.BrandCloudID, status, query)
+	if err != nil {
+		return BrandCloudUserPage{}, err
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT id::text, brand_cloud_id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+		FROM brand_cloud_users
+		WHERE brand_cloud_id = $1
+		  AND (
+		    $2 = ''
+		    OR ($2 = 'active' AND disabled_at IS NULL AND signup_pending_verification = false)
+		    OR ($2 = 'pending_verification' AND disabled_at IS NULL AND signup_pending_verification = true)
+		    OR ($2 = 'disabled' AND disabled_at IS NOT NULL)
+		  )
+		  AND (
+		    $3 = ''
+		    OR lower(email) LIKE '%' || $3 || '%'
+		    OR lower(coalesce(display_name, '')) LIKE '%' || $3 || '%'
+		    OR id::text = $3
+		  )
+		ORDER BY created_at ASC
+		LIMIT $4 OFFSET $5
+	`, in.BrandCloudID, status, query, in.Limit, in.Offset)
+	if err != nil {
+		return BrandCloudUserPage{}, err
+	}
+	defer rows.Close()
+
+	users := []model.BrandCloudUser{}
+	for rows.Next() {
+		user, err := scanBrandCloudUser(rows)
+		if err != nil {
+			return BrandCloudUserPage{}, err
+		}
+		users = append(users, user)
+	}
+	if err := rows.Err(); err != nil {
+		return BrandCloudUserPage{}, err
+	}
+	return BrandCloudUserPage{Users: users, Page: Page{Limit: in.Limit, Offset: in.Offset, Total: total}}, nil
+}
+
+func (s *Store) DisableBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error) {
+	return s.setBrandCloudUserDisabled(ctx, actorUserID, brandCloudID, brandCloudUserID, true, "brand_cloud_user_disabled")
+}
+
+func (s *Store) EnableBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error) {
+	return s.setBrandCloudUserDisabled(ctx, actorUserID, brandCloudID, brandCloudUserID, false, "brand_cloud_user_enabled")
+}
+
+func (s *Store) ApproveBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	user, err := scanBrandCloudUser(tx.QueryRow(ctx, `
+		UPDATE brand_cloud_users
+		SET email_verified = true,
+		    email_verified_at = COALESCE(email_verified_at, now()),
+		    signup_pending_verification = false,
+		    disabled_at = NULL,
+		    updated_at = now()
+		WHERE brand_cloud_id = $1 AND id = $2
+		RETURNING id::text, brand_cloud_id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+	`, brandCloudID, brandCloudUserID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.BrandCloudUser{}, ErrNotFound
+	}
+	if err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE users
+		SET email_verified = true,
+		    email_verified_at = COALESCE(email_verified_at, now()),
+		    signup_pending_verification = false,
+		    disabled_at = NULL,
+		    updated_at = now()
+		WHERE email = $1
+	`, user.Email); err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      "brand_cloud_user_approved",
+		ActorUserID:    &actorUserID,
+		OrganizationID: &brandCloudID,
+		SubjectType:    "brand_cloud_user",
+		SubjectID:      brandCloudUserID,
+		Payload: map[string]any{
+			"brand_cloud_id":      brandCloudID,
+			"brand_cloud_user_id": brandCloudUserID,
+			"email":               user.Email,
+		},
+	}); err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	return user, nil
+}
+
+func (s *Store) DeleteBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) error {
+	_, err := s.setBrandCloudUserDisabled(ctx, actorUserID, brandCloudID, brandCloudUserID, true, "brand_cloud_user_deleted")
+	return err
+}
+
 func (s *Store) GetBrandCloudByTenantSlug(ctx context.Context, tenantSlug string) (model.Organization, error) {
 	org, err := scanOrganization(s.db.QueryRow(ctx, `
 		SELECT id::text, name, tenant_slug, ''::text, organization_kind, status, tier, evaluation_device_quota, metadata, created_at, updated_at
@@ -386,9 +510,91 @@ func (s *Store) GetBrandCloudByTenantSlug(ctx context.Context, tenantSlug string
 }
 
 func (s *Store) GetBrandCloudUserPassword(ctx context.Context, tenantSlug, email string) (BrandCloudLoginResult, error) {
+	return getBrandCloudLoginResultByEmail(ctx, s.db, tenantSlug, email)
+}
+
+func (s *Store) CreateBrandCloudLoginActivationTokenForEmail(ctx context.Context, tenantSlug, email, tokenHash string, expiresAt time.Time) (bool, error) {
+	result, err := s.GetBrandCloudUserPassword(ctx, tenantSlug, email)
+	if errors.Is(err, ErrNotFound) || result.BrandCloudUser.SignupPendingVerification {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, s.createScopedLoginActivationToken(ctx, result.User.ID, brandCloudAuthTokenScope(tenantSlug), tokenHash, expiresAt)
+}
+
+func (s *Store) ActivateBrandCloudLoginToken(ctx context.Context, tenantSlug, tokenHash string) (BrandCloudLoginResult, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return BrandCloudLoginResult{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var userID, email string
+	err = tx.QueryRow(ctx, `
+		SELECT u.id::text, u.email
+		FROM auth_tokens at
+		JOIN users u ON u.id = at.user_id
+		WHERE at.token_hash = $1
+		  AND at.purpose = 'login_activation'
+		  AND at.scope = $2
+		  AND at.consumed_at IS NULL
+		  AND at.expires_at > now()
+		  AND u.disabled_at IS NULL
+		  AND u.signup_pending_verification = false
+		FOR UPDATE OF at
+	`, tokenHash, brandCloudAuthTokenScope(tenantSlug)).Scan(&userID, &email)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return BrandCloudLoginResult{}, ErrNotFound
+	}
+	if err != nil {
+		return BrandCloudLoginResult{}, err
+	}
+
+	result, err := getBrandCloudLoginResultByEmail(ctx, tx, tenantSlug, email)
+	if err != nil {
+		return BrandCloudLoginResult{}, err
+	}
+	if result.User.ID != userID || result.BrandCloudUser.SignupPendingVerification {
+		return BrandCloudLoginResult{}, ErrNotFound
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE auth_tokens
+		SET consumed_at = now()
+		WHERE token_hash = $1
+	`, tokenHash); err != nil {
+		return BrandCloudLoginResult{}, err
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      "brand_cloud_login_activation_consumed",
+		ActorUserID:    &userID,
+		OrganizationID: &result.BrandCloud.ID,
+		SubjectType:    "brand_cloud_user",
+		SubjectID:      result.BrandCloudUser.ID,
+		Payload: map[string]any{
+			"token_purpose":       "login_activation",
+			"tenant_slug":         normalizeTenantSlug(tenantSlug),
+			"email":               result.BrandCloudUser.Email,
+			"brand_cloud_user_id": result.BrandCloudUser.ID,
+		},
+	}); err != nil {
+		return BrandCloudLoginResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return BrandCloudLoginResult{}, err
+	}
+	return result, nil
+}
+
+func brandCloudAuthTokenScope(tenantSlug string) string {
+	return "brand_cloud:" + normalizeTenantSlug(tenantSlug)
+}
+
+func getBrandCloudLoginResultByEmail(ctx context.Context, q rowQuerier, tenantSlug, email string) (BrandCloudLoginResult, error) {
 	var result BrandCloudLoginResult
 	var rawMetadata []byte
-	err := s.db.QueryRow(ctx, `
+	err := q.QueryRow(ctx, `
 		SELECT
 		    o.id::text, o.name, o.tenant_slug, ''::text, o.organization_kind, o.status, o.tier, o.evaluation_device_quota, o.metadata, o.created_at, o.updated_at,
 		    bcu.id::text, bcu.brand_cloud_id::text, bcu.email, bcu.password_hash, bcu.display_name, bcu.email_verified, bcu.email_verified_at, bcu.signup_pending_verification, bcu.created_at, bcu.updated_at, bcu.disabled_at,
@@ -549,6 +755,97 @@ func (s *Store) countBrandClouds(ctx context.Context) (int, error) {
 		WHERE organization_kind = 'brand_cloud'
 	`).Scan(&total)
 	return total, err
+}
+
+func (s *Store) countBrandCloudUsers(ctx context.Context, brandCloudID, status, query string) (int, error) {
+	var total int
+	err := s.db.QueryRow(ctx, `
+		SELECT count(*)::int
+		FROM brand_cloud_users
+		WHERE brand_cloud_id = $1
+		  AND (
+		    $2 = ''
+		    OR ($2 = 'active' AND disabled_at IS NULL AND signup_pending_verification = false)
+		    OR ($2 = 'pending_verification' AND disabled_at IS NULL AND signup_pending_verification = true)
+		    OR ($2 = 'disabled' AND disabled_at IS NOT NULL)
+		  )
+		  AND (
+		    $3 = ''
+		    OR lower(email) LIKE '%' || $3 || '%'
+		    OR lower(coalesce(display_name, '')) LIKE '%' || $3 || '%'
+		    OR id::text = $3
+		  )
+	`, brandCloudID, status, query).Scan(&total)
+	return total, err
+}
+
+func (s *Store) brandCloudExists(ctx context.Context, brandCloudID string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM organizations
+			WHERE id = $1 AND organization_kind = 'brand_cloud'
+		)
+	`, brandCloudID).Scan(&exists)
+	return exists, err
+}
+
+func (s *Store) setBrandCloudUserDisabled(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string, disabled bool, eventType string) (model.BrandCloudUser, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var user model.BrandCloudUser
+	if disabled {
+		user, err = scanBrandCloudUser(tx.QueryRow(ctx, `
+			UPDATE brand_cloud_users
+			SET disabled_at = COALESCE(disabled_at, now()), updated_at = now()
+			WHERE brand_cloud_id = $1 AND id = $2
+			RETURNING id::text, brand_cloud_id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+		`, brandCloudID, brandCloudUserID))
+	} else {
+		user, err = scanBrandCloudUser(tx.QueryRow(ctx, `
+			UPDATE brand_cloud_users
+			SET disabled_at = NULL, updated_at = now()
+			WHERE brand_cloud_id = $1 AND id = $2
+			RETURNING id::text, brand_cloud_id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+		`, brandCloudID, brandCloudUserID))
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.BrandCloudUser{}, ErrNotFound
+	}
+	if err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	if disabled {
+		if _, err := tx.Exec(ctx, `
+			UPDATE brand_cloud_refresh_tokens
+			SET revoked_at = now()
+			WHERE brand_cloud_id = $1 AND brand_cloud_user_id = $2 AND revoked_at IS NULL
+		`, brandCloudID, brandCloudUserID); err != nil {
+			return model.BrandCloudUser{}, err
+		}
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:      eventType,
+		ActorUserID:    &actorUserID,
+		OrganizationID: &brandCloudID,
+		SubjectType:    "brand_cloud_user",
+		SubjectID:      brandCloudUserID,
+		Payload: map[string]any{
+			"brand_cloud_id":      brandCloudID,
+			"brand_cloud_user_id": brandCloudUserID,
+			"email":               user.Email,
+		},
+	}); err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.BrandCloudUser{}, err
+	}
+	return user, nil
 }
 
 type scanner interface {

--- a/internal/store/device_messages_integration_test.go
+++ b/internal/store/device_messages_integration_test.go
@@ -43,7 +43,7 @@ func newStoreIntegrationEnv(t *testing.T) storeIntegrationEnv {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-			TRUNCATE acl_audit_events, external_group_mappings, role_assignments, oidc_login_states, user_identities, identity_providers, device_claims, device_claim_tokens, device_item_profiles, device_message_inbox, device_message_outbox, device_operations, refresh_tokens, device_tags, device_group_members, device_groups, devices, organization_members, organizations, users
+			TRUNCATE acl_audit_events, external_group_mappings, role_assignments, oidc_login_states, user_identities, identity_providers, auth_tokens, quota_raise_requests, device_user_bindings, brand_cloud_end_users, end_user_refresh_tokens, end_user_identities, device_claims, device_claim_tokens, device_item_profiles, device_message_inbox, device_message_outbox, device_operations, brand_cloud_refresh_tokens, refresh_tokens, device_tags, device_group_members, device_groups, devices, brand_cloud_memberships, organization_members, brand_cloud_users, end_users, organizations, users
 			RESTART IDENTITY CASCADE
 		`); err != nil {
 		t.Fatal(err)

--- a/internal/store/schema_integration_test.go
+++ b/internal/store/schema_integration_test.go
@@ -44,6 +44,7 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 
 	requiredColumns := map[string][]string{
 		"organizations":              {"organization_kind", "status", "metadata", "tenant_slug"},
+		"auth_tokens":                {"user_id", "purpose", "scope", "token_hash", "expires_at", "consumed_at"},
 		"brand_cloud_users":          {"brand_cloud_id", "email", "password_hash", "display_name", "email_verified", "email_verified_at", "signup_pending_verification", "disabled_at"},
 		"brand_cloud_memberships":    {"brand_cloud_id", "brand_cloud_user_id", "role"},
 		"brand_cloud_refresh_tokens": {"brand_cloud_user_id", "brand_cloud_id", "token_hash", "expires_at", "revoked_at"},
@@ -90,6 +91,7 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 		{table: "organizations", name: "organizations_evaluation_device_quota_check"},
 		{table: "organizations", name: "organizations_kind_check"},
 		{table: "organizations", name: "organizations_status_check"},
+		{table: "auth_tokens", name: "auth_tokens_purpose_check"},
 		{table: "users", name: "users_email_normalized"},
 		{table: "brand_cloud_users", name: "brand_cloud_users_brand_email_key"},
 		{table: "brand_cloud_memberships", name: "brand_cloud_memberships_role_check"},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -77,6 +77,19 @@ type BrandCloudUserResult struct {
 	BrandCloudMember model.BrandCloudMember `json:"brand_cloud_member"`
 }
 
+type BrandCloudUserListFilter struct {
+	BrandCloudID string
+	Status       string
+	Query        string
+	Limit        int
+	Offset       int
+}
+
+type BrandCloudUserPage struct {
+	Users []model.BrandCloudUser
+	Page  Page
+}
+
 type BrandCloudLoginResult struct {
 	BrandCloud     model.Organization     `json:"brand_cloud"`
 	User           model.User             `json:"user"`
@@ -309,11 +322,54 @@ func (s *Store) EnsurePlatformAdmin(ctx context.Context, email, passwordHash str
 }
 
 func (s *Store) CreateEmailVerificationToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {
-	return s.createAuthToken(ctx, userID, "email_verification", tokenHash, expiresAt)
+	return s.createAuthToken(ctx, userID, "email_verification", "", tokenHash, expiresAt)
 }
 
 func (s *Store) CreatePasswordResetToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {
-	return s.createAuthToken(ctx, userID, "password_reset", tokenHash, expiresAt)
+	return s.createAuthToken(ctx, userID, "password_reset", "", tokenHash, expiresAt)
+}
+
+func (s *Store) CreateLoginActivationToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {
+	return s.createAuthToken(ctx, userID, "login_activation", "", tokenHash, expiresAt)
+}
+
+func (s *Store) createScopedLoginActivationToken(ctx context.Context, userID, scope, tokenHash string, expiresAt time.Time) error {
+	return s.createAuthToken(ctx, userID, "login_activation", scope, tokenHash, expiresAt)
+}
+
+func (s *Store) CreateLoginActivationTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error) {
+	var userID string
+	err := s.db.QueryRow(ctx, `
+		SELECT id::text
+		FROM users
+		WHERE email = $1
+		  AND disabled_at IS NULL
+		  AND signup_pending_verification = false
+		  AND (
+		      platform_admin = true
+		      OR EXISTS (
+		          SELECT 1
+		          FROM organization_members m
+		          JOIN organizations o ON o.id = m.organization_id
+		          WHERE m.user_id = users.id
+		            AND o.organization_kind = 'customer_org'
+		      )
+		      OR NOT EXISTS (
+		          SELECT 1
+		          FROM organization_members m
+		          JOIN organizations o ON o.id = m.organization_id
+		          WHERE m.user_id = users.id
+		            AND o.organization_kind = 'brand_cloud'
+		      )
+		  )
+	`, strings.ToLower(strings.TrimSpace(email))).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, s.CreateLoginActivationToken(ctx, userID, tokenHash, expiresAt)
 }
 
 func (s *Store) CreatePasswordResetTokenForEmail(ctx context.Context, email, tokenHash string, expiresAt time.Time) (bool, error) {
@@ -349,6 +405,49 @@ func (s *Store) CreateEmailVerificationTokenForEmail(ctx context.Context, email,
 	return true, s.CreateEmailVerificationToken(ctx, userID, tokenHash, expiresAt)
 }
 
+func (s *Store) ActivateLoginToken(ctx context.Context, tokenHash string) (model.User, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return model.User{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	userID, err := consumeAuthTokenTx(ctx, tx, tokenHash, "login_activation", "")
+	if err != nil {
+		return model.User{}, err
+	}
+	var user model.User
+	err = tx.QueryRow(ctx, `
+		SELECT id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+		FROM users
+		WHERE id = $1
+		  AND disabled_at IS NULL
+		  AND signup_pending_verification = false
+	`, userID).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return model.User{}, ErrNotFound
+	}
+	if err != nil {
+		return model.User{}, err
+	}
+	if err := createAuditEventTx(ctx, tx, AuditEventInput{
+		EventType:   "login_activation_consumed",
+		ActorUserID: &userID,
+		SubjectType: "user",
+		SubjectID:   userID,
+		Payload: map[string]any{
+			"token_purpose": "login_activation",
+			"email":         user.Email,
+		},
+	}); err != nil {
+		return model.User{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return model.User{}, err
+	}
+	return user, nil
+}
+
 func (s *Store) VerifyEmailToken(ctx context.Context, tokenHash string) (model.User, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -356,7 +455,7 @@ func (s *Store) VerifyEmailToken(ctx context.Context, tokenHash string) (model.U
 	}
 	defer tx.Rollback(ctx)
 
-	userID, err := consumeAuthTokenTx(ctx, tx, tokenHash, "email_verification")
+	userID, err := consumeAuthTokenTx(ctx, tx, tokenHash, "email_verification", "")
 	if err != nil {
 		return model.User{}, err
 	}
@@ -412,7 +511,7 @@ func (s *Store) ResetPasswordWithToken(ctx context.Context, tokenHash, passwordH
 	}
 	defer tx.Rollback(ctx)
 
-	userID, err := consumeAuthTokenTx(ctx, tx, tokenHash, "password_reset")
+	userID, err := consumeAuthTokenTx(ctx, tx, tokenHash, "password_reset", "")
 	if err != nil {
 		return err
 	}
@@ -437,7 +536,7 @@ func (s *Store) ResetPasswordWithToken(ctx context.Context, tokenHash, passwordH
 	return tx.Commit(ctx)
 }
 
-func (s *Store) createAuthToken(ctx context.Context, userID, purpose, tokenHash string, expiresAt time.Time) error {
+func (s *Store) createAuthToken(ctx context.Context, userID, purpose, scope, tokenHash string, expiresAt time.Time) error {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err
@@ -448,8 +547,8 @@ func (s *Store) createAuthToken(ctx context.Context, userID, purpose, tokenHash 
 	if err := tx.QueryRow(ctx, `
 		SELECT count(*)
 		FROM auth_tokens
-		WHERE user_id = $1 AND purpose = $2 AND created_at > now() - interval '1 hour'
-	`, userID, purpose).Scan(&recent); err != nil {
+		WHERE user_id = $1 AND purpose = $2 AND scope = $3 AND created_at > now() - interval '1 hour'
+	`, userID, purpose, scope).Scan(&recent); err != nil {
 		return err
 	}
 	if recent >= 5 {
@@ -458,20 +557,20 @@ func (s *Store) createAuthToken(ctx context.Context, userID, purpose, tokenHash 
 	if _, err := tx.Exec(ctx, `
 		UPDATE auth_tokens
 		SET consumed_at = now()
-		WHERE user_id = $1 AND purpose = $2 AND consumed_at IS NULL
-	`, userID, purpose); err != nil {
+		WHERE user_id = $1 AND purpose = $2 AND scope = $3 AND consumed_at IS NULL
+	`, userID, purpose, scope); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO auth_tokens (user_id, purpose, token_hash, expires_at)
-		VALUES ($1, $2, $3, $4)
-	`, userID, purpose, tokenHash, expiresAt); err != nil {
+		INSERT INTO auth_tokens (user_id, purpose, scope, token_hash, expires_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`, userID, purpose, scope, tokenHash, expiresAt); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
 }
 
-func consumeAuthTokenTx(ctx context.Context, tx pgx.Tx, tokenHash, purpose string) (string, error) {
+func consumeAuthTokenTx(ctx context.Context, tx pgx.Tx, tokenHash, purpose, scope string) (string, error) {
 	var userID string
 	err := tx.QueryRow(ctx, `
 		SELECT at.user_id::text
@@ -479,11 +578,12 @@ func consumeAuthTokenTx(ctx context.Context, tx pgx.Tx, tokenHash, purpose strin
 		JOIN users u ON u.id = at.user_id
 		WHERE at.token_hash = $1
 		  AND at.purpose = $2
+		  AND at.scope = $3
 		  AND at.consumed_at IS NULL
 		  AND at.expires_at > now()
 		  AND u.disabled_at IS NULL
 		FOR UPDATE OF at
-	`, tokenHash, purpose).Scan(&userID)
+	`, tokenHash, purpose, scope).Scan(&userID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", ErrNotFound
 	}

--- a/migrations/028_login_activation_tokens.sql
+++ b/migrations/028_login_activation_tokens.sql
@@ -1,0 +1,9 @@
+ALTER TABLE auth_tokens
+    ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE auth_tokens
+    DROP CONSTRAINT IF EXISTS auth_tokens_purpose_check;
+
+ALTER TABLE auth_tokens
+    ADD CONSTRAINT auth_tokens_purpose_check
+    CHECK (purpose IN ('email_verification', 'password_reset', 'login_activation'));

--- a/migrations/028_login_activation_tokens.sql
+++ b/migrations/028_login_activation_tokens.sql
@@ -1,6 +1,9 @@
 ALTER TABLE auth_tokens
     ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT '';
 
+ALTER TABLE device_claims
+    DROP CONSTRAINT IF EXISTS device_claims_claimed_by_fkey;
+
 ALTER TABLE auth_tokens
     DROP CONSTRAINT IF EXISTS auth_tokens_purpose_check;
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -140,6 +140,46 @@ paths:
           $ref: "#/components/responses/Error"
         "401":
           $ref: "#/components/responses/Error"
+  /v1/auth/sign-in:
+    post:
+      tags:
+        - Auth
+      operationId: requestEmailSignIn
+      summary: Request an email sign-in activation token.
+      description: Returns the same `202 Accepted` status for unknown, disabled, pending, and throttled users to avoid account enumeration. Raw tokens are delivered only by the configured server-side AuthTokenSink and are never returned in the HTTP response.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmailRequest"
+      responses:
+        "202":
+          description: Sign-in request accepted when applicable.
+        "400":
+          $ref: "#/components/responses/Error"
+  /v1/auth/login/activate:
+    post:
+      tags:
+        - Auth
+      operationId: activateEmailSignIn
+      summary: Activate an email sign-in token.
+      description: Consumes a one-time `login_activation` token and issues the normal Account Manager access and refresh token response. Invalid, expired, and replayed tokens fail without issuing a session.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthTokenRequest"
+      responses:
+        "200":
+          description: Login activation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "400":
+          $ref: "#/components/responses/Error"
   /v1/auth/refresh:
     post:
       tags:
@@ -338,6 +378,52 @@ paths:
       responses:
         "200":
           description: Brand-cloud login succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudLoginResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+  /v1/brand-clouds/{tenantSlug}/auth/sign-in:
+    post:
+      tags:
+        - Brand Cloud Auth
+      operationId: requestBrandCloudEmailSignIn
+      summary: Request a tenant-scoped brand-cloud email sign-in activation token.
+      description: Returns the same `202 Accepted` status for unknown, disabled, pending, tenant-mismatched, and throttled users to avoid account enumeration. Raw tokens are delivered only by the configured server-side AuthTokenSink.
+      parameters:
+        - $ref: "#/components/parameters/TenantSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmailRequest"
+      responses:
+        "202":
+          description: Brand-cloud sign-in request accepted when applicable.
+        "400":
+          $ref: "#/components/responses/Error"
+  /v1/brand-clouds/{tenantSlug}/auth/login/activate:
+    post:
+      tags:
+        - Brand Cloud Auth
+      operationId: activateBrandCloudEmailSignIn
+      summary: Activate a tenant-scoped brand-cloud email sign-in token.
+      description: Consumes a one-time `login_activation` token only when the token's user is active in the requested brand-cloud tenant and issues brand-cloud scoped tokens.
+      parameters:
+        - $ref: "#/components/parameters/TenantSlug"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthTokenRequest"
+      responses:
+        "200":
+          description: Brand-cloud login activation succeeded.
           content:
             application/json:
               schema:
@@ -1180,6 +1266,43 @@ paths:
         "404":
           $ref: "#/components/responses/Error"
   /v1/admin/brand-clouds/{brandCloudId}/users:
+    get:
+      tags:
+        - Brand Clouds
+      operationId: listBrandCloudUsers
+      security:
+        - bearerAuth: []
+      summary: List brand-cloud users, including pending activation and disabled users.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, pending_verification, disabled]
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Brand cloud user list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudUsersResponse"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
     post:
       tags:
         - Brand Clouds
@@ -1210,6 +1333,98 @@ paths:
                 $ref: "#/components/schemas/BrandCloudUserResponse"
         "400":
           $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/disable:
+    post:
+      tags:
+        - Brand Clouds
+      operationId: disableBrandCloudUser
+      security:
+        - bearerAuth: []
+      summary: Disable a brand-cloud user and revoke their brand-cloud refresh tokens.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - $ref: "#/components/parameters/BrandCloudUserId"
+      responses:
+        "200":
+          description: Brand cloud user disabled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudUserStateResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/enable:
+    post:
+      tags:
+        - Brand Clouds
+      operationId: enableBrandCloudUser
+      security:
+        - bearerAuth: []
+      summary: Enable a disabled brand-cloud user.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - $ref: "#/components/parameters/BrandCloudUserId"
+      responses:
+        "200":
+          description: Brand cloud user enabled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudUserStateResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/approve:
+    post:
+      tags:
+        - Brand Clouds
+      operationId: approveBrandCloudUser
+      security:
+        - bearerAuth: []
+      summary: Approve a pending brand-cloud user activation.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - $ref: "#/components/parameters/BrandCloudUserId"
+      responses:
+        "200":
+          description: Brand cloud user approved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandCloudUserStateResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}:
+    delete:
+      tags:
+        - Brand Clouds
+      operationId: deleteBrandCloudUser
+      security:
+        - bearerAuth: []
+      summary: Soft-delete a brand-cloud user by disabling brand-cloud access.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - $ref: "#/components/parameters/BrandCloudUserId"
+      responses:
+        "204":
+          description: Brand cloud user soft-deleted.
         "401":
           $ref: "#/components/responses/Error"
         "403":
@@ -2791,6 +3006,13 @@ components:
       schema:
         type: string
         format: uuid
+    BrandCloudUserId:
+      name: brandCloudUserId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     TenantSlug:
       name: tenantSlug
       in: path
@@ -4045,6 +4267,12 @@ components:
           $ref: "#/components/schemas/BrandCloudUser"
         brand_cloud_member:
           $ref: "#/components/schemas/BrandCloudMember"
+    BrandCloudUserStateResponse:
+      type: object
+      required: [brand_cloud_user]
+      properties:
+        brand_cloud_user:
+          $ref: "#/components/schemas/BrandCloudUser"
     BrandCloudLoginResponse:
       type: object
       required: [brand_cloud, brand_cloud_user, brand_cloud_member, tokens]
@@ -4075,6 +4303,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Organization"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+    BrandCloudUsersResponse:
+      type: object
+      required: [brand_cloud_users, pagination]
+      properties:
+        brand_cloud_users:
+          type: array
+          items:
+            $ref: "#/components/schemas/BrandCloudUser"
         pagination:
           $ref: "#/components/schemas/Pagination"
     DeviceItemProfileResponse:


### PR DESCRIPTION
## Summary
- add enumeration-safe console email sign-in and login activation routes
- add brand-cloud tenant-scoped sign-in and activation with scoped auth token validation
- extend auth_tokens to support login_activation and log-sink token delivery for staging
- document the auth lifecycle and update Account Manager OpenAPI

## Tests
- GOWORK=off go test ./...
- Staging smoke: Account Manager release email-auth-20260611b accepted sign-in, emitted activation token to the log sink, activated platform-admin login, and completed forgot/reset password smoke.