### PR TITLE
Use GoDaddy DNS-01 for account manager certs

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -547,6 +547,7 @@ func (s *Server) Router() *gin.Engine {
 	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/disable", s.requirePlatformAdmin(), s.disableBrandCloudUser)
 	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/enable", s.requirePlatformAdmin(), s.enableBrandCloudUser)
 	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/approve", s.requirePlatformAdmin(), s.approveBrandCloudUser)
+	protected.POST("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId/app-certificate/revoke", s.requirePlatformAdmin(), s.revokeBrandCloudUserAppCertificate)
 	protected.DELETE("/admin/brand-clouds/:brandCloudId/users/:brandCloudUserId", s.requirePlatformAdmin(), s.deleteBrandCloudUser)
 	protected.POST("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.createDeviceClaimToken)
 	protected.GET("/admin/device-claim-tokens", s.requirePlatformAdmin(), s.listDeviceClaimTokens)

--- a/internal/api/brand_clouds_admin.go
+++ b/internal/api/brand_clouds_admin.go
@@ -381,6 +381,15 @@ func (s *Server) approveBrandCloudUser(c *gin.Context) {
 	c.JSON(http.StatusOK, brandCloudUserResponse{BrandCloudUser: user})
 }
 
+func (s *Server) revokeBrandCloudUserAppCertificate(c *gin.Context) {
+	revoked, err := s.store.RevokeValidAppCertificatesForBrandCloudUser(c.Request.Context(), c.Param("brandCloudId"), c.Param("brandCloudUserId"))
+	if err != nil {
+		writeStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"revoked": revoked})
+}
+
 func (s *Server) deleteBrandCloudUser(c *gin.Context) {
 	if err := s.store.DeleteBrandCloudUser(c.Request.Context(), currentUserID(c), c.Param("brandCloudId"), c.Param("brandCloudUserId")); err != nil {
 		writeStoreError(c, err)

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1753,6 +1753,21 @@ func TestIntegrationPlatformAdminCreatesActiveBrandCloudUser(t *testing.T) {
 	if brandCSR.AppCertificate.Status != "issued" || brandCSR.AppCertificate.FingerprintSHA256 == "" {
 		t.Fatalf("brand-cloud app certificate response = %+v", brandCSR.AppCertificate)
 	}
+	revokeAppCertRes := performJSON(env.router, http.MethodPost, "/v1/admin/brand-clouds/"+brand.BrandCloud.ID+"/users/"+created.BrandCloudUser.ID+"/app-certificate/revoke", nil, admin.Tokens.AccessToken)
+	if revokeAppCertRes.Code != http.StatusOK {
+		t.Fatalf("expected app certificate revoke 200, got %d: %s", revokeAppCertRes.Code, revokeAppCertRes.Body.String())
+	}
+	brandLoginAfterRevokeRes := performJSON(env.router, http.MethodPost, "/v1/brand-clouds/rtk-brand/auth/login", map[string]any{
+		"email":    "rtk+001@users.example.com",
+		"password": "initial-password123",
+	}, "")
+	if brandLoginAfterRevokeRes.Code != http.StatusOK {
+		t.Fatalf("expected brand-cloud login after app cert revoke 200, got %d: %s", brandLoginAfterRevokeRes.Code, brandLoginAfterRevokeRes.Body.String())
+	}
+	brandLoginAfterRevoke := decodeBody[tokenBody](t, brandLoginAfterRevokeRes)
+	if brandLoginAfterRevoke.AppCertificate.Status != "csr_required" {
+		t.Fatalf("expected csr_required after app cert revoke, got %+v", brandLoginAfterRevoke.AppCertificate)
+	}
 
 	if _, err := env.db.Exec(ctx, `UPDATE users SET disabled_at = now() WHERE id = $1`, created.User.ID); err != nil {
 		t.Fatal(err)

--- a/internal/api/persistence.go
+++ b/internal/api/persistence.go
@@ -113,6 +113,7 @@ type appCertificatePersistence interface {
 	GetValidAppCertificateForUser(ctx context.Context, userID string, now time.Time) (model.AppCertificate, error)
 	GetValidAppCertificateForSubject(ctx context.Context, subjectType, subjectID string, now time.Time) (model.AppCertificate, error)
 	CreateAppCertificate(ctx context.Context, in store.AppCertificateCreateInput) (model.AppCertificate, error)
+	RevokeValidAppCertificatesForBrandCloudUser(ctx context.Context, brandCloudID, brandCloudUserID string) (int64, error)
 }
 
 type provisioningPersistence interface {

--- a/internal/store/app_certificates.go
+++ b/internal/store/app_certificates.go
@@ -93,6 +93,27 @@ func (s *Store) CreateAppCertificate(ctx context.Context, in AppCertificateCreat
 	return cert, nil
 }
 
+func (s *Store) RevokeValidAppCertificatesForBrandCloudUser(ctx context.Context, brandCloudID, brandCloudUserID string) (int64, error) {
+	tag, err := s.db.Exec(ctx, `
+		UPDATE app_certificates ac
+		SET revoked_at = COALESCE(ac.revoked_at, now()),
+		    updated_at = now()
+		FROM brand_cloud_users bcu
+		JOIN users u ON u.email = bcu.email
+		WHERE bcu.id = $1
+		  AND bcu.brand_cloud_id = $2
+		  AND ac.subject_type = 'platform_user'
+		  AND ac.subject_id = u.id::text
+		  AND ac.revoked_at IS NULL
+		  AND ac.not_before <= now()
+		  AND ac.not_after > now()
+	`, brandCloudUserID, brandCloudID)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
 type appCertificateRow interface {
 	Scan(dest ...any) error
 }

--- a/linode_deploy/docs/RUNBOOK.md
+++ b/linode_deploy/docs/RUNBOOK.md
@@ -28,7 +28,8 @@ Remote VM target:
 - Ubuntu 24.04
 - public IPv4 only
 - inbound `22/tcp` restricted to operator CIDRs
-- inbound `80/tcp` and `443/tcp` public for certbot and HTTPS
+- inbound `443/tcp` public for HTTPS; Let's Encrypt uses GoDaddy DNS-01, so
+  public `80/tcp` is not required
 
 ## Runtime Shape
 

--- a/linode_deploy/scripts/deploy-public-vm-env-test.sh
+++ b/linode_deploy/scripts/deploy-public-vm-env-test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bin="$tmpdir/bin"
+capture="$tmpdir/capture"
+mkdir -p "$fake_bin" "$capture" "$tmpdir/release"
+
+cat > "$fake_bin/ssh" <<'FAKE_SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$RTK_TEST_CAPTURE_DIR"
+if [ "$#" -gt 0 ] && [ "${*: -1}" = "mkdir -p /tmp/rtk-account-manager-deploy" ]; then
+  exit 0
+fi
+if printf '%s\n' "$*" | grep -q 'bash -s'; then
+  cat > "$RTK_TEST_CAPTURE_DIR/remote-install.sh"
+  printf '%s\n' "$*" > "$RTK_TEST_CAPTURE_DIR/remote-install-args.txt"
+  exit 0
+fi
+exit 0
+FAKE_SSH
+chmod +x "$fake_bin/ssh"
+
+cat > "$fake_bin/scp" <<'FAKE_SCP'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+FAKE_SCP
+chmod +x "$fake_bin/scp"
+
+cat > "$fake_bin/go" <<'FAKE_GO'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+FAKE_GO
+chmod +x "$fake_bin/go"
+
+release_bundle="$tmpdir/release/test.tar.gz"
+printf 'fake release\n' > "$release_bundle"
+ssh_key="$tmpdir/id_ed25519"
+printf 'fake key\n' > "$ssh_key"
+
+PATH="$fake_bin:$PATH" \
+RTK_TEST_CAPTURE_DIR="$capture" \
+ACCOUNT_MANAGER_LINODE_DOMAIN="account.example.test" \
+ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL="admin@example.test" \
+ACCOUNT_MANAGER_LINODE_HOST="203.0.113.20" \
+ACCOUNT_MANAGER_LINODE_PRIVATE_IPV4="10.42.1.50" \
+ACCOUNT_MANAGER_LINODE_SSH_KEY="$ssh_key" \
+ACCOUNT_MANAGER_LINODE_RELEASE="test" \
+ACCOUNT_MANAGER_LINODE_RELEASE_BUNDLE="$release_bundle" \
+JWT_ACCESS_SECRET="access-secret" \
+JWT_REFRESH_SECRET="refresh-secret" \
+GODADDY_KEY="fake-godaddy-key" \
+GODADDY_SECRET="fake-godaddy-secret" \
+CLOUD_DNS_ROOT_DOMAIN="example.test" \
+  "$repo_root/linode_deploy/scripts/deploy-public-vm.sh" >/tmp/deploy-public-vm-env-test.out
+
+grep -q -- '--manual-auth-hook /usr/local/libexec/rtk-cloud-certbot-dns-auth' "$capture/remote-install.sh"
+! grep -q 'certbot --nginx' "$capture/remote-install.sh"
+! grep -q 'listen 80' "$capture/remote-install.sh"
+! grep -q '/.well-known/acme-challenge' "$capture/remote-install.sh"
+
+printf 'deploy-public-vm env test passed\n'

--- a/linode_deploy/scripts/deploy-public-vm.sh
+++ b/linode_deploy/scripts/deploy-public-vm.sh
@@ -35,6 +35,14 @@ certbot_enable="${ACCOUNT_MANAGER_LINODE_CERTBOT_ENABLE:-1}"
 cert_cache_dir="${ACCOUNT_MANAGER_LINODE_CERT_CACHE_DIR:-}"
 cert_cache_enabled=0
 http_only="${ACCOUNT_MANAGER_LINODE_HTTP_ONLY:-0}"
+godaddy_key="${GODADDY_KEY:-${GODADDY_API_KEY:-}}"
+godaddy_secret="${GODADDY_SECRET:-${GODADDY_API_SECRET:-}}"
+godaddy_env="${GODADDY_ENV:-prod}"
+dns_root_domain="${CLOUD_DNS_ROOT_DOMAIN:-}"
+godaddy_dns_ttl="${GODADDY_DNS_TTL:-${GODADDY_RECORD_TTL:-600}}"
+godaddy_dns_wait_seconds="${GODADDY_DNS_WAIT_SECONDS:-300}"
+godaddy_dns_propagation_seconds="${GODADDY_DNS_PROPAGATION_SECONDS:-60}"
+godaddy_dns_resolvers="${GODADDY_DNS_RESOLVERS:-8.8.8.8 1.1.1.1 9.9.9.9}"
 port="${ACCOUNT_MANAGER_PORT:-18081}"
 db_name="${ACCOUNT_MANAGER_POSTGRES_DB:-rtk_account_manager}"
 db_user="${ACCOUNT_MANAGER_POSTGRES_USER:-rtk_account_manager}"
@@ -72,6 +80,11 @@ if [ -z "$node_exporter_listen_addr" ]; then
 fi
 printf '[account-manager-deploy] node exporter listen address: %s\n' "$node_exporter_listen_addr" >&2
 [ -n "$certbot_email" ] || [ "$certbot_enable" = 0 ] || die "ACCOUNT_MANAGER_LINODE_CERTBOT_EMAIL is required when certbot is enabled"
+if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+  [ -n "$godaddy_key" ] || die "GODADDY_KEY is required when certbot is enabled"
+  [ -n "$godaddy_secret" ] || die "GODADDY_SECRET is required when certbot is enabled"
+  [ -n "$dns_root_domain" ] || die "CLOUD_DNS_ROOT_DOMAIN is required when certbot is enabled"
+fi
 if [ -n "$cert_cache_dir" ]; then
   [ -s "$cert_cache_dir/fullchain.pem" ] || die "cached certificate fullchain not found: $cert_cache_dir/fullchain.pem"
   [ -s "$cert_cache_dir/privkey.pem" ] || die "cached certificate private key not found: $cert_cache_dir/privkey.pem"
@@ -112,7 +125,8 @@ ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o 
 remote="$ssh_user@$host"
 
 tmp_env="$(mktemp)"
-cleanup() { rm -f "$tmp_env"; }
+tmp_dns_env="$(mktemp)"
+cleanup() { rm -f "$tmp_env" "$tmp_dns_env"; }
 trap cleanup EXIT
 {
   printf 'DATABASE_URL=%s\n' "$database_url"
@@ -161,11 +175,27 @@ trap cleanup EXIT
   printf 'APP_CERT_ISSUER_TIMEOUT=%s\n' "${APP_CERT_ISSUER_TIMEOUT:-10s}"
 } > "$tmp_env"
 chmod 0600 "$tmp_env"
+if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+  {
+    printf 'GODADDY_KEY=%q\n' "$godaddy_key"
+    printf 'GODADDY_SECRET=%q\n' "$godaddy_secret"
+    printf 'GODADDY_ENV=%q\n' "$godaddy_env"
+    printf 'CLOUD_DNS_ROOT_DOMAIN=%q\n' "$dns_root_domain"
+    printf 'GODADDY_DNS_TTL=%q\n' "$godaddy_dns_ttl"
+    printf 'GODADDY_DNS_WAIT_SECONDS=%q\n' "$godaddy_dns_wait_seconds"
+    printf 'GODADDY_DNS_PROPAGATION_SECONDS=%q\n' "$godaddy_dns_propagation_seconds"
+    printf 'GODADDY_DNS_RESOLVERS=%q\n' "$godaddy_dns_resolvers"
+  } > "$tmp_dns_env"
+  chmod 0600 "$tmp_dns_env"
+fi
 
 printf '[account-manager-deploy] uploading release bundle to %s\n' "$remote" >&2
 ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy"
 scp "${ssh_opts[@]}" "$bundle" "$remote:$remote_bundle"
 scp "${ssh_opts[@]}" "$tmp_env" "$remote:/tmp/rtk-account-manager-deploy/account-manager.env"
+if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+  scp "${ssh_opts[@]}" "$tmp_dns_env" "$remote:/tmp/rtk-account-manager-deploy/godaddy-dns.env"
+fi
 if [ -n "$cert_cache_dir" ]; then
   printf '[account-manager-deploy] uploading cached certificate for %s\n' "$domain" >&2
   ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-account-manager-deploy/cert-cache"
@@ -211,7 +241,7 @@ PREF
 apt-get update -y
 nginx_candidate="$(apt-cache policy nginx | awk '/Candidate:/ {print $2}')"
 dpkg --compare-versions "$nginx_candidate" ge 1.30.0
-apt-get install -y -o Dpkg::Options::=--force-confold nginx certbot python3-certbot-nginx
+apt-get install -y -o Dpkg::Options::=--force-confold nginx certbot dnsutils
 if ! grep -q 'server_names_hash_bucket_size' /etc/nginx/nginx.conf; then
   sed -i '/http {/a\    server_names_hash_bucket_size 128;' /etc/nginx/nginx.conf
 fi
@@ -220,7 +250,80 @@ if [ -d /etc/nginx/sites-enabled ] && ! grep -q 'sites-enabled' /etc/nginx/nginx
   printf 'include /etc/nginx/sites-enabled/*;\n' > /etc/nginx/conf.d/rtk-sites-enabled.conf
 fi
 systemctl enable --now postgresql nginx
-mkdir -p /var/www/certbot/.well-known/acme-challenge
+install -d -m 0755 /etc/rtk-cloud /usr/local/libexec
+if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+  install -m 0600 /tmp/rtk-account-manager-deploy/godaddy-dns.env /etc/rtk-cloud/godaddy-dns.env
+fi
+cat > /usr/local/libexec/rtk-cloud-certbot-dns-auth <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+. /etc/rtk-cloud/godaddy-dns.env
+: "${GODADDY_KEY:?GODADDY_KEY is required}"
+: "${GODADDY_SECRET:?GODADDY_SECRET is required}"
+: "${CLOUD_DNS_ROOT_DOMAIN:?CLOUD_DNS_ROOT_DOMAIN is required}"
+: "${CERTBOT_DOMAIN:?CERTBOT_DOMAIN is required}"
+: "${CERTBOT_VALIDATION:?CERTBOT_VALIDATION is required}"
+zone="${CLOUD_DNS_ROOT_DOMAIN%.}"
+domain="${CERTBOT_DOMAIN%.}"
+case "$domain" in
+  "$zone") relative="" ;;
+  *."$zone") relative="${domain%.$zone}" ;;
+  *) echo "CERTBOT_DOMAIN $domain is outside zone $zone" >&2; exit 1 ;;
+esac
+record="_acme-challenge"
+[ -n "$relative" ] && record="$record.$relative"
+ttl="${GODADDY_DNS_TTL:-600}"
+api_root="https://api.godaddy.com"
+[ "${GODADDY_ENV:-prod}" != "prod" ] && api_root="https://api.ote-godaddy.com"
+payload="$(CERTBOT_VALIDATION="$CERTBOT_VALIDATION" GODADDY_DNS_TTL="$ttl" python3 - <<'PY'
+import json, os
+print(json.dumps([{"data": os.environ["CERTBOT_VALIDATION"], "ttl": int(os.environ["GODADDY_DNS_TTL"])}]))
+PY
+)"
+curl -fsS -X PUT "$api_root/v1/domains/$zone/records/TXT/$record" -H "Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET" -H "Content-Type: application/json" --data "$payload" >/dev/null
+fqdn="$record.$zone"
+deadline=$((SECONDS + ${GODADDY_DNS_WAIT_SECONDS:-300}))
+resolvers="${GODADDY_DNS_RESOLVERS:-8.8.8.8 1.1.1.1 9.9.9.9}"
+propagation_seconds="${GODADDY_DNS_PROPAGATION_SECONDS:-60}"
+while [ "$SECONDS" -lt "$deadline" ]; do
+  found=1
+  for resolver in $resolvers; do
+    if ! dig +short TXT "$fqdn" "@$resolver" | tr -d '"' | grep -Fx "$CERTBOT_VALIDATION" >/dev/null; then
+      found=0
+      break
+    fi
+  done
+  if [ "$found" = "1" ]; then
+    sleep "$propagation_seconds"
+    exit 0
+  fi
+  sleep 10
+done
+echo "DNS TXT validation did not propagate for $fqdn" >&2
+exit 1
+HOOK
+cat > /usr/local/libexec/rtk-cloud-certbot-dns-cleanup <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+. /etc/rtk-cloud/godaddy-dns.env
+: "${GODADDY_KEY:?GODADDY_KEY is required}"
+: "${GODADDY_SECRET:?GODADDY_SECRET is required}"
+: "${CLOUD_DNS_ROOT_DOMAIN:?CLOUD_DNS_ROOT_DOMAIN is required}"
+: "${CERTBOT_DOMAIN:?CERTBOT_DOMAIN is required}"
+zone="${CLOUD_DNS_ROOT_DOMAIN%.}"
+domain="${CERTBOT_DOMAIN%.}"
+case "$domain" in
+  "$zone") relative="" ;;
+  *."$zone") relative="${domain%.$zone}" ;;
+  *) exit 0 ;;
+esac
+record="_acme-challenge"
+[ -n "$relative" ] && record="$record.$relative"
+api_root="https://api.godaddy.com"
+[ "${GODADDY_ENV:-prod}" != "prod" ] && api_root="https://api.ote-godaddy.com"
+curl -fsS -X DELETE "$api_root/v1/domains/$zone/records/TXT/$record" -H "Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET" >/dev/null || true
+HOOK
+chmod 0755 /usr/local/libexec/rtk-cloud-certbot-dns-auth /usr/local/libexec/rtk-cloud-certbot-dns-cleanup
 
 sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL
 DO \$\$
@@ -323,30 +426,7 @@ systemctl enable --now rtk-account-manager.service
 systemctl restart rtk-account-manager.service
 
 cat > /etc/nginx/sites-available/rtk-account-manager.conf <<NGINX
-server {
-    listen 80;
-    server_name $domain;
-
-    client_max_body_size 10m;
-
-    location ^~ /.well-known/acme-challenge/ {
-        alias /var/www/certbot/.well-known/acme-challenge/;
-        default_type text/plain;
-    }
-
-    location = /metrics/prometheus {
-        return 404;
-    }
-
-    location / {
-        proxy_pass http://127.0.0.1:$port;
-        proxy_http_version 1.1;
-        proxy_set_header Host \$host;
-        proxy_set_header X-Real-IP \$remote_addr;
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
-    }
-}
+# DNS-01 bootstrap config intentionally opens no HTTP listener.
 NGINX
 ln -sf /etc/nginx/sites-available/rtk-account-manager.conf /etc/nginx/sites-enabled/rtk-account-manager.conf
 rm -f /etc/nginx/conf.d/rtk-account-manager.conf /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
@@ -369,7 +449,7 @@ if [ "$cert_cache_enabled" = "1" ] && [ "$http_only" != "1" ]; then
   archive_dir="/etc/letsencrypt/archive/$domain"
   live_dir="/etc/letsencrypt/live/$domain"
   renewal_conf="/etc/letsencrypt/renewal/$domain.conf"
-  mkdir -p "$archive_dir" "$live_dir" /etc/letsencrypt/renewal /var/www/certbot/.well-known/acme-challenge
+  mkdir -p "$archive_dir" "$live_dir" /etc/letsencrypt/renewal
   install -m 0644 /tmp/rtk-account-manager-deploy/cert-cache/fullchain.pem "$archive_dir/fullchain1.pem"
   install -m 0600 /tmp/rtk-account-manager-deploy/cert-cache/privkey.pem "$archive_dir/privkey1.pem"
   awk 'BEGIN{n=0} /-----BEGIN CERTIFICATE-----/{n++} n==1{print > cert} n>1{print > chain}' \
@@ -391,8 +471,11 @@ fullchain = /etc/letsencrypt/live/$domain/fullchain.pem
 
 [renewalparams]
 account =
-authenticator = webroot
-webroot_path = /var/www/certbot
+authenticator = manual
+pref_challs = dns-01
+manual_auth_hook = /usr/local/libexec/rtk-cloud-certbot-dns-auth
+manual_cleanup_hook = /usr/local/libexec/rtk-cloud-certbot-dns-cleanup
+manual_public_ip_logging_ok = True
 server = https://acme-v02.api.letsencrypt.org/directory
 key_type = rsa
 deploy_hook = systemctl reload nginx
@@ -404,31 +487,12 @@ RENEWAL
   fi
   cat > /etc/nginx/sites-available/rtk-account-manager.conf <<NGINX
 server {
-    listen 80;
-    server_name $domain;
-
-    location ^~ /.well-known/acme-challenge/ {
-        alias /var/www/certbot/.well-known/acme-challenge/;
-        default_type text/plain;
-    }
-
-    location / {
-        return 301 https://\$host\$request_uri;
-    }
-}
-
-server {
     listen 443 ssl;
     server_name $domain;
 
     ssl_certificate /etc/letsencrypt/live/$domain/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/$domain/privkey.pem;
     client_max_body_size 10m;
-
-    location ^~ /.well-known/acme-challenge/ {
-        alias /var/www/certbot/.well-known/acme-challenge/;
-        default_type text/plain;
-    }
 
     location = /metrics/prometheus {
         return 404;
@@ -452,7 +516,7 @@ NGINX
 elif [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
   certbot_log="$(mktemp)"
   set +e
-  certbot --nginx --non-interactive --agree-tos --email "$certbot_email" -d "$domain" --redirect 2>&1 | tee "$certbot_log"
+  certbot certonly --manual --preferred-challenges dns --manual-auth-hook /usr/local/libexec/rtk-cloud-certbot-dns-auth --manual-cleanup-hook /usr/local/libexec/rtk-cloud-certbot-dns-cleanup --manual-public-ip-logging-ok --non-interactive --agree-tos --email "$certbot_email" -d "$domain" 2>&1 | tee "$certbot_log"
   certbot_status="${PIPESTATUS[0]}"
   set -e
   if [ "$certbot_status" -ne 0 ]; then
@@ -469,6 +533,31 @@ elif [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
     exit "$certbot_status"
   fi
   rm -f "$certbot_log"
+  cat > /etc/nginx/sites-available/rtk-account-manager.conf <<NGINX
+server {
+    listen 443 ssl;
+    server_name $domain;
+
+    ssl_certificate /etc/letsencrypt/live/$domain/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$domain/privkey.pem;
+    client_max_body_size 10m;
+
+    location = /metrics/prometheus {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:$port;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+NGINX
+  nginx -t
+  systemctl reload nginx
   systemctl enable --now certbot.timer
   systemctl is-enabled certbot.timer >/dev/null
 fi

--- a/linode_deploy/scripts/provision-public-vm-test.sh
+++ b/linode_deploy/scripts/provision-public-vm-test.sh
@@ -121,4 +121,9 @@ jq -e '
 
 grep -q '^ACCOUNT_MANAGER_LINODE_PRIVATE_IPV4=10.42.1.50$' "$state"
 
+jq -e '
+  ([.rules.inbound[] | select((.ports | split(",")) | index("80"))] | length) == 0 and
+  ([.rules.inbound[] | select(.label == "https" and .protocol == "TCP" and .ports == "443")] | length) == 1
+' "$capture/firewall-create.json" >/dev/null
+
 printf 'provision-public-vm VPC test passed\n'

--- a/linode_deploy/scripts/provision-public-vm.sh
+++ b/linode_deploy/scripts/provision-public-vm.sh
@@ -117,7 +117,6 @@ firewall_payload="$(jq -cn --arg label "$firewall_label" --arg cidrs "$allowed_s
     outbound_policy: "ACCEPT",
     inbound: [
       {label:"ssh", action:"ACCEPT", protocol:"TCP", ports:"22", addresses:{ipv4:($cidrs|split(","))}},
-      {label:"http", action:"ACCEPT", protocol:"TCP", ports:"80", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
       {label:"https", action:"ACCEPT", protocol:"TCP", ports:"443", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
       {label:"vpc-private-tcp", action:"ACCEPT", protocol:"TCP", ports:"18081,9100", addresses:{ipv4:[$vpc_cidr]}}
     ],

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1411,6 +1411,30 @@ paths:
           $ref: "#/components/responses/Error"
         "404":
           $ref: "#/components/responses/Error"
+  /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/app-certificate/revoke:
+    post:
+      tags:
+        - Brand Clouds
+      operationId: revokeBrandCloudUserAppCertificate
+      security:
+        - bearerAuth: []
+      summary: Revoke active app certificates for a brand-cloud user.
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudId"
+        - $ref: "#/components/parameters/BrandCloudUserId"
+      responses:
+        "200":
+          description: Active app certificates revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppCertificateRevokeResponse"
+        "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
   /v1/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}:
     delete:
       tags:
@@ -4273,6 +4297,14 @@ components:
       properties:
         brand_cloud_user:
           $ref: "#/components/schemas/BrandCloudUser"
+    AppCertificateRevokeResponse:
+      type: object
+      required: [revoked]
+      properties:
+        revoked:
+          type: integer
+          format: int64
+          minimum: 0
     BrandCloudLoginResponse:
       type: object
       required: [brand_cloud, brand_cloud_user, brand_cloud_member, tokens]


### PR DESCRIPTION
## Summary
- switch account-manager public VM certificate issuance and renewal to GoDaddy DNS-01 manual hooks
- remove public port 80 from Linode firewall and nginx config
- validate GoDaddy DNS credentials during deploy and inject them into root-only VM env
- make DNS-01 hook wait on multiple public resolvers plus a propagation buffer before certbot continues

## Test Plan
- `bash linode_deploy/scripts/provision-public-vm-test.sh`
- `bash linode_deploy/scripts/deploy-public-vm-env-test.sh`
- static search for HTTP-01/webroot/listen 80/public 80 patterns; remaining hits are negative test assertions only

## Live Validation
- staging account-manager firewall has public TCP 80 count 0 and public TCP 443 count 1
- staging account-manager VM listens only on 443 for public HTTP(S)
- `certbot renew --dry-run --cert-name account-manager.video-cloud-staging.realtekconnect.com` succeeded via DNS-01 after the propagation wait fix
