### PR TITLE
Align brand cloud identity with brand-scoped users

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1033,16 +1033,21 @@ Stores one-time email verification, login activation, and password reset tokens.
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `id` | UUID | Yes | Primary key. |
-| `user_id` | UUID | Yes | References `users.id`. |
+| `user_id` | UUID | No | Legacy/platform FK to `users.id`; null for brand-cloud subjects. |
+| `subject_type` | Text | Yes | One of `platform_user`, `brand_cloud_user`. |
+| `subject_id` | UUID | Yes | `users.id` for platform subjects, `brand_cloud_users.id` for brand-cloud subjects. |
 | `purpose` | Text | Yes | One of `email_verification`, `login_activation`, `password_reset`. |
+| `scope` | Text | Yes | Empty for global platform flows; `brand_cloud:<tenantSlug>` for brand-cloud login activation. |
 | `token_hash` | Text | Yes | Unique hash of the one-time token. |
 | `expires_at` | Timestamp | Yes | Expiration timestamp. |
 | `consumed_at` | Timestamp | No | Set after successful one-time use. |
 | `created_at` | Timestamp | Yes | Creation timestamp. |
 
 Auth tokens must be stored hashed, not in raw form, and are throttled by
-`user_id`, `purpose`, and scope when applicable. Tenant-scoped brand-cloud login
-activation tokens store a scope such as `brand_cloud:<tenantSlug>`.
+`subject_type`, `subject_id`, `purpose`, and scope when applicable.
+Tenant-scoped brand-cloud login activation tokens store a scope such as
+`brand_cloud:<tenantSlug>` and reference `brand_cloud_users.id`; they must not
+create or require a global `users` row.
 
 ### Keycloak/OIDC Tables
 
@@ -1434,8 +1439,8 @@ All endpoints are versioned under `/v1`.
 | `GET` | `/v1/admin/brand-clouds` | Yes | Platform admin | List brand cloud organizations. |
 | `GET` | `/v1/admin/brand-clouds/:brandCloudId` | Yes | Platform admin | Read one brand cloud organization. |
 | `PATCH` | `/v1/admin/brand-clouds/:brandCloudId` | Yes | Platform admin | Update brand cloud name, tenant slug, status, or metadata. |
-| `POST` | `/v1/admin/brand-clouds/:brandCloudId/members` | Yes | Platform admin | Assign/update a brand-cloud membership by `brand_cloud_user_id`; legacy `user_id` is accepted only during migration. |
-| `POST` | `/v1/admin/brand-clouds/:brandCloudId/users` | Yes | Platform admin | Create/reactivate a brand-scoped user and membership; response includes legacy aliases during migration. |
+| `POST` | `/v1/admin/brand-clouds/:brandCloudId/members` | Yes | Platform admin | Assign/update a brand-cloud membership by `brand_cloud_user_id`; platform `user_id` values are not accepted. |
+| `POST` | `/v1/admin/brand-clouds/:brandCloudId/users` | Yes | Platform admin | Create/reactivate a brand-scoped user and membership; response returns `brand_cloud_user` and `brand_cloud_member`. |
 | `GET` | `/v1/admin/brand-clouds/:brandCloudId/users` | Yes | Platform admin | List brand-scoped users, including active, pending-verification, and disabled states. |
 | `POST` | `/v1/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/approve` | Yes | Platform admin | Approve a pending brand-cloud user activation and mark the brand-scoped user verified. |
 | `POST` | `/v1/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/disable` | Yes | Platform admin | Disable brand-cloud access and revoke active brand-cloud refresh tokens. |

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -500,6 +500,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestApplyProjectionMetadataPreservesExistingFieldsAndClearsNil`
 - `rtk_account_manager/internal/store`: `TestBrandCloudLoginActivationTokenIsTenantScoped`
 - `rtk_account_manager/internal/store`: `TestBrandCloudStoreCRUDAndErrorPaths`
+- `rtk_account_manager/internal/store`: `TestBrandCloudUserProvisioningUsesBrandScopedIdentityOnly`
 - `rtk_account_manager/internal/store`: `TestClaimOutboxMessagesReadyLeasesRows`
 - `rtk_account_manager/internal/store`: `TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshotWithLossyUTF8`
 - `rtk_account_manager/internal/store`: `TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshot`
@@ -633,7 +634,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 
 ```sh
 gofmt -l .
-TEST_DATABASE_URL='***' go test -json ./... -coverpkg=./internal/... -coverprofile=reports/coverage.out -covermode=atomic
+TEST_DATABASE_URL='***' go test -json -count=1 ./... -coverpkg=./internal/... -coverprofile=reports/coverage.out -covermode=atomic
 go tool cover -func=reports/coverage.out
 go tool cover -html=reports/coverage.out -o reports/coverage.html
 go build ./...

--- a/internal/api/app_certificates.go
+++ b/internal/api/app_certificates.go
@@ -80,6 +80,10 @@ func (s *Server) appCertificateForLogin(ctx context.Context, userID, csrPEM stri
 	return s.appCertificateForSubject(ctx, "platform_user", userID, "app-user:"+userID, csrPEM)
 }
 
+func (s *Server) appCertificateForBrandCloudLogin(ctx context.Context, brandCloudUserID, csrPEM string) (appCertificateResponse, error) {
+	return s.appCertificateForSubject(ctx, "brand_cloud_user", brandCloudUserID, "app-brand-cloud-user:"+brandCloudUserID, csrPEM)
+}
+
 func (s *Server) appCertificateForEndUserLogin(ctx context.Context, endUserID, csrPEM string) (appCertificateResponse, error) {
 	return s.appCertificateForSubject(ctx, "end_user", endUserID, "app-end-user:"+endUserID, csrPEM)
 }

--- a/internal/api/brand_cloud_auth.go
+++ b/internal/api/brand_cloud_auth.go
@@ -67,12 +67,12 @@ func (s *Server) brandCloudActivateLogin(c *gin.Context) {
 }
 
 func (s *Server) writeBrandCloudLoginResponse(c *gin.Context, appCSRPem string, result store.BrandCloudLoginResult) {
-	tokens, err := s.issueBrandCloudTokens(c, result.User.ID, result.BrandCloudUser.ID, result.BrandCloud.ID, valueOrEmpty(result.BrandCloud.TenantSlug))
+	tokens, err := s.issueBrandCloudTokens(c, result.BrandCloudUser.ID, result.BrandCloudUser.ID, result.BrandCloud.ID, valueOrEmpty(result.BrandCloud.TenantSlug))
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "token_issue_failed", "Could not issue tokens")
 		return
 	}
-	appCert, err := s.appCertificateForLogin(c.Request.Context(), result.User.ID, appCSRPem)
+	appCert, err := s.appCertificateForBrandCloudLogin(c.Request.Context(), result.BrandCloudUser.ID, appCSRPem)
 	if err != nil {
 		writeAppCertificateError(c, err)
 		return

--- a/internal/api/brand_clouds_admin.go
+++ b/internal/api/brand_clouds_admin.go
@@ -19,7 +19,6 @@ type brandCloudRequest struct {
 }
 
 type brandCloudMemberRequest struct {
-	UserID           string `json:"user_id,omitempty"`
 	BrandCloudUserID string `json:"brand_cloud_user_id,omitempty"`
 	Role             string `json:"role" binding:"required"`
 }
@@ -284,15 +283,12 @@ func (s *Server) assignBrandCloudMember(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "invalid_role", "Invalid role")
 		return
 	}
-	userID := strings.TrimSpace(req.UserID)
-	if userID == "" {
-		userID = strings.TrimSpace(req.BrandCloudUserID)
-	}
-	if userID == "" {
-		writeError(c, http.StatusBadRequest, "missing_user", "user_id or brand_cloud_user_id is required")
+	brandCloudUserID := strings.TrimSpace(req.BrandCloudUserID)
+	if brandCloudUserID == "" {
+		writeError(c, http.StatusBadRequest, "missing_brand_cloud_user", "brand_cloud_user_id is required")
 		return
 	}
-	member, err := s.store.AssignBrandCloudMember(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), userID, role)
+	member, err := s.store.AssignBrandCloudMember(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), brandCloudUserID, role)
 	if err != nil {
 		writeStoreError(c, err)
 		return

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1457,16 +1457,25 @@ func TestIntegrationPlatformAdminBrandCloudLifecycle(t *testing.T) {
 		t.Fatalf("expected missing brand cloud patch 404, got %d: %s", missingPatchRes.Code, missingPatchRes.Body.String())
 	}
 
+	brandUserRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+created.BrandCloud.ID+"/users", map[string]any{
+		"email":    owner.User.Email,
+		"password": "brand-owner-password123",
+		"role":     "owner",
+	}, admin.Tokens.AccessToken)
+	if brandUserRes.Code != http.StatusCreated {
+		t.Fatalf("expected brand cloud user create 201, got %d: %s", brandUserRes.Code, brandUserRes.Body.String())
+	}
+	brandUser := decodeBody[brandCloudUserBody](t, brandUserRes)
 	memberRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+created.BrandCloud.ID+"/members", map[string]any{
-		"user_id": owner.User.ID,
-		"role":    "owner",
+		"brand_cloud_user_id": brandUser.BrandCloudUser.ID,
+		"role":                "owner",
 	}, admin.Tokens.AccessToken)
 	if memberRes.Code != http.StatusCreated {
 		t.Fatalf("expected brand cloud member assignment 201, got %d: %s", memberRes.Code, memberRes.Body.String())
 	}
 	missingMemberRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/00000000-0000-0000-0000-000000000000/members", map[string]any{
-		"user_id": owner.User.ID,
-		"role":    "member",
+		"brand_cloud_user_id": brandUser.BrandCloudUser.ID,
+		"role":                "member",
 	}, admin.Tokens.AccessToken)
 	if missingMemberRes.Code != http.StatusNotFound {
 		t.Fatalf("expected missing brand cloud member assignment 404, got %d: %s", missingMemberRes.Code, missingMemberRes.Body.String())
@@ -1717,7 +1726,7 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 		t.Fatalf("expected brand user create 201, got %d: %s", createRes.Code, createRes.Body.String())
 	}
 	created := decodeBody[brandCloudUserBody](t, createRes)
-	if created.Action != "created" || created.User.Email != "rtk+001@users.example.com" || !created.User.EmailVerified || created.User.SignupPendingVerification || created.Member.Role != "member" {
+	if created.Action != "created" || created.BrandCloudUser.Email != "rtk+001@users.example.com" || !created.BrandCloudUser.EmailVerified || created.BrandCloudUser.SignupPendingVerification || created.BrandCloudMember.Role != "member" {
 		t.Fatalf("unexpected created brand user response: %+v", created)
 	}
 
@@ -1744,7 +1753,7 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 	brandCSRRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
 		"email":       "rtk+001@users.example.com",
 		"password":    "initial-password123",
-		"app_csr_pem": generateTestCSR(t, "app-user:"+created.User.ID),
+		"app_csr_pem": generateTestCSR(t, "app-brand-cloud-user:"+created.BrandCloudUser.ID),
 	}, "")
 	if brandCSRRes.Code != http.StatusOK {
 		t.Fatalf("expected brand-cloud csr login 200, got %d: %s", brandCSRRes.Code, brandCSRRes.Body.String())
@@ -1754,7 +1763,7 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 		t.Fatalf("brand-cloud app certificate response = %+v", brandCSR.AppCertificate)
 	}
 
-	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, created.User.ID); err != nil {
+	if _, err := env.db.Exec(ctx, `UPDATE brand_cloud_users SET disabled_at = now() WHERE id = $1`, created.BrandCloudUser.ID); err != nil {
 		t.Fatal(err)
 	}
 	reassignRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users", map[string]any{
@@ -1767,7 +1776,7 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 		t.Fatalf("expected existing brand user upsert 200, got %d: %s", reassignRes.Code, reassignRes.Body.String())
 	}
 	reassigned := decodeBody[brandCloudUserBody](t, reassignRes)
-	if reassigned.Action != "assigned" || reassigned.User.DisabledAt != nil || reassigned.User.DisplayName == nil || *reassigned.User.DisplayName != "RTK User 001 Reactivated" {
+	if reassigned.Action != "assigned" || reassigned.BrandCloudUser.DisabledAt != nil || reassigned.BrandCloudUser.DisplayName == nil || *reassigned.BrandCloudUser.DisplayName != "RTK User 001 Reactivated" {
 		t.Fatalf("unexpected reassigned brand user response: %+v", reassigned)
 	}
 	ignoredPasswordLoginRes := performJSON(env.router, http.MethodPost, "/v1/auth/login", map[string]any{
@@ -1809,13 +1818,6 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 		SET email_verified = false, email_verified_at = NULL, signup_pending_verification = true, updated_at = now()
 		WHERE id = $1
 	`, created.BrandCloudUser.ID); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := env.db.Exec(ctx, `
-		UPDATE users
-		SET email_verified = false, email_verified_at = NULL, signup_pending_verification = true, updated_at = now()
-		WHERE id = $1
-	`, created.User.ID); err != nil {
 		t.Fatal(err)
 	}
 	pendingLoginRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
@@ -5511,19 +5513,7 @@ type deviceItemProfilesBody struct {
 }
 
 type brandCloudUserBody struct {
-	Action string `json:"action"`
-	User   struct {
-		ID                        string     `json:"id"`
-		Email                     string     `json:"email"`
-		DisplayName               *string    `json:"display_name"`
-		EmailVerified             bool       `json:"email_verified"`
-		SignupPendingVerification bool       `json:"signup_pending_verification"`
-		DisabledAt                *time.Time `json:"disabled_at"`
-	} `json:"user"`
-	Member struct {
-		UserID string `json:"user_id"`
-		Role   string `json:"role"`
-	} `json:"member"`
+	Action         string `json:"action"`
 	BrandCloudUser struct {
 		ID                        string     `json:"id"`
 		BrandCloudID              string     `json:"brand_cloud_id"`

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -242,11 +242,6 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 		"status": "disabled",
 	}, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPatch, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID, brandCloudPatchRes)
-	brandCloudMemberRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/members", map[string]any{
-		"user_id": registered.User.ID,
-		"role":    "owner",
-	}, admin.Tokens.AccessToken)
-	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/members", brandCloudMemberRes)
 	brandCloudUserRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", map[string]any{
 		"email":        "contract-brand-user@example.com",
 		"password":     "password123",
@@ -255,6 +250,11 @@ func TestIntegrationResponsesMatchOpenAPIContract(t *testing.T) {
 	}, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", brandCloudUserRes)
 	brandCloudUserBody := decodeBody[brandCloudUserBody](t, brandCloudUserRes)
+	brandCloudMemberRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/members", map[string]any{
+		"brand_cloud_user_id": brandCloudUserBody.BrandCloudUser.ID,
+		"role":                "owner",
+	}, admin.Tokens.AccessToken)
+	contract.validate(t, http.MethodPost, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/members", brandCloudMemberRes)
 	brandCloudUsersRes := performJSON(env.router, http.MethodGet, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", nil, admin.Tokens.AccessToken)
 	contract.validate(t, http.MethodGet, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID+"/users", brandCloudUsersRes)
 	brandCloudReactivateRes := performJSON(env.router, http.MethodPatch, "/v1/admin/brand-clouds/"+brandCloudResp.BrandCloud.ID, map[string]any{

--- a/internal/api/persistence.go
+++ b/internal/api/persistence.go
@@ -197,7 +197,7 @@ type brandCloudPersistence interface {
 	GetBrandCloud(ctx context.Context, orgID string) (model.Organization, error)
 	GetBrandCloudByTenantSlug(ctx context.Context, tenantSlug string) (model.Organization, error)
 	UpdateBrandCloud(ctx context.Context, actorUserID, orgID string, in store.BrandCloudInput) (model.Organization, error)
-	AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, userID string, role model.Role) (model.Member, error)
+	AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, brandCloudUserID string, role model.Role) (model.BrandCloudMember, error)
 	CreateBrandCloudUser(ctx context.Context, actorUserID, orgID string, in store.BrandCloudUserInput) (store.BrandCloudUserResult, error)
 	ListBrandCloudUsers(ctx context.Context, in store.BrandCloudUserListFilter) (store.BrandCloudUserPage, error)
 	DisableBrandCloudUser(ctx context.Context, actorUserID, brandCloudID, brandCloudUserID string) (model.BrandCloudUser, error)

--- a/internal/store/app_certificates.go
+++ b/internal/store/app_certificates.go
@@ -99,11 +99,13 @@ func (s *Store) RevokeValidAppCertificatesForBrandCloudUser(ctx context.Context,
 		SET revoked_at = COALESCE(ac.revoked_at, now()),
 		    updated_at = now()
 		FROM brand_cloud_users bcu
-		JOIN users u ON u.email = bcu.email
+		LEFT JOIN users u ON u.email = bcu.email
 		WHERE bcu.id = $1
 		  AND bcu.brand_cloud_id = $2
-		  AND ac.subject_type = 'platform_user'
-		  AND ac.subject_id = u.id::text
+		  AND (
+		    (ac.subject_type = 'brand_cloud_user' AND ac.subject_id = bcu.id::text)
+		    OR (ac.subject_type = 'platform_user' AND u.id IS NOT NULL AND ac.subject_id = u.id::text)
+		  )
 		  AND ac.revoked_at IS NULL
 		  AND ac.not_before <= now()
 		  AND ac.not_after > now()

--- a/internal/store/auth_tokens_integration_test.go
+++ b/internal/store/auth_tokens_integration_test.go
@@ -203,14 +203,90 @@ func TestBrandCloudStoreCRUDAndErrorPaths(t *testing.T) {
 		t.Fatalf("expected missing brand cloud update not found, got %v", err)
 	}
 
-	assigned, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, acme.ID, member.User.ID, model.RoleAdmin)
+	brandMember, err := env.store.CreateBrandCloudUser(ctx, admin.User.ID, acme.ID, BrandCloudUserInput{
+		Email:        member.User.Email,
+		PasswordHash: "hash",
+		Role:         model.RoleMember,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if assigned.UserID != member.User.ID || assigned.Role != model.RoleAdmin {
+	assigned, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, acme.ID, brandMember.BrandCloudUser.ID, model.RoleAdmin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assigned.BrandCloudUserID != brandMember.BrandCloudUser.ID || assigned.Role != model.RoleAdmin {
 		t.Fatalf("unexpected assigned brand-cloud member: %+v", assigned)
 	}
-	if _, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, "00000000-0000-0000-0000-000000000000", member.User.ID, model.RoleMember); !errors.Is(err, ErrNotFound) {
+	if _, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, "00000000-0000-0000-0000-000000000000", brandMember.BrandCloudUser.ID, model.RoleMember); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected missing brand cloud member assignment not found, got %v", err)
+	}
+}
+
+func TestBrandCloudUserProvisioningUsesBrandScopedIdentityOnly(t *testing.T) {
+	env := newStoreIntegrationEnv(t)
+	ctx := context.Background()
+
+	admin, err := env.store.Register(ctx, RegisterInput{
+		Email:            "brand-target-admin@example.com",
+		PasswordHash:     "hash",
+		OrganizationName: "Brand Target Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	acme, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Target Acme", TenantSlug: "target-acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contoso, err := env.store.CreateBrandCloud(ctx, admin.User.ID, BrandCloudInput{Name: "Target Contoso", TenantSlug: "target-contoso"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acmeUser, err := env.store.CreateBrandCloudUser(ctx, admin.User.ID, acme.ID, BrandCloudUserInput{
+		Email:        "shared-target@example.com",
+		PasswordHash: "hash-acme",
+		Role:         model.RoleOwner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contosoUser, err := env.store.CreateBrandCloudUser(ctx, admin.User.ID, contoso.ID, BrandCloudUserInput{
+		Email:        "shared-target@example.com",
+		PasswordHash: "hash-contoso",
+		Role:         model.RoleAdmin,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acmeUser.BrandCloudUser.ID == contosoUser.BrandCloudUser.ID {
+		t.Fatalf("same email in different brand clouds must create distinct brand-cloud users: acme=%+v contoso=%+v", acmeUser, contosoUser)
+	}
+
+	var globalUserCount int
+	if err := env.db.QueryRow(ctx, `SELECT count(*) FROM users WHERE email = 'shared-target@example.com'`).Scan(&globalUserCount); err != nil {
+		t.Fatal(err)
+	}
+	if globalUserCount != 0 {
+		t.Fatalf("brand-cloud user provisioning must not create global users, got %d", globalUserCount)
+	}
+	var legacyMembershipCount int
+	if err := env.db.QueryRow(ctx, `SELECT count(*) FROM organization_members WHERE organization_id IN ($1, $2)`, acme.ID, contoso.ID).Scan(&legacyMembershipCount); err != nil {
+		t.Fatal(err)
+	}
+	if legacyMembershipCount != 0 {
+		t.Fatalf("brand-cloud user provisioning must not create legacy organization_members, got %d", legacyMembershipCount)
+	}
+
+	assigned, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, acme.ID, acmeUser.BrandCloudUser.ID, model.RoleAdmin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assigned.BrandCloudUserID != acmeUser.BrandCloudUser.ID || assigned.Role != model.RoleAdmin {
+		t.Fatalf("brand-cloud member assignment must use brand_cloud_user_id only, got %+v", assigned)
+	}
+	if _, err := env.store.AssignBrandCloudMember(ctx, admin.User.ID, acme.ID, admin.User.ID, model.RoleMember); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("legacy global user_id assignment must be rejected, got %v", err)
 	}
 }

--- a/internal/store/brand_clouds.go
+++ b/internal/store/brand_clouds.go
@@ -193,10 +193,10 @@ func (s *Store) UpdateBrandCloud(ctx context.Context, actorUserID, orgID string,
 	return org, nil
 }
 
-func (s *Store) AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, userID string, role model.Role) (model.Member, error) {
+func (s *Store) AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, brandCloudUserID string, role model.Role) (model.BrandCloudMember, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return model.Member{}, err
+		return model.BrandCloudMember{}, err
 	}
 	defer tx.Rollback(ctx)
 
@@ -207,32 +207,37 @@ func (s *Store) AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, 
 			WHERE id = $1 AND organization_kind = 'brand_cloud'
 		)
 	`, orgID).Scan(&exists); err != nil {
-		return model.Member{}, err
+		return model.BrandCloudMember{}, err
 	}
 	if !exists {
-		return model.Member{}, ErrNotFound
+		return model.BrandCloudMember{}, ErrNotFound
 	}
 
-	member, err := scanMember(tx.QueryRow(ctx, `
-		INSERT INTO organization_members (organization_id, user_id, role)
-		SELECT $1, id, $3 FROM users WHERE id = $2 AND disabled_at IS NULL
-		ON CONFLICT (organization_id, user_id)
+	member, err := scanBrandCloudMember(tx.QueryRow(ctx, `
+		INSERT INTO brand_cloud_memberships (brand_cloud_id, brand_cloud_user_id, role)
+		SELECT $1, id, $3
+		FROM brand_cloud_users
+		WHERE brand_cloud_id = $1 AND id = $2 AND disabled_at IS NULL
+		ON CONFLICT ON CONSTRAINT brand_cloud_memberships_brand_user_key
 		DO UPDATE SET role = EXCLUDED.role, updated_at = now()
-		RETURNING organization_id::text, user_id::text, role, created_at, updated_at
-	`, orgID, userID, role))
+		RETURNING brand_cloud_id::text, brand_cloud_user_id::text, role, created_at, updated_at
+	`, orgID, brandCloudUserID, role))
 	if errors.Is(err, pgx.ErrNoRows) {
-		return model.Member{}, ErrNotFound
+		return model.BrandCloudMember{}, ErrNotFound
 	}
 	if err != nil {
-		return model.Member{}, err
+		return model.BrandCloudMember{}, err
 	}
-	user, err := getUserTx(ctx, tx, member.UserID)
+	user, err := scanBrandCloudUser(tx.QueryRow(ctx, `
+		SELECT id::text, brand_cloud_id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
+		FROM brand_cloud_users
+		WHERE brand_cloud_id = $1 AND id = $2
+	`, orgID, member.BrandCloudUserID))
 	if err != nil {
-		return model.Member{}, err
+		return model.BrandCloudMember{}, err
 	}
 	member.Email = user.Email
 	member.DisplayName = user.DisplayName
-	member.DisabledAt = user.DisabledAt
 
 	if err := createAuditEventTx(ctx, tx, AuditEventInput{
 		EventType:      "brand_cloud_member_assigned",
@@ -241,14 +246,15 @@ func (s *Store) AssignBrandCloudMember(ctx context.Context, actorUserID, orgID, 
 		SubjectType:    "brand_cloud",
 		SubjectID:      orgID,
 		Payload: map[string]any{
-			"user_id": member.UserID,
-			"role":    member.Role,
+			"brand_cloud_user_id": member.BrandCloudUserID,
+			"email":               member.Email,
+			"role":                member.Role,
 		},
 	}); err != nil {
-		return model.Member{}, err
+		return model.BrandCloudMember{}, err
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return model.Member{}, err
+		return model.BrandCloudMember{}, err
 	}
 	return member, nil
 }
@@ -318,39 +324,6 @@ func (s *Store) CreateBrandCloudUser(ctx context.Context, actorUserID, orgID str
 	brandCloudMember.Email = brandCloudUser.Email
 	brandCloudMember.DisplayName = brandCloudUser.DisplayName
 
-	var user model.User
-	err = tx.QueryRow(ctx, `
-		INSERT INTO users (email, password_hash, display_name, email_verified, email_verified_at, signup_pending_verification, disabled_at)
-		VALUES ($1, $2, $3, true, now(), false, NULL)
-		ON CONFLICT (email)
-		DO UPDATE SET
-			password_hash = CASE WHEN $4 THEN EXCLUDED.password_hash ELSE users.password_hash END,
-			display_name = COALESCE(EXCLUDED.display_name, users.display_name),
-			email_verified = true,
-			email_verified_at = COALESCE(users.email_verified_at, now()),
-			signup_pending_verification = false,
-			disabled_at = NULL,
-			updated_at = now()
-		RETURNING id::text, email, display_name, email_verified, email_verified_at, signup_pending_verification, created_at, updated_at, disabled_at
-	`, email, in.PasswordHash, in.DisplayName, in.RotatePassword).Scan(&user.ID, &user.Email, &user.DisplayName, &user.EmailVerified, &user.EmailVerifiedAt, &user.SignupPendingVerification, &user.CreatedAt, &user.UpdatedAt, &user.DisabledAt)
-	if err != nil {
-		return BrandCloudUserResult{}, err
-	}
-
-	member, err := scanMember(tx.QueryRow(ctx, `
-		INSERT INTO organization_members (organization_id, user_id, role)
-		VALUES ($1, $2, $3)
-		ON CONFLICT (organization_id, user_id)
-		DO UPDATE SET role = EXCLUDED.role, updated_at = now()
-		RETURNING organization_id::text, user_id::text, role, created_at, updated_at
-	`, orgID, user.ID, in.Role))
-	if err != nil {
-		return BrandCloudUserResult{}, err
-	}
-	member.Email = user.Email
-	member.DisplayName = user.DisplayName
-	member.DisabledAt = user.DisabledAt
-
 	eventType := "brand_cloud_user_assigned"
 	if action == "created" {
 		eventType = "brand_cloud_user_created"
@@ -362,7 +335,6 @@ func (s *Store) CreateBrandCloudUser(ctx context.Context, actorUserID, orgID str
 		SubjectType:    "brand_cloud",
 		SubjectID:      orgID,
 		Payload: map[string]any{
-			"user_id":             user.ID,
 			"brand_cloud_user_id": brandCloudUser.ID,
 			"email":               brandCloudUser.Email,
 			"role":                brandCloudMember.Role,
@@ -374,7 +346,7 @@ func (s *Store) CreateBrandCloudUser(ctx context.Context, actorUserID, orgID str
 	if err := tx.Commit(ctx); err != nil {
 		return BrandCloudUserResult{}, err
 	}
-	return BrandCloudUserResult{Action: action, User: user, Member: member, BrandCloudUser: brandCloudUser, BrandCloudMember: brandCloudMember}, nil
+	return BrandCloudUserResult{Action: action, BrandCloudUser: brandCloudUser, BrandCloudMember: brandCloudMember}, nil
 }
 
 func (s *Store) ListBrandCloudUsers(ctx context.Context, in BrandCloudUserListFilter) (BrandCloudUserPage, error) {
@@ -461,17 +433,6 @@ func (s *Store) ApproveBrandCloudUser(ctx context.Context, actorUserID, brandClo
 	if err != nil {
 		return model.BrandCloudUser{}, err
 	}
-	if _, err := tx.Exec(ctx, `
-		UPDATE users
-		SET email_verified = true,
-		    email_verified_at = COALESCE(email_verified_at, now()),
-		    signup_pending_verification = false,
-		    disabled_at = NULL,
-		    updated_at = now()
-		WHERE email = $1
-	`, user.Email); err != nil {
-		return model.BrandCloudUser{}, err
-	}
 	if err := createAuditEventTx(ctx, tx, AuditEventInput{
 		EventType:      "brand_cloud_user_approved",
 		ActorUserID:    &actorUserID,
@@ -521,7 +482,7 @@ func (s *Store) CreateBrandCloudLoginActivationTokenForEmail(ctx context.Context
 	if err != nil {
 		return false, err
 	}
-	return true, s.createScopedLoginActivationToken(ctx, result.User.ID, brandCloudAuthTokenScope(tenantSlug), tokenHash, expiresAt)
+	return true, s.createAuthTokenForSubject(ctx, "brand_cloud_user", result.BrandCloudUser.ID, "", "login_activation", brandCloudAuthTokenScope(tenantSlug), tokenHash, expiresAt)
 }
 
 func (s *Store) ActivateBrandCloudLoginToken(ctx context.Context, tenantSlug, tokenHash string) (BrandCloudLoginResult, error) {
@@ -531,20 +492,25 @@ func (s *Store) ActivateBrandCloudLoginToken(ctx context.Context, tenantSlug, to
 	}
 	defer tx.Rollback(ctx)
 
-	var userID, email string
+	var brandCloudUserID string
 	err = tx.QueryRow(ctx, `
-		SELECT u.id::text, u.email
+		SELECT bcu.id::text
 		FROM auth_tokens at
-		JOIN users u ON u.id = at.user_id
+		JOIN brand_cloud_users bcu ON bcu.id = at.subject_id
+		JOIN organizations o ON o.id = bcu.brand_cloud_id
 		WHERE at.token_hash = $1
+		  AND at.subject_type = 'brand_cloud_user'
 		  AND at.purpose = 'login_activation'
 		  AND at.scope = $2
 		  AND at.consumed_at IS NULL
 		  AND at.expires_at > now()
-		  AND u.disabled_at IS NULL
-		  AND u.signup_pending_verification = false
+		  AND o.organization_kind = 'brand_cloud'
+		  AND o.status = 'active'
+		  AND o.tenant_slug = $3
+		  AND bcu.disabled_at IS NULL
+		  AND bcu.signup_pending_verification = false
 		FOR UPDATE OF at
-	`, tokenHash, brandCloudAuthTokenScope(tenantSlug)).Scan(&userID, &email)
+	`, tokenHash, brandCloudAuthTokenScope(tenantSlug), normalizeTenantSlug(tenantSlug)).Scan(&brandCloudUserID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return BrandCloudLoginResult{}, ErrNotFound
 	}
@@ -552,11 +518,11 @@ func (s *Store) ActivateBrandCloudLoginToken(ctx context.Context, tenantSlug, to
 		return BrandCloudLoginResult{}, err
 	}
 
-	result, err := getBrandCloudLoginResultByEmail(ctx, tx, tenantSlug, email)
+	result, err := getBrandCloudLoginResultByID(ctx, tx, tenantSlug, brandCloudUserID)
 	if err != nil {
 		return BrandCloudLoginResult{}, err
 	}
-	if result.User.ID != userID || result.BrandCloudUser.SignupPendingVerification {
+	if result.BrandCloudUser.SignupPendingVerification {
 		return BrandCloudLoginResult{}, ErrNotFound
 	}
 	if _, err := tx.Exec(ctx, `
@@ -568,7 +534,6 @@ func (s *Store) ActivateBrandCloudLoginToken(ctx context.Context, tenantSlug, to
 	}
 	if err := createAuditEventTx(ctx, tx, AuditEventInput{
 		EventType:      "brand_cloud_login_activation_consumed",
-		ActorUserID:    &userID,
 		OrganizationID: &result.BrandCloud.ID,
 		SubjectType:    "brand_cloud_user",
 		SubjectID:      result.BrandCloudUser.ID,
@@ -592,25 +557,31 @@ func brandCloudAuthTokenScope(tenantSlug string) string {
 }
 
 func getBrandCloudLoginResultByEmail(ctx context.Context, q rowQuerier, tenantSlug, email string) (BrandCloudLoginResult, error) {
+	return getBrandCloudLoginResult(ctx, q, tenantSlug, strings.ToLower(strings.TrimSpace(email)), "")
+}
+
+func getBrandCloudLoginResultByID(ctx context.Context, q rowQuerier, tenantSlug, brandCloudUserID string) (BrandCloudLoginResult, error) {
+	return getBrandCloudLoginResult(ctx, q, tenantSlug, "", brandCloudUserID)
+}
+
+func getBrandCloudLoginResult(ctx context.Context, q rowQuerier, tenantSlug, email, brandCloudUserID string) (BrandCloudLoginResult, error) {
 	var result BrandCloudLoginResult
 	var rawMetadata []byte
 	err := q.QueryRow(ctx, `
 		SELECT
 		    o.id::text, o.name, o.tenant_slug, ''::text, o.organization_kind, o.status, o.tier, o.evaluation_device_quota, o.metadata, o.created_at, o.updated_at,
 		    bcu.id::text, bcu.brand_cloud_id::text, bcu.email, bcu.password_hash, bcu.display_name, bcu.email_verified, bcu.email_verified_at, bcu.signup_pending_verification, bcu.created_at, bcu.updated_at, bcu.disabled_at,
-		    bcm.role, bcm.created_at, bcm.updated_at,
-		    u.id::text, u.email, u.display_name, u.email_verified, u.email_verified_at, u.signup_pending_verification, u.created_at, u.updated_at, u.disabled_at
+		    bcm.role, bcm.created_at, bcm.updated_at
 		FROM organizations o
 		JOIN brand_cloud_users bcu ON bcu.brand_cloud_id = o.id
 		JOIN brand_cloud_memberships bcm ON bcm.brand_cloud_id = o.id AND bcm.brand_cloud_user_id = bcu.id
-		JOIN users u ON u.email = bcu.email
 		WHERE o.organization_kind = 'brand_cloud'
 		  AND o.status = 'active'
 		  AND o.tenant_slug = $1
-		  AND bcu.email = $2
+		  AND ($2 = '' OR bcu.email = $2)
+		  AND ($3 = '' OR bcu.id = NULLIF($3, '')::uuid)
 		  AND bcu.disabled_at IS NULL
-		  AND u.disabled_at IS NULL
-	`, normalizeTenantSlug(tenantSlug), strings.ToLower(strings.TrimSpace(email))).Scan(
+	`, normalizeTenantSlug(tenantSlug), email, brandCloudUserID).Scan(
 		&result.BrandCloud.ID,
 		&result.BrandCloud.Name,
 		&result.BrandCloud.TenantSlug,
@@ -636,15 +607,6 @@ func getBrandCloudLoginResultByEmail(ctx context.Context, q rowQuerier, tenantSl
 		&result.Member.Role,
 		&result.Member.CreatedAt,
 		&result.Member.UpdatedAt,
-		&result.User.ID,
-		&result.User.Email,
-		&result.User.DisplayName,
-		&result.User.EmailVerified,
-		&result.User.EmailVerifiedAt,
-		&result.User.SignupPendingVerification,
-		&result.User.CreatedAt,
-		&result.User.UpdatedAt,
-		&result.User.DisabledAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return BrandCloudLoginResult{}, ErrNotFound
@@ -659,6 +621,15 @@ func getBrandCloudLoginResultByEmail(ctx context.Context, q rowQuerier, tenantSl
 	result.Member.BrandCloudUserID = result.BrandCloudUser.ID
 	result.Member.Email = result.BrandCloudUser.Email
 	result.Member.DisplayName = result.BrandCloudUser.DisplayName
+	result.User.ID = result.BrandCloudUser.ID
+	result.User.Email = result.BrandCloudUser.Email
+	result.User.DisplayName = result.BrandCloudUser.DisplayName
+	result.User.EmailVerified = result.BrandCloudUser.EmailVerified
+	result.User.EmailVerifiedAt = result.BrandCloudUser.EmailVerifiedAt
+	result.User.SignupPendingVerification = result.BrandCloudUser.SignupPendingVerification
+	result.User.CreatedAt = result.BrandCloudUser.CreatedAt
+	result.User.UpdatedAt = result.BrandCloudUser.UpdatedAt
+	result.User.DisabledAt = result.BrandCloudUser.DisabledAt
 	return result, nil
 }
 

--- a/internal/store/schema_integration_test.go
+++ b/internal/store/schema_integration_test.go
@@ -44,7 +44,7 @@ func TestIntegrationDatabaseSchemaInvariants(t *testing.T) {
 
 	requiredColumns := map[string][]string{
 		"organizations":              {"organization_kind", "status", "metadata", "tenant_slug"},
-		"auth_tokens":                {"user_id", "purpose", "scope", "token_hash", "expires_at", "consumed_at"},
+		"auth_tokens":                {"user_id", "subject_type", "subject_id", "purpose", "scope", "token_hash", "expires_at", "consumed_at"},
 		"brand_cloud_users":          {"brand_cloud_id", "email", "password_hash", "display_name", "email_verified", "email_verified_at", "signup_pending_verification", "disabled_at"},
 		"brand_cloud_memberships":    {"brand_cloud_id", "brand_cloud_user_id", "role"},
 		"brand_cloud_refresh_tokens": {"brand_cloud_user_id", "brand_cloud_id", "token_hash", "expires_at", "revoked_at"},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -71,8 +71,6 @@ type BrandCloudUserInput struct {
 
 type BrandCloudUserResult struct {
 	Action           string                 `json:"action"`
-	User             model.User             `json:"user"`
-	Member           model.Member           `json:"member"`
 	BrandCloudUser   model.BrandCloudUser   `json:"brand_cloud_user"`
 	BrandCloudMember model.BrandCloudMember `json:"brand_cloud_member"`
 }
@@ -537,6 +535,10 @@ func (s *Store) ResetPasswordWithToken(ctx context.Context, tokenHash, passwordH
 }
 
 func (s *Store) createAuthToken(ctx context.Context, userID, purpose, scope, tokenHash string, expiresAt time.Time) error {
+	return s.createAuthTokenForSubject(ctx, "platform_user", userID, userID, purpose, scope, tokenHash, expiresAt)
+}
+
+func (s *Store) createAuthTokenForSubject(ctx context.Context, subjectType, subjectID, userID, purpose, scope, tokenHash string, expiresAt time.Time) error {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err
@@ -547,8 +549,8 @@ func (s *Store) createAuthToken(ctx context.Context, userID, purpose, scope, tok
 	if err := tx.QueryRow(ctx, `
 		SELECT count(*)
 		FROM auth_tokens
-		WHERE user_id = $1 AND purpose = $2 AND scope = $3 AND created_at > now() - interval '1 hour'
-	`, userID, purpose, scope).Scan(&recent); err != nil {
+		WHERE subject_type = $1 AND subject_id = $2 AND purpose = $3 AND scope = $4 AND created_at > now() - interval '1 hour'
+	`, subjectType, subjectID, purpose, scope).Scan(&recent); err != nil {
 		return err
 	}
 	if recent >= 5 {
@@ -557,14 +559,14 @@ func (s *Store) createAuthToken(ctx context.Context, userID, purpose, scope, tok
 	if _, err := tx.Exec(ctx, `
 		UPDATE auth_tokens
 		SET consumed_at = now()
-		WHERE user_id = $1 AND purpose = $2 AND scope = $3 AND consumed_at IS NULL
-	`, userID, purpose, scope); err != nil {
+		WHERE subject_type = $1 AND subject_id = $2 AND purpose = $3 AND scope = $4 AND consumed_at IS NULL
+	`, subjectType, subjectID, purpose, scope); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO auth_tokens (user_id, purpose, scope, token_hash, expires_at)
-		VALUES ($1, $2, $3, $4, $5)
-	`, userID, purpose, scope, tokenHash, expiresAt); err != nil {
+		INSERT INTO auth_tokens (user_id, subject_type, subject_id, purpose, scope, token_hash, expires_at)
+		VALUES (NULLIF($1, '')::uuid, $2, $3, $4, $5, $6, $7)
+	`, userID, subjectType, subjectID, purpose, scope, tokenHash, expiresAt); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/migrations/029_auth_token_subjects.sql
+++ b/migrations/029_auth_token_subjects.sql
@@ -1,0 +1,24 @@
+ALTER TABLE auth_tokens
+    ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE auth_tokens
+    ADD COLUMN IF NOT EXISTS subject_type TEXT NOT NULL DEFAULT 'platform_user',
+    ADD COLUMN IF NOT EXISTS subject_id UUID;
+
+UPDATE auth_tokens
+SET subject_type = 'platform_user',
+    subject_id = user_id
+WHERE subject_id IS NULL;
+
+ALTER TABLE auth_tokens
+    ALTER COLUMN subject_id SET NOT NULL;
+
+ALTER TABLE auth_tokens
+    DROP CONSTRAINT IF EXISTS auth_tokens_subject_type_check;
+
+ALTER TABLE auth_tokens
+    ADD CONSTRAINT auth_tokens_subject_type_check
+    CHECK (subject_type IN ('platform_user', 'brand_cloud_user'));
+
+CREATE INDEX IF NOT EXISTS auth_tokens_subject_purpose_idx
+    ON auth_tokens (subject_type, subject_id, purpose, scope, created_at DESC);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3764,16 +3764,12 @@ components:
           additionalProperties: true
     BrandCloudMemberRequest:
       type: object
-      required: [role]
+      required: [brand_cloud_user_id, role]
       properties:
-        user_id:
-          type: string
-          format: uuid
-          description: Legacy platform user id accepted during migration.
         brand_cloud_user_id:
           type: string
           format: uuid
-          description: Brand-scoped user id.
+          description: Brand-scoped user id. Platform user ids are not accepted for brand-cloud membership writes.
         role:
           $ref: "#/components/schemas/Role"
     BrandCloudUserRequest:
@@ -3807,7 +3803,7 @@ components:
           type: string
         app_csr_pem:
           type: string
-          description: Optional app-generated CSR PEM. For APP end users, the CSR subject must be `app-end-user:<end_user_id>`.
+          description: Optional app-generated CSR PEM. Platform users use `app-user:<user_id>`, brand-cloud users use `app-brand-cloud-user:<brand_cloud_user_id>`, and APP end users use `app-end-user:<end_user_id>`.
     DeviceItemProfileRequest:
       type: object
       additionalProperties: false
@@ -4184,7 +4180,7 @@ components:
           enum: [csr_required, issued]
         subject:
           type: string
-          description: APP certificate subject. Platform users use `app-user:<user_id>`; APP end users use `app-end-user:<end_user_id>`.
+          description: APP certificate subject. Platform users use `app-user:<user_id>`, brand-cloud users use `app-brand-cloud-user:<brand_cloud_user_id>`, and APP end users use `app-end-user:<end_user_id>`.
           example: app-end-user:0f0475fb-4c8d-4f78-8b6f-3b9e76c5b34b
         certificate_pem:
           type: string
@@ -4254,15 +4250,11 @@ components:
           $ref: "#/components/schemas/Organization"
     BrandCloudUserResponse:
       type: object
-      required: [action, user, member, brand_cloud_user, brand_cloud_member]
+      required: [action, brand_cloud_user, brand_cloud_member]
       properties:
         action:
           type: string
           enum: [created, assigned]
-        user:
-          $ref: "#/components/schemas/User"
-        member:
-          $ref: "#/components/schemas/Member"
         brand_cloud_user:
           $ref: "#/components/schemas/BrandCloudUser"
         brand_cloud_member:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1241,7 +1241,7 @@ paths:
       operationId: assignBrandCloudMember
       security:
         - bearerAuth: []
-      summary: Assign an existing user to a brand cloud.
+      summary: Assign an existing brand-scoped user to a brand cloud.
       parameters:
         - $ref: "#/components/parameters/BrandCloudId"
       requestBody:
@@ -1256,7 +1256,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MemberResponse"
+                $ref: "#/components/schemas/BrandCloudMemberResponse"
         "400":
           $ref: "#/components/responses/Error"
         "401":
@@ -4506,6 +4506,12 @@ components:
       properties:
         member:
           $ref: "#/components/schemas/Member"
+    BrandCloudMemberResponse:
+      type: object
+      required: [member]
+      properties:
+        member:
+          $ref: "#/components/schemas/BrandCloudMember"
     DevicesResponse:
       type: object
       required: [devices, pagination]

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -56,8 +56,23 @@ if [ -s "$FORMAT_OUT" ]; then
 	format_status=1
 fi
 
-TEST_DATABASE_URL="$TEST_DATABASE_URL" go test -json ./... -coverpkg=./internal/... -coverprofile="$COVERAGE_OUT" -covermode=atomic | tee "$TEST_EVENTS" >/dev/null
+TEST_DATABASE_URL="$TEST_DATABASE_URL" go test -json -count=1 ./... -coverpkg=./internal/... -coverprofile="$COVERAGE_OUT" -covermode=atomic | tee "$TEST_EVENTS" >/dev/null
 test_status=${PIPESTATUS[0]}
+if [ "$test_status" -ne 0 ]; then
+	echo "go test failed with status $test_status. Failed test events:" >&2
+	grep '"Action":"fail"' "$TEST_EVENTS" >&2 || true
+	grep '"Action":"fail".*"Test":' "$TEST_EVENTS" \
+		| sed -E 's/.*"Test":"([^"]+)".*/\1/' \
+		| LC_ALL=C sort -u \
+		| while IFS= read -r failed_test; do
+			if [ -n "$failed_test" ]; then
+				echo "Events for failed test $failed_test:" >&2
+				grep '"Test":"'"$failed_test"'"' "$TEST_EVENTS" >&2 || true
+			fi
+		done
+	echo "Last 80 go test events:" >&2
+	tail -80 "$TEST_EVENTS" >&2 || true
+fi
 
 if [ -f "$COVERAGE_OUT" ]; then
 	go tool cover -func="$COVERAGE_OUT" >"$COVERAGE_FUNC"
@@ -272,7 +287,7 @@ $(if [ -s "$TEST_CASES_MD" ]; then cat "$TEST_CASES_MD"; else echo "No test case
 
 \`\`\`sh
 gofmt -l .
-TEST_DATABASE_URL='***' go test -json ./... -coverpkg=./internal/... -coverprofile=$COVERAGE_OUT -covermode=atomic
+TEST_DATABASE_URL='***' go test -json -count=1 ./... -coverpkg=./internal/... -coverprofile=$COVERAGE_OUT -covermode=atomic
 go tool cover -func=$COVERAGE_OUT
 go tool cover -html=$COVERAGE_OUT -o $COVERAGE_HTML
 go build ./...


### PR DESCRIPTION
## Summary
- Make brand-cloud membership writes use brand_cloud_user_id only.
- Stop brand-cloud user provisioning from creating global users or organization_members rows.
- Add auth_tokens subject_type/subject_id so brand-cloud login activation targets brand_cloud_users directly.
- Update Account Manager SPEC/OpenAPI and integration coverage.

## Test Plan
- GOWORK=off GOCACHE=/private/tmp/rtk-brand-account-gocache go test ./...
