### PR TITLE
[codex] Add account-manager API root landing

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -304,11 +304,13 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestRequireAuthRejectsInvalidToken`
 - `rtk_account_manager/internal/api`: `TestRequireAuthRejectsMissingToken`
 - `rtk_account_manager/internal/api`: `TestRequireAuthRejectsRefreshTokenAsBearer`
+- `rtk_account_manager/internal/api`: `TestRootRouteDescribesAPIService`
 - `rtk_account_manager/internal/api`: `TestSMTPAuthTokenSinkWritesDelivery`
 - `rtk_account_manager/internal/api`: `TestSMTPQuotaRaiseNotificationSinkWritesDelivery`
 - `rtk_account_manager/internal/api`: `TestSendSMTPMailDeliversMessage`
 - `rtk_account_manager/internal/api`: `TestSendSMTPMailTimesOut`
 - `rtk_account_manager/internal/api`: `TestTrimPtrNormalizesOptionalStrings`
+- `rtk_account_manager/internal/api`: `TestUnknownRouteStillReturnsNotFound`
 - `rtk_account_manager/internal/api`: `TestValidationHelpersWriteErrors`
 - `rtk_account_manager/internal/api`: `TestValueOrEmpty`
 - `rtk_account_manager/internal/api`: `TestWriteClaimResolveErrorIncludesRetryability/invalid_token`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -451,6 +451,13 @@ func (s *Server) recoveryLogger() gin.HandlerFunc {
 func (s *Server) Router() *gin.Engine {
 	r := gin.New()
 	r.Use(s.requestLogger(), s.recoveryLogger())
+	r.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"service": "account-manager",
+			"status":  "ok",
+			"health":  "/v1/health",
+		})
+	})
 	r.GET("/metrics/prometheus", s.prometheusMetrics)
 
 	v1 := r.Group("/v1")

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -73,6 +73,43 @@ func TestHealthRoute(t *testing.T) {
 	}
 }
 
+func TestRootRouteDescribesAPIService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := New(nil, nil).Router()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected root 200, got %d", res.Code)
+	}
+	var body struct {
+		Service string `json:"service"`
+		Status  string `json:"status"`
+		Health  string `json:"health"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected JSON root body, got %v", err)
+	}
+	if body.Service != "account-manager" || body.Status != "ok" || body.Health != "/v1/health" {
+		t.Fatalf("unexpected root body: %+v", body)
+	}
+}
+
+func TestUnknownRouteStillReturnsNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := New(nil, nil).Router()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/unknown", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("expected unknown route 404, got %d", res.Code)
+	}
+}
+
 func TestPrometheusMetricsRoute(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := New(nil, nil).Router()


### PR DESCRIPTION
## Summary
- add a minimal JSON landing response for `GET /` on the account-manager API service
- keep unknown API routes returning 404
- add tests for the root landing and unknown-route behavior

## Validation
- `GOWORK=off go test ./... -count=1`
