### PR TITLE
[codex] Add brand cloud user app certificate revoke API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -547,6 +547,7 @@ func (s *Server) Router() *gin.Engine {
 	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/disable", s.requirePlatformAdmin(), s.disableBrandCloudUser)
 	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/enable", s.requirePlatformAdmin(), s.enableBrandCloudUser)
 	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/approve", s.requirePlatformAdmin(), s.approveBrandCloudUser)
+	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/app-certificate/revoke", s.requirePlatformAdmin(), s.revokeBrandCloudUserAppCertificate)
 	protected.DELETE("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId", s.requirePlatformAdmin(), s.deleteBrandCloudUser)
 	protected.POST("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.createDeviceClaimToken)
 	protected.GET("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.listDeviceClaimTokens)

--- a/internal/api/brand_clouds_admin.go
+++ b/internal/api/brand_clouds_admin.go
@@ -381,6 +381,15 @@ func (s *Server) approveBrandCloudUser(c *gin.Context) {
 	c.JSON(http.StatusOK, brandCloudUserResponse{BrandCloudUser: user})
 }
 
+func (s *Server) revokeBrandCloudUserAppCertificate(c *gin.Context) {
+	revoked, err := s.store.RevokeValidAppCertificatesForBrandCloudUser(c.Request.Context(), c.Param("brandCloudId"), c.Param("brandCloudUserId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"revoked": revoked})
+}
+
 func (s *Server) deleteBrandCloudUser(c *gin.Context) {
 	if err := s.store.DeleteBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), c.Param("brandCloudUserId")); err != nil {
 		writeStoreError(c, err)

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1753,6 +1753,21 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 	if brandCSR.AppCertificate.Status != "issued" || brandCSR.AppCertificate.FingerprintSHA256 == "" {
 		t.Fatalf("brand-cloud app certificate response = %+v", brandCSR.AppCertificate)
 	}
+	revokeAppCertRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users/"+created.BrandCloudUser.ID+"/app-certificate/revoke", nil, admin.Tokens.AccessToken)
+	if revokeAppCertRes.Code != http.StatusOK {
+		t.Fatalf("expected app certificate revoke 200, got %d: %s", revokeAppCertRes.Code, revokeAppCertRes.Body.String())
+	}
+	brandLoginAfterRevokeRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "initial-password123",
+	}, "")
+	if brandLoginAfterRevokeRes.Code != http.StatusOK {
+		t.Fatalf("expected brand-cloud login after app cert revoke 200, got %d: %s", brandLoginAfterRevokeRes.Code, brandLoginAfterRevokeRes.Body.String())
+	}
+	brandLoginAfterRevoke := decodeBody[tokenBody](t, brandLoginAfterRevokeRes)
+	if brandLoginAfterRevoke.AppCertificate.Status != "csr_required" {
+		t.Fatalf("expected csr_required after app cert revoke, got %+v", brandLoginAfterRevoke.AppCertificate)
+	}
 
 	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, created.User.ID); err != nil {
 		t.Fatal(err)

--- a/internal/api/persistence.go
+++ b/internal/api/persistence.go
@@ -113,6 +113,7 @@ type appCertificatePersistence interface {
 	GetValidAppCertificateForUser(ctx context.Context, userID string, now time.Time) (model.AppCertificate, error)
 	GetValidAppCertificateForSubject(ctx context.Context, subjectType, subjectID string, now time.Time) (model.AppCertificate, error)
 	CreateAppCertificate(ctx context.Context, in store.AppCertificateCreateInput) (model.AppCertificate, error)
+	RevokeValidAppCertificatesForBrandCloudUser(ctx context.Context, brandCloudID, brandCloudUserID string) (int64, error)
 }
 
 type provisioningPersistence interface {

--- a/internal/store/app_certificates.go
+++ b/internal/store/app_certificates.go
@@ -93,6 +93,27 @@ func (s *Store) CreateAppCertificate(ctx context.Context, in AppCertificateCreat
 	return cert, nil
 }
 
+func (s *Store) RevokeValidAppCertificatesForBrandCloudUser(ctx context.Context, brandCloudID, brandCloudUserID string) (int64, error) {
+	tag, err := s.db.Exec(ctx, `
+		UPDATE app_certificates ac
+		SET revoked_at = COALESCE(ac.revoked_at, now()),
+		    updated_at = now()
+		FROM brand_cloud_users bcu
+		JOIN users u ON u.email = bcu.email
+		WHERE bcu.id = $1
+		  AND bcu.brand_cloud_id = $2
+		  AND ac.subject_type = 'platform_user'
+		  AND ac.subject_id = u.id::text
+		  AND ac.revoked_at IS NULL
+		  AND ac.not_before <= now()
+		  AND ac.not_after > now()
+	`, brandCloudUserID, brandCloudID)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
 type appCertificateRow interface {
 	Scan(dest ...any) error
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1411,6 +1411,30 @@ paths:
           $ref: "#/components/responses/Error"
         "404":
           $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/app-certificate/revoke:
+    post:
+      tags:
+        - Brand Clouds
+      operationId: revokeBrandCloudUserAppCertificate
+      security:
+        - bearerAuth: []
+      summary: Revoke active app certificates for a brand-cloud user.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - $ref: "#/components/parameters/BrandCloudUserId"
+      responses:
+        "200":
+          description: Active app certificates revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppCertificateRevokeResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
   /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}:
     delete:
       tags:
@@ -4273,6 +4297,14 @@ components:
       properties:
         brand_cloud_user:
           $ref: "#/components/schemas/BrandCloudUser"
+    AppCertificateRevokeResponse:
+      type: object
+      required: [revoked]
+      properties:
+        revoked:
+          type: integer
+          format: int64
+          minimum: 0
     BrandCloudLoginResponse:
       type: object
       required: [brand_cloud, brand_cloud_user, brand_cloud_member, tokens]


### PR DESCRIPTION
## Summary
- add a platform-admin endpoint to revoke active app certificates for a brand-cloud user
- wire store support for revoking valid app certificates by brand cloud user
- document the endpoint and response schema in OpenAPI

## Why
The staging data setup needs to recover existing brand-cloud users whose app certificate exists remotely but whose local private key is missing. Revoking the stale app certificate lets the next login return `csr_required` so the script can issue a fresh app certificate without manual database work.

## Validation
- `GOWORK=off /usr/local/go/bin/go test ./internal/api ./internal/store -count=1`
