### PR TITLE
[codex] Harden auth signup and DB error resilience

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,6 +57,7 @@ func main() {
 	}
 	notificationSink := quotaRaiseNotificationSink(cfg, logger)
 	accountStore := store.New(db)
+	accountStore.ConfigureAuthTokenRateLimit(cfg.AuthTokenRateLimitMax, cfg.AuthTokenRateLimitWindow)
 	if cfg.BootstrapPlatformAdminEmail != "" || cfg.BootstrapPlatformAdminPassword != "" {
 		if cfg.BootstrapPlatformAdminEmail == "" || cfg.BootstrapPlatformAdminPassword == "" {
 			fatal(logger, "bootstrap platform admin config incomplete", nil)

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -272,8 +272,10 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestIntegrationStoreRefreshTokenHelpers`
 - `rtk_account_manager/internal/api`: `TestIntegrationValidationAndNotFoundErrors`
 - `rtk_account_manager/internal/api`: `TestIsDisposableSignupEmail`
+- `rtk_account_manager/internal/api`: `TestIsUniqueViolationClassifiesPostgresErrors`
 - `rtk_account_manager/internal/api`: `TestLoadSignupPolicyHonorsEnvironmentOverrides`
 - `rtk_account_manager/internal/api`: `TestLogAuthTokenSinkWritesDelivery`
+- `rtk_account_manager/internal/api`: `TestLogDeliveryFailureHandlesNilLogger`
 - `rtk_account_manager/internal/api`: `TestLogQuotaRaiseNotificationSinkWritesDelivery`
 - `rtk_account_manager/internal/api`: `TestMatchExistingDeactivateOperation`
 - `rtk_account_manager/internal/api`: `TestMatchExistingProvisionOperation`
@@ -316,6 +318,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/api`: `TestSMTPQuotaRaiseNotificationSinkWritesDelivery`
 - `rtk_account_manager/internal/api`: `TestSendSMTPMailDeliversMessage`
 - `rtk_account_manager/internal/api`: `TestSendSMTPMailTimesOut`
+- `rtk_account_manager/internal/api`: `TestSignupLimiterEvictsStaleEntries`
 - `rtk_account_manager/internal/api`: `TestTrimPtrNormalizesOptionalStrings`
 - `rtk_account_manager/internal/api`: `TestUnknownRouteStillReturnsNotFound`
 - `rtk_account_manager/internal/api`: `TestValidationHelpersWriteErrors`
@@ -487,6 +490,10 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/config`: `TestLoadUsesOIDCDefaultsAndBooleanFallbacks`
 - `rtk_account_manager/internal/config`: `TestLoadWorkerAllowsMissingJWTSecrets`
 - `rtk_account_manager/internal/config`: `TestLoadWorkerFallsBackForInvalidMaxAttempts`
+- `rtk_account_manager/internal/database`: `TestEnvDurationFallback`
+- `rtk_account_manager/internal/database`: `TestEnvIntFallback`
+- `rtk_account_manager/internal/database`: `TestFindMigrationDirCandidates`
+- `rtk_account_manager/internal/database`: `TestFindMigrationDirHonorsEnvOverride`
 - `rtk_account_manager/internal/database`: `TestFindMigrationDirMissing`
 - `rtk_account_manager/internal/logging`: `TestNewBuildsServiceLoggerFromConfig`
 - `rtk_account_manager/internal/logging`: `TestNewFromEnvReadsLoggingConfigWithFallbacks`
@@ -518,6 +525,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshotWithLossyUTF8`
 - `rtk_account_manager/internal/store`: `TestCompareInboxCreateAcceptsLegacyMalformedPayloadSnapshot`
 - `rtk_account_manager/internal/store`: `TestCompareOperationCreate`
+- `rtk_account_manager/internal/store`: `TestConfigureAuthTokenRateLimit`
 - `rtk_account_manager/internal/store`: `TestCreateDeviceClaimTokenRejectsUnsupportedServiceOptions`
 - `rtk_account_manager/internal/store`: `TestCreateOrGetDeviceOperationIsIdempotent`
 - `rtk_account_manager/internal/store`: `TestCreateOrGetDeviceOperationRejectsMismatchedDeviceOrganization`
@@ -550,6 +558,7 @@ Coverage is only a signal that code executed. Correctness is validated by assert
 - `rtk_account_manager/internal/store`: `TestLoginActivationTokenLifecycleAndScope`
 - `rtk_account_manager/internal/store`: `TestMergeDeviceMetadataPreservesUnrelatedFields`
 - `rtk_account_manager/internal/store`: `TestMetadataChangedProjectionFiltersNonVideoCloudKeys`
+- `rtk_account_manager/internal/store`: `TestNewStoreHasDefaultAuthTokenRateLimit`
 - `rtk_account_manager/internal/store`: `TestNormalizeTenantSlug/empty_after_normalization`
 - `rtk_account_manager/internal/store`: `TestNormalizeTenantSlug/lowercase`
 - `rtk_account_manager/internal/store`: `TestNormalizeTenantSlug/punctuation`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	cloudlogger "github.com/hkt999rtk/rtk_cloud_logger"
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.uber.org/zap"
 
 	"rtk_account_manager/internal/auth"
@@ -413,6 +414,18 @@ func (s *Server) SetLogger(logger *zap.Logger) {
 	s.logger = logger
 }
 
+func (s *Server) logDeliveryFailure(purpose, email string, err error) {
+	logger := s.logger
+	if logger == nil {
+		logger = cloudlogger.Nop()
+	}
+	logger.Warn("auth token delivery failed",
+		zap.String("purpose", purpose),
+		zap.String("email", email),
+		zap.Error(err),
+	)
+}
+
 func (s *Server) requestLogger() gin.HandlerFunc {
 	logger := s.logger
 	if logger == nil {
@@ -616,11 +629,16 @@ type registerRequest struct {
 	Password         string  `json:"password" binding:"required,min=8"`
 	DisplayName      *string `json:"display_name"`
 	OrganizationName string  `json:"organization_name" binding:"required"`
+	CaptchaToken     *string `json:"captcha_token"`
 }
 
 func (s *Server) register(c *gin.Context) {
 	var req registerRequest
 	if !bind(c, &req) {
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	if !s.allowSignup(c, email, req.CaptchaToken) {
 		return
 	}
 	if !requireNonBlank(c, "organization_name", req.OrganizationName) {
@@ -632,7 +650,7 @@ func (s *Server) register(c *gin.Context) {
 		return
 	}
 	result, err := s.store.Register(c.Request.Context(), store.RegisterInput{
-		Email:                     strings.ToLower(strings.TrimSpace(req.Email)),
+		Email:                     email,
 		PasswordHash:              hash,
 		DisplayName:               req.DisplayName,
 		OrganizationName:          strings.TrimSpace(req.OrganizationName),
@@ -673,11 +691,15 @@ func (s *Server) login(c *gin.Context) {
 		return
 	}
 	user, hash, err := s.store.GetUserPassword(c.Request.Context(), strings.ToLower(strings.TrimSpace(req.Email)))
-	if err != nil || !auth.CheckPassword(hash, req.Password) {
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			writeStoreError(c, err)
+			return
+		}
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
 		return
 	}
-	if user.SignupPendingVerification {
+	if !auth.CheckPassword(hash, req.Password) || user.SignupPendingVerification {
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
 		return
 	}
@@ -715,7 +737,9 @@ func (s *Server) signIn(c *gin.Context) {
 		return
 	}
 	if created {
-		_ = s.deliverAuthToken(c, email, "login_activation", token, expiresAt)
+		if err := s.deliverAuthToken(c, email, "login_activation", token, expiresAt); err != nil {
+			s.logDeliveryFailure("login_activation", email, err)
+		}
 	}
 	c.Status(http.StatusAccepted)
 }
@@ -1171,7 +1195,9 @@ func (s *Server) forgotPassword(c *gin.Context) {
 		return
 	}
 	if created {
-		_ = s.deliverAuthToken(c, email, "password_reset", token, expiresAt)
+		if err := s.deliverAuthToken(c, email, "password_reset", token, expiresAt); err != nil {
+			s.logDeliveryFailure("password_reset", email, err)
+		}
 	}
 	c.Status(http.StatusAccepted)
 }
@@ -1986,7 +2012,7 @@ func writeStoreError(c *gin.Context, err error) {
 		writeError(c, http.StatusConflict, "developer_cloud_limit_exceeded", "Developer brand cloud limit exceeded")
 	case errors.Is(err, errOperationStateInconsistent):
 		writeError(c, http.StatusInternalServerError, "operation_state_inconsistent", err.Error())
-	case strings.Contains(err.Error(), "duplicate key"):
+	case isUniqueViolation(err):
 		writeError(c, http.StatusConflict, "conflict", "Resource already exists")
 	default:
 		writeError(c, http.StatusInternalServerError, "internal_error", "Internal server error")
@@ -2013,7 +2039,7 @@ func writeClaimResolveError(c *gin.Context, err error) {
 		writeClaimError(c, http.StatusBadRequest, "operator_evidence_required", "Operator reason and evidence are required", false, "provide_operator_evidence")
 	case errors.Is(err, store.ErrEvaluationQuotaExceeded):
 		writeClaimError(c, http.StatusConflict, "EVALUATION_QUOTA_EXCEEDED", "Evaluation device quota exceeded", false, "request_quota_raise_or_contact_admin")
-	case strings.Contains(err.Error(), "duplicate key"):
+	case isUniqueViolation(err):
 		writeClaimError(c, http.StatusConflict, "conflict", "Resource already exists", false, "retry_with_current_claim_state")
 	default:
 		writeClaimError(c, http.StatusServiceUnavailable, "service_unavailable", "Claim resolve is temporarily unavailable", true, "retry_later")
@@ -2045,4 +2071,9 @@ func writeErrorWithFields(c *gin.Context, status int, code, message string, retr
 		errBody["resolution_action"] = strings.TrimSpace(*resolutionAction)
 	}
 	c.JSON(status, gin.H{"error": errBody})
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -1611,4 +1612,21 @@ func readinessDisabledDevice(status model.DeviceStatus, metadata map[string]any)
 
 func operationStatusPtr(status model.DeviceOperationStatus) *model.DeviceOperationStatus {
 	return &status
+}
+
+func TestIsUniqueViolationClassifiesPostgresErrors(t *testing.T) {
+	if !isUniqueViolation(&pgconn.PgError{Code: "23505"}) {
+		t.Fatal("expected 23505 to be a unique violation")
+	}
+	if isUniqueViolation(&pgconn.PgError{Code: "23503"}) {
+		t.Fatal("expected foreign key violation to not be a unique violation")
+	}
+	if isUniqueViolation(errors.New("not a pg error")) {
+		t.Fatal("expected generic error to not be a unique violation")
+	}
+}
+
+func TestLogDeliveryFailureHandlesNilLogger(t *testing.T) {
+	server := &Server{}
+	server.logDeliveryFailure("password_reset", "user@example.com", errors.New("smtp down"))
 }

--- a/internal/api/brand_cloud_auth.go
+++ b/internal/api/brand_cloud_auth.go
@@ -17,7 +17,15 @@ func (s *Server) brandCloudLogin(c *gin.Context) {
 		return
 	}
 	result, err := s.store.GetBrandCloudUserPassword(c.Request.Context(), c.Param("tenantSlug"), strings.ToLower(strings.TrimSpace(req.Email)))
-	if err != nil || !auth.CheckPassword(result.PasswordHash, req.Password) || result.BrandCloudUser.SignupPendingVerification {
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			writeStoreError(c, err)
+			return
+		}
+		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
+		return
+	}
+	if !auth.CheckPassword(result.PasswordHash, req.Password) || result.BrandCloudUser.SignupPendingVerification {
 		writeError(c, http.StatusUnauthorized, "invalid_credentials", "Invalid email or password")
 		return
 	}

--- a/internal/api/eval_tier.go
+++ b/internal/api/eval_tier.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"net/mail"
 	"os"
@@ -115,6 +116,17 @@ func newSignupLimiter(limit int, window time.Duration) *signupLimiter {
 func (l *signupLimiter) allow(key string, now time.Time) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
+	// Lazy eviction of stale windows so the map cannot grow unboundedly when
+	// callers vary the key (e.g. spoofed X-Forwarded-For). The sweep is
+	// amortized: only run when the map is non-trivially sized.
+	if len(l.counters) > 256 {
+		for k, state := range l.counters {
+			if state.windowStart.IsZero() || now.Sub(state.windowStart) >= l.window {
+				delete(l.counters, k)
+			}
+		}
+	}
 
 	state := l.counters[key]
 	if state.windowStart.IsZero() || now.Sub(state.windowStart) >= l.window {
@@ -311,7 +323,11 @@ func (s *Server) requirePlatformAdmin() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		isAdmin, err := s.store.IsPlatformAdmin(c.Request.Context(), currentUserID(c))
 		if err != nil {
-			writeError(c, http.StatusForbidden, "forbidden", "Insufficient permissions")
+			if errors.Is(err, store.ErrNotFound) {
+				writeError(c, http.StatusForbidden, "forbidden", "Insufficient permissions")
+			} else {
+				writeError(c, http.StatusInternalServerError, "internal_error", "Internal server error")
+			}
 			c.Abort()
 			return
 		}

--- a/internal/api/eval_tier_test.go
+++ b/internal/api/eval_tier_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,6 +99,21 @@ func TestAllowSignupEnforcesCaptchaDisposableAndRateLimit(t *testing.T) {
 	}
 	if limitedRecorder.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected rate limit failure 429, got %d", limitedRecorder.Code)
+	}
+}
+
+func TestSignupLimiterEvictsStaleEntries(t *testing.T) {
+	limiter := newSignupLimiter(1, time.Millisecond)
+	now := time.Now().UTC()
+	for i := 0; i < 300; i++ {
+		limiter.allow(fmt.Sprintf("10.0.0.%d", i), now)
+	}
+	later := now.Add(time.Second)
+	if !limiter.allow("fresh-ip", later) {
+		t.Fatal("expected fresh ip to be allowed after eviction")
+	}
+	if _, ok := limiter.counters["10.0.0.0"]; ok {
+		t.Fatalf("expected stale entries to be evicted, still present")
 	}
 }
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -92,6 +92,7 @@ func newIntegrationEnv(t *testing.T) integrationEnv {
 	tokenSink := &recordingAuthTokenSink{}
 	notificationSink := &recordingQuotaRaiseNotificationSink{}
 	server := NewWithAuthTokenAndNotificationSink(store.New(db), authService, tokenSink, notificationSink)
+	server.signupLimiter = nil
 	return integrationEnv{
 		router:           server.Router(),
 		server:           server,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,8 @@ type Config struct {
 	PasswordResetTTL               time.Duration
 	OTPResendInterval              time.Duration
 	OTPMaxAttempts                 int
+	AuthTokenRateLimitMax          int
+	AuthTokenRateLimitWindow       time.Duration
 	OIDCEnabled                    bool
 	OIDCProviderID                 string
 	OIDCProviderName               string
@@ -173,6 +175,8 @@ func load() (Config, error) {
 		PasswordResetTTL:               duration("PASSWORD_RESET_TTL", 30*time.Minute),
 		OTPResendInterval:              duration("OTP_RESEND_INTERVAL", 60*time.Second),
 		OTPMaxAttempts:                 intValue("OTP_MAX_ATTEMPTS", 5),
+		AuthTokenRateLimitMax:          intValue("AUTH_TOKEN_RATE_LIMIT_MAX", 5),
+		AuthTokenRateLimitWindow:       duration("AUTH_TOKEN_RATE_LIMIT_WINDOW", time.Hour),
 		OIDCEnabled:                    boolValue("OIDC_ENABLED", false),
 		OIDCProviderID:                 getenv("OIDC_PROVIDER_ID", "keycloak"),
 		OIDCProviderName:               getenv("OIDC_PROVIDER_NAME", "Keycloak"),

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -5,13 +5,31 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func Connect(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
-	pool, err := pgxpool.New(ctx, databaseURL)
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if v := envInt("DATABASE_MAX_CONNS", 0); v > 0 {
+		config.MaxConns = int32(v)
+	}
+	if v := envInt("DATABASE_MIN_CONNS", 0); v > 0 {
+		config.MinConns = int32(v)
+	}
+	if v := envDuration("DATABASE_MAX_CONN_LIFETIME", 0); v > 0 {
+		config.MaxConnLifetime = v
+	}
+	if v := envDuration("DATABASE_MAX_CONN_IDLE_TIME", 0); v > 0 {
+		config.MaxConnIdleTime = v
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -20,6 +38,30 @@ func Connect(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 		return nil, err
 	}
 	return pool, nil
+}
+
+func envInt(key string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return fallback
+	}
+	return d
 }
 
 func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
@@ -78,6 +120,11 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 }
 
 func findMigrationDir() (string, error) {
+	if env := strings.TrimSpace(os.Getenv("MIGRATIONS_DIR")); env != "" {
+		if info, err := os.Stat(env); err == nil && info.IsDir() {
+			return env, nil
+		}
+	}
 	candidates := []string{"migrations", "../../migrations"}
 	for _, candidate := range candidates {
 		info, err := os.Stat(candidate)
@@ -85,5 +132,5 @@ func findMigrationDir() (string, error) {
 			return candidate, nil
 		}
 	}
-	return "", fmt.Errorf("migrations directory not found")
+	return "", fmt.Errorf("migrations directory not found (set MIGRATIONS_DIR)")
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,11 +1,75 @@
 package database
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestFindMigrationDirMissing(t *testing.T) {
 	t.Chdir(t.TempDir())
 
 	if _, err := findMigrationDir(); err == nil {
 		t.Fatal("expected missing migrations directory error")
+	}
+}
+
+func TestFindMigrationDirHonorsEnvOverride(t *testing.T) {
+	t.Chdir(t.TempDir())
+	dir := t.TempDir()
+	t.Setenv("MIGRATIONS_DIR", dir)
+
+	got, err := findMigrationDir()
+	if err != nil {
+		t.Fatalf("expected env override to succeed, got %v", err)
+	}
+	if got != dir {
+		t.Fatalf("expected %s, got %s", dir, got)
+	}
+}
+
+func TestEnvIntFallback(t *testing.T) {
+	if v := envInt("DATABASE_TEST_MISSING_INT", 7); v != 7 {
+		t.Fatalf("expected fallback 7, got %d", v)
+	}
+	t.Setenv("DATABASE_TEST_INT", "invalid")
+	if v := envInt("DATABASE_TEST_INT", 9); v != 9 {
+		t.Fatalf("expected fallback for invalid value, got %d", v)
+	}
+	t.Setenv("DATABASE_TEST_INT", "42")
+	if v := envInt("DATABASE_TEST_INT", 9); v != 42 {
+		t.Fatalf("expected 42, got %d", v)
+	}
+}
+
+func TestEnvDurationFallback(t *testing.T) {
+	if v := envDuration("DATABASE_TEST_MISSING_DUR", 3*time.Second); v != 3*time.Second {
+		t.Fatalf("expected fallback, got %v", v)
+	}
+	t.Setenv("DATABASE_TEST_DUR", "not-a-duration")
+	if v := envDuration("DATABASE_TEST_DUR", 5*time.Second); v != 5*time.Second {
+		t.Fatalf("expected fallback for invalid value, got %v", v)
+	}
+	t.Setenv("DATABASE_TEST_DUR", "10s")
+	if v := envDuration("DATABASE_TEST_DUR", 5*time.Second); v != 10*time.Second {
+		t.Fatalf("expected 10s, got %v", v)
+	}
+}
+
+func TestFindMigrationDirCandidates(t *testing.T) {
+	tmp := t.TempDir()
+	migrationsDir := filepath.Join(tmp, "migrations")
+	if err := os.Mkdir(migrationsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmp)
+
+	got, err := findMigrationDir()
+	if err != nil {
+		t.Fatalf("expected candidate lookup to succeed, got %v", err)
+	}
+	if got != "migrations" {
+		t.Fatalf("expected migrations, got %s", got)
 	}
 }

--- a/internal/store/device_claims.go
+++ b/internal/store/device_claims.go
@@ -473,7 +473,7 @@ func (s *Store) overrideDeviceClaim(ctx context.Context, in claimOverrideInput) 
 		RETURNING id::text, organization_id::text, name, category, serial_number, mac_address, manufacturer, model, status, last_seen_at, metadata, created_at, updated_at, disabled_at
 	`, claim.DeviceID, in.TargetOrganizationID, now))
 	if err != nil {
-		if strings.Contains(err.Error(), "duplicate key") {
+		if isUniqueViolation(err) {
 			return DeviceClaimOverrideResult{}, ErrConflict
 		}
 		return DeviceClaimOverrideResult{}, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,10 +38,28 @@ var (
 
 type Store struct {
 	db *pgxpool.Pool
+
+	authTokenRateLimitMax    int
+	authTokenRateLimitWindow time.Duration
 }
 
 func New(db *pgxpool.Pool) *Store {
-	return &Store{db: db}
+	return &Store{
+		db:                       db,
+		authTokenRateLimitMax:    5,
+		authTokenRateLimitWindow: time.Hour,
+	}
+}
+
+// ConfigureAuthTokenRateLimit tunes the per-subject auth-token issuance limiter
+// used by password reset, login activation, and email verification flows.
+func (s *Store) ConfigureAuthTokenRateLimit(max int, window time.Duration) {
+	if max > 0 {
+		s.authTokenRateLimitMax = max
+	}
+	if window > 0 {
+		s.authTokenRateLimitWindow = window
+	}
 }
 
 type Page struct {
@@ -581,11 +599,11 @@ func (s *Store) createAuthTokenForSubject(ctx context.Context, subjectType, subj
 	if err := tx.QueryRow(ctx, `
 		SELECT count(*)
 		FROM auth_tokens
-		WHERE subject_type = $1 AND subject_id = $2 AND purpose = $3 AND scope = $4 AND created_at > now() - interval '1 hour'
-	`, subjectType, subjectID, purpose, scope).Scan(&recent); err != nil {
+		WHERE subject_type = $1 AND subject_id = $2 AND purpose = $3 AND scope = $4 AND created_at > now() - make_interval(secs => $5)
+	`, subjectType, subjectID, purpose, scope, int(s.authTokenRateLimitWindow.Seconds())).Scan(&recent); err != nil {
 		return err
 	}
-	if recent >= 5 {
+	if recent >= s.authTokenRateLimitMax {
 		return ErrRateLimited
 	}
 	if _, err := tx.Exec(ctx, `

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigureAuthTokenRateLimit(t *testing.T) {
+	s := &Store{}
+
+	s.ConfigureAuthTokenRateLimit(10, 2*time.Hour)
+	if s.authTokenRateLimitMax != 10 {
+		t.Fatalf("expected max 10, got %d", s.authTokenRateLimitMax)
+	}
+	if s.authTokenRateLimitWindow != 2*time.Hour {
+		t.Fatalf("expected window 2h, got %v", s.authTokenRateLimitWindow)
+	}
+
+	s.ConfigureAuthTokenRateLimit(0, 0)
+	if s.authTokenRateLimitMax != 10 {
+		t.Fatalf("expected max to remain 10 on invalid input, got %d", s.authTokenRateLimitMax)
+	}
+	if s.authTokenRateLimitWindow != 2*time.Hour {
+		t.Fatalf("expected window to remain 2h on invalid input, got %v", s.authTokenRateLimitWindow)
+	}
+}
+
+func TestNewStoreHasDefaultAuthTokenRateLimit(t *testing.T) {
+	s := New(nil)
+	if s.authTokenRateLimitMax != 5 {
+		t.Fatalf("expected default max 5, got %d", s.authTokenRateLimitMax)
+	}
+	if s.authTokenRateLimitWindow != time.Hour {
+		t.Fatalf("expected default window 1h, got %v", s.authTokenRateLimitWindow)
+	}
+}


### PR DESCRIPTION
## Summary

Code review found several security/reliability issues. This PR fixes the highest-impact ones.

## Changes

### Security / Reliability
- **`/v1/auth/register` now goes through `allowSignup`** — previously it bypassed IP rate limiting, captcha, and disposable-email blocking while creating a `commercial`-tier org with `SignupPendingVerification: false`. (`internal/api/api.go`)
- **Login / brand-cloud login / `requirePlatformAdmin` no longer mask DB errors as 401/403.** `ErrNotFound` still maps to auth failure; other store errors return 500 so outages are visible. (`api.go`, `brand_cloud_auth.go`, `eval_tier.go`)
- **`signupLimiter` now evicts stale entries** when the map exceeds 256 keys, preventing unbounded memory growth from spoofed `X-Forwarded-For`. (`eval_tier.go`)
- **Auth-token delivery failures are now logged** (`signIn`, `forgotPassword`) via `logDeliveryFailure` warn log instead of being silently discarded. (`api.go`)

### Operability
- **DB connection pool is tunable** via `DATABASE_MAX_CONNS` / `DATABASE_MIN_CONNS` / `DATABASE_MAX_CONN_LIFETIME` / `DATABASE_MAX_CONN_IDLE_TIME`. (`internal/database/database.go`)
- **Auth-token rate limit is configurable** via `AUTH_TOKEN_RATE_LIMIT_MAX` / `AUTH_TOKEN_RATE_LIMIT_WINDOW`; previously hardcoded `5` /`1h` and ignored the existing `OTP_*` config. (`store.go`, `config.go`, `cmd/server/main.go`)
- **Migration directory overridable** via `MIGRATIONS_DIR` env. (`database.go`)

### Code quality
- **Replaced fragile `strings.Contains(err.Error(), "duplicate key")`** with `isUniqueViolation` (`pgconn.PgError` code `23505`) in `writeStoreError`, `writeClaimResolveError`, and `device_claims.go`.

## Testing
- `go build ./...` / `go vet ./...` clean
- `go test ./...` (unit) green
- `make integration-test` (Postgres-backed) green
- `go test -race ./internal/api/... ./internal/store/...` green

## Notes
- Integration test env disables `signupLimiter` (set to nil) since tests register many users from localhost; the OTP/auth-token rate limit at the store layer still applies.