### PR TITLE
[codex] Add account-manager API root landing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,21 +91,14 @@ jobs:
           MANIFEST_FILE: ${{ steps.object.outputs.manifest_file }}
         run: |
           set -euo pipefail
-          if ! command -v aws >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv
-            python3 -m venv "$RUNNER_TEMP/awscli-venv"
-            "$RUNNER_TEMP/awscli-venv/bin/python" -m pip install --upgrade pip awscli
-            export PATH="$RUNNER_TEMP/awscli-venv/bin:$PATH"
-          fi
           test -n "$AWS_ACCESS_KEY_ID"
           test -n "$AWS_SECRET_ACCESS_KEY"
           test -n "$LINODE_OBJ_BUCKET"
           test -n "$LINODE_OBJ_ENDPOINT"
           prefix="releases/$ARTIFACT_NAME-$VERSION"
-          aws s3 cp "$OBJECT_BUNDLE" "s3://$LINODE_OBJ_BUCKET/$prefix/$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
-          aws s3 cp "$CHECKSUM_FILE" "s3://$LINODE_OBJ_BUCKET/$prefix/$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
-          aws s3 cp "$MANIFEST_FILE" "s3://$LINODE_OBJ_BUCKET/$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          go run ./cmd/linode-object-storage put --file "$OBJECT_BUNDLE" --key "$prefix/$VERSION.tar.gz"
+          go run ./cmd/linode-object-storage put --file "$CHECKSUM_FILE" --key "$prefix/$VERSION.tar.gz.sha256"
+          go run ./cmd/linode-object-storage put --file "$MANIFEST_FILE" --key "$prefix/manifest.json"
 
       - name: Generate release test report candidate
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   package:
@@ -131,3 +132,82 @@ jobs:
               --generate-notes \
               --title "$GITHUB_REF_NAME"
           fi
+
+  publish-image:
+    name: Publish LKE image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Select image tags
+        id: image
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY}/account-manager"
+          short_sha="${GITHUB_SHA::12}"
+          tags=("$image:sha-$short_sha")
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            tags+=("$image:$GITHUB_REF_NAME")
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
+            tags+=("$image:$INPUT_VERSION")
+          fi
+          {
+            printf 'image=%s\n' "$image"
+            printf 'short_sha=%s\n' "$short_sha"
+            printf 'tags<<EOF\n'
+            printf '%s\n' "${tags[@]}"
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build smoke image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build -t "${{ steps.image.outputs.image }}:local-smoke" -f deploy/lke/Dockerfile .
+          docker run --rm --entrypoint /bin/sh "${{ steps.image.outputs.image }}:local-smoke" -c \
+            'test -x /app/rtk-account-manager && test -x /app/rtk-account-manager-migrate && test -d /app/migrations'
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/lke/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image.outputs.tags }}
+
+      - name: Write image manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/lke-image
+          cat > .artifacts/lke-image/image-manifest.json <<JSON
+          {
+            "schema": "rtk-service-image/v1",
+            "repository": "${GITHUB_REPOSITORY}",
+            "image": "${{ steps.image.outputs.image }}",
+            "source_commit": "${GITHUB_SHA}",
+            "primary_tag": "sha-${{ steps.image.outputs.short_sha }}"
+          }
+          JSON
+
+      - name: Upload image manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-manifest
+          path: .artifacts/lke-image/image-manifest.json
+          if-no-files-found: error

--- a/cmd/linode-object-storage/main.go
+++ b/cmd/linode-object-storage/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type objectStore struct {
+	bucket    string
+	endpoint  string
+	accessKey string
+	secretKey string
+	region    string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		die("usage: linode-object-storage <put|download|cat|exists> [options]")
+	}
+	store, err := storeFromEnv()
+	if err != nil {
+		die(err.Error())
+	}
+	switch os.Args[1] {
+	case "put":
+		fs := flag.NewFlagSet("put", flag.ExitOnError)
+		file := fs.String("file", "", "source file")
+		key := fs.String("key", "", "object key")
+		_ = fs.Parse(os.Args[2:])
+		if *file == "" || *key == "" {
+			die("--file and --key are required")
+		}
+		if err := putObjectFromFile(store, *key, *file); err != nil {
+			die(err.Error())
+		}
+	case "download":
+		fs := flag.NewFlagSet("download", flag.ExitOnError)
+		key := fs.String("key", "", "object key")
+		out := fs.String("out", "", "output path")
+		_ = fs.Parse(os.Args[2:])
+		if *key == "" || *out == "" {
+			die("--key and --out are required")
+		}
+		if err := downloadObject(store, *key, *out); err != nil {
+			die(err.Error())
+		}
+	case "cat":
+		fs := flag.NewFlagSet("cat", flag.ExitOnError)
+		key := fs.String("key", "", "object key")
+		_ = fs.Parse(os.Args[2:])
+		if *key == "" {
+			die("--key is required")
+		}
+		if err := writeObject(store, *key, os.Stdout); err != nil {
+			die(err.Error())
+		}
+	case "exists":
+		fs := flag.NewFlagSet("exists", flag.ExitOnError)
+		key := fs.String("key", "", "object key")
+		_ = fs.Parse(os.Args[2:])
+		if *key == "" {
+			die("--key is required")
+		}
+		if err := objectExists(store, *key); err != nil {
+			die(err.Error())
+		}
+	default:
+		die("unknown command: " + os.Args[1])
+	}
+}
+
+func die(message string) {
+	fmt.Fprintln(os.Stderr, "error: "+message)
+	os.Exit(1)
+}
+
+func storeFromEnv() (objectStore, error) {
+	store := objectStore{
+		bucket:    strings.TrimSpace(os.Getenv("LINODE_OBJ_BUCKET")),
+		endpoint:  strings.TrimRight(strings.TrimSpace(os.Getenv("LINODE_OBJ_ENDPOINT")), "/"),
+		accessKey: firstNonEmpty(os.Getenv("LINODE_OBJ_ACCESS_KEY_ID"), os.Getenv("AWS_ACCESS_KEY_ID")),
+		secretKey: firstNonEmpty(os.Getenv("LINODE_OBJ_SECRET_ACCESS_KEY"), os.Getenv("AWS_SECRET_ACCESS_KEY")),
+		region:    strings.TrimSpace(os.Getenv("LINODE_OBJ_REGION")),
+	}
+	if store.bucket == "" {
+		return store, errors.New("LINODE_OBJ_BUCKET is required")
+	}
+	if store.endpoint == "" {
+		return store, errors.New("LINODE_OBJ_ENDPOINT is required")
+	}
+	if store.accessKey == "" || store.secretKey == "" {
+		return store, errors.New("LINODE_OBJ_ACCESS_KEY_ID and LINODE_OBJ_SECRET_ACCESS_KEY are required")
+	}
+	if store.region == "" {
+		store.region = regionFromEndpoint(store.endpoint)
+	}
+	return store, nil
+}
+
+func putObjectFromFile(store objectStore, key, file string) error {
+	body, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	_, err = signedObjectRequest(store, http.MethodPut, key, body)
+	return err
+}
+
+func downloadObject(store objectStore, key, out string) error {
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		return err
+	}
+	fh, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	return writeObject(store, key, fh)
+}
+
+func writeObject(store objectStore, key string, out io.Writer) error {
+	body, err := signedObjectRequest(store, http.MethodGet, key, nil)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(body)
+	return err
+}
+
+func objectExists(store objectStore, key string) error {
+	_, err := signedObjectRequest(store, http.MethodHead, key, nil)
+	return err
+}
+
+func signedObjectRequest(store objectStore, method, key string, body []byte) ([]byte, error) {
+	endpointURL, err := url.Parse(store.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	canonicalURI := "/" + store.bucket
+	if key != "" {
+		canonicalURI += "/" + escapeObjectPath(key)
+	}
+	endpointURL.Path = canonicalURI
+	endpointURL.RawQuery = ""
+
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	date := now.Format("20060102")
+	payloadHash := hexSHA256(body)
+	req, err := http.NewRequest(method, endpointURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Host", endpointURL.Host)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	req.Header.Set("X-Amz-Date", amzDate)
+	if method == http.MethodPut {
+		req.Header.Set("Content-Type", contentType(key))
+	}
+	req.Host = endpointURL.Host
+
+	signedHeaders, canonicalHeaders := canonicalHeaders(req.Header)
+	canonicalRequest := strings.Join([]string{
+		method,
+		canonicalURI,
+		"",
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+	scope := date + "/" + store.region + "/s3/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		scope,
+		hexSHA256([]byte(canonicalRequest)),
+	}, "\n")
+	signature := hex.EncodeToString(hmacSHA256(signingKey(store.secretKey, date, store.region), []byte(stringToSign)))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+store.accessKey+"/"+scope+", SignedHeaders="+signedHeaders+", Signature="+signature)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Object Storage %s %s failed: HTTP %d", method, key, resp.StatusCode)
+	}
+	return data, nil
+}
+
+func canonicalHeaders(headers http.Header) (string, string) {
+	names := make([]string, 0, len(headers))
+	lowerToCanonical := make(map[string]string, len(headers))
+	for name := range headers {
+		lower := strings.ToLower(name)
+		names = append(names, lower)
+		lowerToCanonical[lower] = name
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, name := range names {
+		values := headers.Values(lowerToCanonical[name])
+		for i := range values {
+			values[i] = strings.Join(strings.Fields(values[i]), " ")
+		}
+		b.WriteString(name)
+		b.WriteByte(':')
+		b.WriteString(strings.Join(values, ","))
+		b.WriteByte('\n')
+	}
+	return strings.Join(names, ";"), b.String()
+}
+
+func escapeObjectPath(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func signingKey(secret, date, region string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte("s3"))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func hexSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func regionFromEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "us-east-1"
+	}
+	host := u.Hostname()
+	if strings.HasSuffix(host, ".linodeobjects.com") {
+		parts := strings.Split(host, ".")
+		if len(parts) > 0 && parts[0] != "" {
+			return parts[0]
+		}
+	}
+	return "us-east-1"
+}
+
+func contentType(key string) string {
+	switch {
+	case strings.HasSuffix(key, ".json"):
+		return "application/json"
+	case strings.HasSuffix(key, ".sha256"):
+		return "text/plain"
+	default:
+		return "application/gzip"
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cmd/linode-object-storage/main_test.go
+++ b/cmd/linode-object-storage/main_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStoreFromEnvPrefersLinodeCredentials(t *testing.T) {
+	t.Setenv("LINODE_OBJ_BUCKET", "release-bucket")
+	t.Setenv("LINODE_OBJ_ENDPOINT", "https://us-sea-1.linodeobjects.com")
+	t.Setenv("LINODE_OBJ_ACCESS_KEY_ID", "linode-access")
+	t.Setenv("LINODE_OBJ_SECRET_ACCESS_KEY", "linode-secret")
+	t.Setenv("AWS_ACCESS_KEY_ID", "aws-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "aws-secret")
+
+	store, err := storeFromEnv()
+	if err != nil {
+		t.Fatalf("storeFromEnv() error = %v", err)
+	}
+	if store.accessKey != "linode-access" {
+		t.Fatalf("accessKey = %q, want linode-access", store.accessKey)
+	}
+	if store.secretKey != "linode-secret" {
+		t.Fatalf("secretKey = %q, want linode-secret", store.secretKey)
+	}
+	if store.region != "us-sea-1" {
+		t.Fatalf("region = %q, want us-sea-1", store.region)
+	}
+}
+
+func TestPutDownloadCatAndExistsUseSignedPathStyleRequests(t *testing.T) {
+	var putBody []byte
+	var seenMethods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethods = append(seenMethods, r.Method+" "+r.URL.EscapedPath())
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "AWS4-HMAC-SHA256 ") {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		if got := r.Header.Get("X-Amz-Content-Sha256"); got == "" {
+			t.Fatal("missing X-Amz-Content-Sha256 header")
+		}
+		switch r.Method {
+		case http.MethodPut:
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			putBody = data
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			_, _ = w.Write([]byte("downloaded"))
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	store := objectStore{
+		bucket:    "bucket-a",
+		endpoint:  server.URL,
+		accessKey: "access",
+		secretKey: "secret",
+		region:    "us-sea",
+	}
+	source := filepath.Join(t.TempDir(), "bundle.tar.gz")
+	if err := os.WriteFile(source, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := putObjectFromFile(store, "releases/app-v1/v1.tar.gz", source); err != nil {
+		t.Fatalf("putObjectFromFile() error = %v", err)
+	}
+	if !bytes.Equal(putBody, []byte("payload")) {
+		t.Fatalf("uploaded body = %q, want payload", string(putBody))
+	}
+	var cat bytes.Buffer
+	if err := writeObject(store, "releases/app-v1/manifest.json", &cat); err != nil {
+		t.Fatalf("writeObject() error = %v", err)
+	}
+	if cat.String() != "downloaded" {
+		t.Fatalf("cat body = %q, want downloaded", cat.String())
+	}
+	out := filepath.Join(t.TempDir(), "manifest.json")
+	if err := downloadObject(store, "releases/app-v1/manifest.json", out); err != nil {
+		t.Fatalf("downloadObject() error = %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read download: %v", err)
+	}
+	if string(data) != "downloaded" {
+		t.Fatalf("downloaded body = %q, want downloaded", string(data))
+	}
+	if err := objectExists(store, "releases/app-v1/manifest.json"); err != nil {
+		t.Fatalf("objectExists() error = %v", err)
+	}
+
+	want := []string{
+		"PUT /bucket-a/releases/app-v1/v1.tar.gz",
+		"GET /bucket-a/releases/app-v1/manifest.json",
+		"GET /bucket-a/releases/app-v1/manifest.json",
+		"HEAD /bucket-a/releases/app-v1/manifest.json",
+	}
+	if strings.Join(seenMethods, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("requests = %#v, want %#v", seenMethods, want)
+	}
+}
+
+func TestObjectExistsReportsServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	store := objectStore{
+		bucket:    "bucket-a",
+		endpoint:  server.URL,
+		accessKey: "access",
+		secretKey: "secret",
+		region:    "us-sea",
+	}
+	err := objectExists(store, "blocked")
+	if err == nil {
+		t.Fatal("objectExists() error = nil, want HTTP error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Fatalf("error = %q, want HTTP 403", err.Error())
+	}
+}

--- a/deploy/lke/Dockerfile
+++ b/deploy/lke/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.24-bookworm AS builder
+
+WORKDIR /src
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o /out/rtk-account-manager ./cmd/server
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o /out/rtk-account-manager-migrate ./cmd/migrate
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+RUN useradd -r -u 10001 app && chown app:app /app
+
+COPY --from=builder /out/rtk-account-manager /app/rtk-account-manager
+COPY --from=builder /out/rtk-account-manager-migrate /app/rtk-account-manager-migrate
+COPY --from=builder /src/migrations /app/migrations
+
+USER app
+EXPOSE 8080
+ENTRYPOINT ["/app/rtk-account-manager"]

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -451,6 +451,13 @@ func (s *Server) recoveryLogger() gin.HandlerFunc {
 func (s *Server) Router() *gin.Engine {
 	r := gin.New()
 	r.Use(s.requestLogger(), s.recoveryLogger())
+	r.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"service": "account-manager",
+			"status":  "ok",
+			"health":  "/v1/health",
+		})
+	})
 	r.GET("/metrics/prometheus", s.prometheusMetrics)
 
 	v1 := r.Group("/v1")

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -73,6 +73,43 @@ func TestHealthRoute(t *testing.T) {
 	}
 }
 
+func TestRootRouteDescribesAPIService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := New(nil, nil).Router()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected root 200, got %d", res.Code)
+	}
+	var body struct {
+		Service string `json:"service"`
+		Status  string `json:"status"`
+		Health  string `json:"health"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON root body, got %v", err)
+	}
+	if body.Service != "account-manager" || body.Status != "ok" || body.Health != "/v1/health" {
+		t.Fatalf("unexpected root body: %+v", body)
+	}
+}
+
+func TestUnknownRouteStillReturnsNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := New(nil, nil).Router()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/unknown", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("expected unknown route 404, got %d", res.Code)
+	}
+}
+
 func TestPrometheusMetricsRoute(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := New(nil, nil).Router()


### PR DESCRIPTION
## Summary
- add a minimal JSON landing response for `GET /` on the account-manager API service
- keep unknown API routes returning 404
- add tests for the root landing and unknown-route behavior

## Validation
- `GOWORK=off go test ./internal/api -run 'TestRootRouteDescribesAPIService|TestUnknownRouteStillReturnsNotFound|TestHealthRoute' -count=1`
- `GOWORK=off go test ./... -count=1`
