### PR TITLE
ci: harden GHCR image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.image.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Write image manifest
         shell: bash
@@ -204,9 +207,17 @@ jobs:
             "primary_tag": "sha-${{ steps.image.outputs.short_sha }}"
           }
           JSON
+          {
+            echo "## LKE image"
+            echo
+            echo "\`\`\`json"
+            cat .artifacts/lke-image/image-manifest.json
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload image manifest
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: image-manifest
           path: .artifacts/lke-image/image-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
         description: "Release version. Defaults to the git ref name or timestamped short SHA."
         required: false
         type: string
+      publish_bundle:
+        description: "Build and upload the native release bundle. Set false for GHCR image-only publishes."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -19,6 +24,7 @@ permissions:
 
 jobs:
   package:
+    if: github.event_name != 'workflow_dispatch' || inputs.publish_bundle
     name: Package release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- keep publishing GHCR service images with GITHUB_TOKEN and packages: write
- add OCI source/revision labels so GHCR packages are linked back to the source repo
- write image manifest to the step summary
- make image manifest artifact upload best-effort so artifact quota does not mask image publish status

## Validation
- git diff --check
- YAML parse .github/workflows/release.yml